### PR TITLE
feat(engine): implement tournament engine Elo initialization and scoring core

### DIFF
--- a/__tests__/engine/confidence.test.ts
+++ b/__tests__/engine/confidence.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  getConfidenceTier,
+  getAllConfidenceTiers,
+  getConfidenceLabel,
+} from "@/lib/engine/confidence";
+
+/* ------------------------------------------------------------------ */
+/* getConfidenceTier                                                   */
+/* ------------------------------------------------------------------ */
+
+describe("getConfidenceTier", () => {
+  it("returns 'very_high' for Elo >= 1400", () => {
+    expect(getConfidenceTier(1400)).toBe("very_high");
+    expect(getConfidenceTier(1500)).toBe("very_high");
+    expect(getConfidenceTier(3000)).toBe("very_high");
+  });
+
+  it("returns 'high' for 1200 <= Elo < 1400", () => {
+    expect(getConfidenceTier(1200)).toBe("high");
+    expect(getConfidenceTier(1300)).toBe("high");
+    expect(getConfidenceTier(1399)).toBe("high");
+  });
+
+  it("returns 'medium' for 900 <= Elo < 1200", () => {
+    expect(getConfidenceTier(900)).toBe("medium");
+    expect(getConfidenceTier(1000)).toBe("medium");
+    expect(getConfidenceTier(1199)).toBe("medium");
+  });
+
+  it("returns 'low' for Elo < 900", () => {
+    expect(getConfidenceTier(899)).toBe("low");
+    expect(getConfidenceTier(500)).toBe("low");
+    expect(getConfidenceTier(100)).toBe("low");
+  });
+
+  it("handles edge cases at tier boundaries", () => {
+    expect(getConfidenceTier(1400)).toBe("very_high");
+    expect(getConfidenceTier(1399)).toBe("high");
+    expect(getConfidenceTier(1200)).toBe("high");
+    expect(getConfidenceTier(1199)).toBe("medium");
+    expect(getConfidenceTier(900)).toBe("medium");
+    expect(getConfidenceTier(899)).toBe("low");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* getAllConfidenceTiers                                                */
+/* ------------------------------------------------------------------ */
+
+describe("getAllConfidenceTiers", () => {
+  it("returns tiers for all allergens", () => {
+    const input = [
+      { allergen_id: "oak", elo_score: 1500 },
+      { allergen_id: "ragweed", elo_score: 1100 },
+      { allergen_id: "dust-mites", elo_score: 800 },
+    ];
+    const results = getAllConfidenceTiers(input);
+    expect(results).toHaveLength(3);
+    expect(results[0].tier).toBe("very_high");
+    expect(results[1].tier).toBe("medium");
+    expect(results[2].tier).toBe("low");
+  });
+
+  it("preserves allergen_id and elo_score", () => {
+    const input = [{ allergen_id: "oak", elo_score: 1500 }];
+    const results = getAllConfidenceTiers(input);
+    expect(results[0].allergen_id).toBe("oak");
+    expect(results[0].elo_score).toBe(1500);
+  });
+
+  it("returns empty array for empty input", () => {
+    const results = getAllConfidenceTiers([]);
+    expect(results).toHaveLength(0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* getConfidenceLabel                                                  */
+/* ------------------------------------------------------------------ */
+
+describe("getConfidenceLabel", () => {
+  it("returns human-readable labels", () => {
+    expect(getConfidenceLabel("very_high")).toBe("Very High");
+    expect(getConfidenceLabel("high")).toBe("High");
+    expect(getConfidenceLabel("medium")).toBe("Medium");
+    expect(getConfidenceLabel("low")).toBe("Low");
+  });
+});

--- a/__tests__/engine/elo.test.ts
+++ b/__tests__/engine/elo.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculatePriorProbability,
+  initializeElo,
+  initializeAllElo,
+  calculateKFactor,
+  updateElo,
+  clampElo,
+} from "@/lib/engine/elo";
+import type { Allergen, AllergenElo } from "@/lib/engine/types";
+import { ELO_MIN, ELO_MAX, ELO_CENTER } from "@/lib/engine/types";
+
+/* ------------------------------------------------------------------ */
+/* Test fixtures                                                       */
+/* ------------------------------------------------------------------ */
+
+const makeAllergen = (
+  overrides: Partial<Allergen> = {},
+): Allergen => ({
+  id: "oak",
+  common_name: "Oak",
+  category: "tree",
+  base_elo: 1400,
+  region_northeast: 3,
+  region_midwest: 3,
+  region_northwest: 1,
+  region_south_central: 4,
+  region_southeast: 4,
+  region_southwest: 2,
+  ...overrides,
+});
+
+const makeAllergenElo = (
+  overrides: Partial<AllergenElo> = {},
+): AllergenElo => ({
+  allergen_id: "oak",
+  elo_score: 1000,
+  positive_signals: 0,
+  negative_signals: 0,
+  ...overrides,
+});
+
+const testAllergens: Allergen[] = [
+  makeAllergen({ id: "oak", base_elo: 1400, region_southeast: 4 }),
+  makeAllergen({ id: "ragweed", base_elo: 1600, region_southeast: 3 }),
+  makeAllergen({ id: "dust-mites", base_elo: 1200, region_southeast: 2 }),
+];
+
+/* ------------------------------------------------------------------ */
+/* calculatePriorProbability                                           */
+/* ------------------------------------------------------------------ */
+
+describe("calculatePriorProbability", () => {
+  it("returns a value between 0 and 1", () => {
+    const pS = calculatePriorProbability(
+      testAllergens[0],
+      "Southeast",
+      testAllergens,
+    );
+    expect(pS).toBeGreaterThanOrEqual(0);
+    expect(pS).toBeLessThanOrEqual(1);
+  });
+
+  it("higher base_elo and regional presence yields higher P(S)", () => {
+    const pOak = calculatePriorProbability(
+      testAllergens[0], // base_elo: 1400, SE: 4
+      "Southeast",
+      testAllergens,
+    );
+    const pDust = calculatePriorProbability(
+      testAllergens[2], // base_elo: 1200, SE: 2
+      "Southeast",
+      testAllergens,
+    );
+    expect(pOak).toBeGreaterThan(pDust);
+  });
+
+  it("all probabilities sum to 1 across allergen set", () => {
+    const total = testAllergens.reduce((sum, a) => {
+      return sum + calculatePriorProbability(a, "Southeast", testAllergens);
+    }, 0);
+    expect(total).toBeCloseTo(1.0, 10);
+  });
+
+  it("returns 0 when all scores are 0", () => {
+    const zeroAllergens = [
+      makeAllergen({ id: "a", base_elo: 0, region_southeast: 0 }),
+      makeAllergen({ id: "b", base_elo: 0, region_southeast: 0 }),
+    ];
+    const pS = calculatePriorProbability(
+      zeroAllergens[0],
+      "Southeast",
+      zeroAllergens,
+    );
+    expect(pS).toBe(0);
+  });
+
+  it("uses the correct regional field for different regions", () => {
+    const allergen = makeAllergen({
+      region_northeast: 4,
+      region_southwest: 1,
+    });
+    const pNE = calculatePriorProbability(
+      allergen,
+      "Northeast",
+      [allergen],
+    );
+    const pSW = calculatePriorProbability(
+      allergen,
+      "Southwest",
+      [allergen],
+    );
+    // Single allergen → both should be 1.0 (sole probability)
+    expect(pNE).toBeCloseTo(1.0);
+    expect(pSW).toBeCloseTo(1.0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* initializeElo                                                       */
+/* ------------------------------------------------------------------ */
+
+describe("initializeElo", () => {
+  it("P(S) = 0.5 produces center Elo (1000)", () => {
+    expect(initializeElo(0.5)).toBe(ELO_CENTER);
+  });
+
+  it("P(S) > 0.5 produces Elo above center", () => {
+    expect(initializeElo(0.8)).toBeGreaterThan(ELO_CENTER);
+  });
+
+  it("P(S) < 0.5 produces Elo below center", () => {
+    expect(initializeElo(0.2)).toBeLessThan(ELO_CENTER);
+  });
+
+  it("P(S) = 0 produces minimum-bounded Elo", () => {
+    const elo = initializeElo(0);
+    expect(elo).toBeGreaterThanOrEqual(ELO_MIN);
+  });
+
+  it("P(S) = 1 produces maximum-bounded Elo", () => {
+    const elo = initializeElo(1);
+    expect(elo).toBeLessThanOrEqual(ELO_MAX);
+  });
+
+  it("result is always an integer", () => {
+    expect(Number.isInteger(initializeElo(0.333))).toBe(true);
+    expect(Number.isInteger(initializeElo(0.777))).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* initializeAllElo                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("initializeAllElo", () => {
+  it("returns one Elo record per allergen", () => {
+    const results = initializeAllElo(testAllergens, "Southeast");
+    expect(results).toHaveLength(testAllergens.length);
+  });
+
+  it("all records start with 0 signals", () => {
+    const results = initializeAllElo(testAllergens, "Southeast");
+    for (const r of results) {
+      expect(r.positive_signals).toBe(0);
+      expect(r.negative_signals).toBe(0);
+    }
+  });
+
+  it("all Elo scores are within bounds", () => {
+    const results = initializeAllElo(testAllergens, "Southeast");
+    for (const r of results) {
+      expect(r.elo_score).toBeGreaterThanOrEqual(ELO_MIN);
+      expect(r.elo_score).toBeLessThanOrEqual(ELO_MAX);
+    }
+  });
+
+  it("allergen IDs match input allergens", () => {
+    const results = initializeAllElo(testAllergens, "Southeast");
+    const ids = results.map((r) => r.allergen_id);
+    expect(ids).toEqual(testAllergens.map((a) => a.id));
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* calculateKFactor                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("calculateKFactor", () => {
+  it("returns maximum K for 0 signals (volatile early)", () => {
+    const k = calculateKFactor(0);
+    expect(k).toBe(64);
+  });
+
+  it("K decreases as signals increase", () => {
+    const k0 = calculateKFactor(0);
+    const k10 = calculateKFactor(10);
+    const k50 = calculateKFactor(50);
+    expect(k0).toBeGreaterThan(k10);
+    expect(k10).toBeGreaterThan(k50);
+  });
+
+  it("K never drops below minimum (8)", () => {
+    const k = calculateKFactor(10000);
+    expect(k).toBeGreaterThanOrEqual(8);
+  });
+
+  it("K at 10 signals is lower than K at 0", () => {
+    const k0 = calculateKFactor(0);
+    const k10 = calculateKFactor(10);
+    expect(k10).toBeLessThan(k0);
+    // K = 64 / (1 + 0.1 * 10) = 64 / 2 = 32
+    expect(k10).toBe(32);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* updateElo                                                           */
+/* ------------------------------------------------------------------ */
+
+describe("updateElo", () => {
+  it("positive delta increases Elo", () => {
+    const current = makeAllergenElo({ elo_score: 1000 });
+    const result = updateElo(current, 1.0);
+    expect(result.new_elo).toBeGreaterThan(1000);
+  });
+
+  it("negative delta decreases Elo", () => {
+    const current = makeAllergenElo({ elo_score: 1000 });
+    const result = updateElo(current, -1.0);
+    expect(result.new_elo).toBeLessThan(1000);
+  });
+
+  it("zero delta leaves Elo unchanged", () => {
+    const current = makeAllergenElo({ elo_score: 1000 });
+    const result = updateElo(current, 0);
+    expect(result.new_elo).toBe(1000);
+  });
+
+  it("Elo stays within bounds after extreme positive input", () => {
+    const current = makeAllergenElo({ elo_score: 2900 });
+    const result = updateElo(current, 100);
+    expect(result.new_elo).toBeLessThanOrEqual(ELO_MAX);
+  });
+
+  it("Elo stays within bounds after extreme negative input", () => {
+    const current = makeAllergenElo({ elo_score: 200 });
+    const result = updateElo(current, -100);
+    expect(result.new_elo).toBeGreaterThanOrEqual(ELO_MIN);
+  });
+
+  it("uses correct K-factor based on signal count", () => {
+    const current = makeAllergenElo({
+      elo_score: 1000,
+      positive_signals: 5,
+      negative_signals: 5, // total = 10
+    });
+    const result = updateElo(current, 1.0);
+    // K = 64 / (1 + 0.1 * 10) = 32
+    expect(result.k_factor).toBe(32);
+    expect(result.new_elo).toBe(1032);
+  });
+
+  it("returns correct delta", () => {
+    const current = makeAllergenElo({ elo_score: 1000 });
+    const result = updateElo(current, 1.0);
+    expect(result.delta).toBe(result.new_elo - 1000);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* clampElo                                                            */
+/* ------------------------------------------------------------------ */
+
+describe("clampElo", () => {
+  it("clamps below minimum to ELO_MIN", () => {
+    expect(clampElo(-500)).toBe(ELO_MIN);
+    expect(clampElo(0)).toBe(ELO_MIN);
+    expect(clampElo(50)).toBe(ELO_MIN);
+  });
+
+  it("clamps above maximum to ELO_MAX", () => {
+    expect(clampElo(5000)).toBe(ELO_MAX);
+    expect(clampElo(3001)).toBe(ELO_MAX);
+  });
+
+  it("passes through values within bounds", () => {
+    expect(clampElo(1000)).toBe(1000);
+    expect(clampElo(100)).toBe(100);
+    expect(clampElo(3000)).toBe(3000);
+  });
+
+  it("rounds to nearest integer", () => {
+    expect(clampElo(1000.7)).toBe(1001);
+    expect(clampElo(1000.3)).toBe(1000);
+  });
+});

--- a/__tests__/engine/seasonal.test.ts
+++ b/__tests__/engine/seasonal.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  getSeasonalMultiplier,
+  getSeasonalSeverity,
+  getAllSeasonalMultipliers,
+  isAllergenActive,
+} from "@/lib/engine/seasonal";
+
+/* ------------------------------------------------------------------ */
+/* getSeasonalMultiplier                                               */
+/* ------------------------------------------------------------------ */
+
+describe("getSeasonalMultiplier", () => {
+  it("returns 0.0 for inactive month (oak in January Northeast)", () => {
+    // Oak is inactive in January in Northeast (winter)
+    const multiplier = getSeasonalMultiplier("oak", "Northeast", 1);
+    expect(multiplier).toBe(0.0);
+  });
+
+  it("returns 3.0 for severe month (oak in spring Southeast)", () => {
+    // Oak peaks in spring in Southeast — should be severe
+    const multiplier = getSeasonalMultiplier("oak", "Southeast", 4);
+    expect(multiplier).toBe(3.0);
+  });
+
+  it("returns 1.2 for mild month", () => {
+    // Find a mild entry — oak in February Northeast should be mild
+    const multiplier = getSeasonalMultiplier("oak", "Northeast", 2);
+    expect(multiplier).toBe(1.2);
+  });
+
+  it("returns valid multiplier values only (0.0, 1.2, 2.0, or 3.0)", () => {
+    const validMultipliers = [0.0, 1.2, 2.0, 3.0];
+    // Check a spread of allergens and months
+    const allergens = ["oak", "ragweed", "dust-mites", "alternaria"];
+    const months = [1, 4, 7, 10];
+    for (const allergenId of allergens) {
+      for (const month of months) {
+        const m = getSeasonalMultiplier(allergenId, "Southeast", month);
+        expect(validMultipliers).toContain(m);
+      }
+    }
+  });
+
+  it("returns 0.0 for unknown allergen", () => {
+    const multiplier = getSeasonalMultiplier(
+      "nonexistent-allergen",
+      "Southeast",
+      4,
+    );
+    expect(multiplier).toBe(0.0);
+  });
+
+  it("indoor allergens are active year-round", () => {
+    // Dust mites should be active all 12 months
+    let activeCount = 0;
+    for (let month = 1; month <= 12; month++) {
+      const m = getSeasonalMultiplier("dust-mites", "Southeast", month);
+      if (m > 0) activeCount++;
+    }
+    expect(activeCount).toBe(12);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* getSeasonalSeverity                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("getSeasonalSeverity", () => {
+  it("returns 'inactive' for inactive month", () => {
+    const severity = getSeasonalSeverity("oak", "Northeast", 1);
+    expect(severity).toBe("inactive");
+  });
+
+  it("returns valid severity values", () => {
+    const validSeverities = ["inactive", "mild", "moderate", "severe"];
+    const severity = getSeasonalSeverity("oak", "Southeast", 4);
+    expect(validSeverities).toContain(severity);
+  });
+
+  it("returns 'inactive' for unknown allergen", () => {
+    const severity = getSeasonalSeverity("fake-allergen", "Southeast", 4);
+    expect(severity).toBe("inactive");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* getAllSeasonalMultipliers                                            */
+/* ------------------------------------------------------------------ */
+
+describe("getAllSeasonalMultipliers", () => {
+  it("returns multipliers for all requested allergens", () => {
+    const ids = ["oak", "ragweed", "dust-mites"];
+    const results = getAllSeasonalMultipliers(ids, "Southeast", 4);
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => r.allergen_id)).toEqual(ids);
+  });
+
+  it("each result has severity and multiplier fields", () => {
+    const results = getAllSeasonalMultipliers(["oak"], "Southeast", 4);
+    expect(results[0]).toHaveProperty("allergen_id", "oak");
+    expect(results[0]).toHaveProperty("severity");
+    expect(results[0]).toHaveProperty("multiplier");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* isAllergenActive                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("isAllergenActive", () => {
+  it("returns false for inactive allergen/month", () => {
+    expect(isAllergenActive("oak", "Northeast", 1)).toBe(false);
+  });
+
+  it("returns true for active allergen/month", () => {
+    expect(isAllergenActive("oak", "Southeast", 4)).toBe(true);
+  });
+
+  it("returns false for unknown allergen", () => {
+    expect(isAllergenActive("nonexistent", "Southeast", 4)).toBe(false);
+  });
+});

--- a/__tests__/engine/symptoms.test.ts
+++ b/__tests__/engine/symptoms.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkSymptomGate,
+  calculateSymptomMultiplier,
+  getAllSymptomMultipliers,
+} from "@/lib/engine/symptoms";
+import type { SymptomInput } from "@/lib/engine/types";
+
+/* ------------------------------------------------------------------ */
+/* checkSymptomGate                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("checkSymptomGate", () => {
+  it("returns false when global_severity is 0 (no symptoms)", () => {
+    const symptoms: SymptomInput = { zones: [], global_severity: 0 };
+    expect(checkSymptomGate(symptoms)).toBe(false);
+  });
+
+  it("returns true when global_severity is 1", () => {
+    const symptoms: SymptomInput = { zones: ["nose"], global_severity: 1 };
+    expect(checkSymptomGate(symptoms)).toBe(true);
+  });
+
+  it("returns true when global_severity is 3", () => {
+    const symptoms: SymptomInput = {
+      zones: ["eyes", "nose", "lungs"],
+      global_severity: 3,
+    };
+    expect(checkSymptomGate(symptoms)).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* calculateSymptomMultiplier                                          */
+/* ------------------------------------------------------------------ */
+
+describe("calculateSymptomMultiplier", () => {
+  it("returns 1.0 (neutral) with no reported zones", () => {
+    const result = calculateSymptomMultiplier("tree", []);
+    expect(result.multiplier).toBe(1.0);
+    expect(result.matching_zones).toHaveLength(0);
+  });
+
+  it("boosts tree allergens for eye symptoms", () => {
+    const result = calculateSymptomMultiplier("tree", ["eyes"]);
+    expect(result.multiplier).toBe(1.3); // 1.0 + 0.3
+    expect(result.matching_zones).toContain("eyes");
+  });
+
+  it("boosts tree allergens for nose symptoms", () => {
+    const result = calculateSymptomMultiplier("tree", ["nose"]);
+    expect(result.multiplier).toBe(1.3);
+    expect(result.matching_zones).toContain("nose");
+  });
+
+  it("stacks multiple zone matches (tree with eyes + nose + throat)", () => {
+    const result = calculateSymptomMultiplier("tree", [
+      "eyes",
+      "nose",
+      "throat",
+    ]);
+    // Tree maps to: eyes, nose, throat → 3 matches → 1.0 + 0.9 = 1.9
+    expect(result.multiplier).toBe(1.9);
+    expect(result.matching_zones).toHaveLength(3);
+  });
+
+  it("does not boost when zone does not match category", () => {
+    // "skin" maps to indoor and food, not tree
+    const result = calculateSymptomMultiplier("tree", ["skin"]);
+    expect(result.multiplier).toBe(1.0);
+    expect(result.matching_zones).toHaveLength(0);
+  });
+
+  it("boosts indoor allergens for skin symptoms", () => {
+    const result = calculateSymptomMultiplier("indoor", ["skin"]);
+    expect(result.multiplier).toBe(1.3);
+    expect(result.matching_zones).toContain("skin");
+  });
+
+  it("boosts indoor allergens for lungs symptoms", () => {
+    const result = calculateSymptomMultiplier("indoor", ["lungs"]);
+    expect(result.multiplier).toBe(1.3);
+    expect(result.matching_zones).toContain("lungs");
+  });
+
+  it("boosts mold for throat + lungs (2 zones)", () => {
+    const result = calculateSymptomMultiplier("mold", ["throat", "lungs"]);
+    expect(result.multiplier).toBe(1.6); // 1.0 + 0.6
+    expect(result.matching_zones).toHaveLength(2);
+  });
+
+  it("boosts grass for eyes + nose", () => {
+    const result = calculateSymptomMultiplier("grass", ["eyes", "nose"]);
+    expect(result.multiplier).toBe(1.6); // 1.0 + 0.6
+  });
+
+  it("boosts weed only for nose (not eyes)", () => {
+    const result = calculateSymptomMultiplier("weed", ["eyes", "nose"]);
+    // Weed maps to nose only → 1 match → 1.3
+    expect(result.multiplier).toBe(1.3);
+    expect(result.matching_zones).toEqual(["nose"]);
+  });
+
+  it("caps multiplier at 2.5", () => {
+    // Hypothetical: if a category could match 6+ zones
+    // In practice, tree matches eyes + nose + throat = 1.9
+    // This tests the cap mechanism
+    const result = calculateSymptomMultiplier("tree", [
+      "eyes",
+      "nose",
+      "throat",
+    ]);
+    expect(result.multiplier).toBeLessThanOrEqual(2.5);
+  });
+
+  it("food category boosts for stomach symptoms", () => {
+    const result = calculateSymptomMultiplier("food", ["stomach"]);
+    expect(result.multiplier).toBe(1.3);
+    expect(result.matching_zones).toContain("stomach");
+  });
+
+  it("food category boosts for skin + stomach", () => {
+    const result = calculateSymptomMultiplier("food", ["skin", "stomach"]);
+    expect(result.multiplier).toBe(1.6);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* getAllSymptomMultipliers                                             */
+/* ------------------------------------------------------------------ */
+
+describe("getAllSymptomMultipliers", () => {
+  const allergens = [
+    { allergen_id: "oak", category: "tree" },
+    { allergen_id: "dust-mites", category: "indoor" },
+    { allergen_id: "alternaria", category: "mold" },
+  ];
+
+  it("returns multipliers for all allergens", () => {
+    const symptoms: SymptomInput = {
+      zones: ["eyes", "nose"],
+      global_severity: 2,
+    };
+    const results = getAllSymptomMultipliers(allergens, symptoms);
+    expect(results).toHaveLength(3);
+  });
+
+  it("suppresses all to 0.0 when symptom gate fails (severity 0)", () => {
+    const symptoms: SymptomInput = { zones: ["eyes"], global_severity: 0 };
+    const results = getAllSymptomMultipliers(allergens, symptoms);
+    for (const r of results) {
+      expect(r.multiplier).toBe(0.0);
+      expect(r.matching_zones).toHaveLength(0);
+    }
+  });
+
+  it("applies different multipliers per category", () => {
+    const symptoms: SymptomInput = {
+      zones: ["eyes", "nose"],
+      global_severity: 2,
+    };
+    const results = getAllSymptomMultipliers(allergens, symptoms);
+
+    // Tree: eyes + nose → 1.6
+    const tree = results.find((r) => r.allergen_id === "oak");
+    expect(tree?.multiplier).toBe(1.6);
+
+    // Indoor: no match for eyes/nose → 1.0
+    const indoor = results.find((r) => r.allergen_id === "dust-mites");
+    expect(indoor?.multiplier).toBe(1.0);
+
+    // Mold: no match for eyes/nose → 1.0
+    const mold = results.find((r) => r.allergen_id === "alternaria");
+    expect(mold?.multiplier).toBe(1.0);
+  });
+});

--- a/lib/engine/confidence.ts
+++ b/lib/engine/confidence.ts
@@ -1,0 +1,81 @@
+/**
+ * Elo → Confidence Tier Mapping
+ *
+ * Maps final Elo scores to human-readable confidence tiers
+ * for display on the leaderboard and in reports.
+ *
+ * Server-side only — never import from client components.
+ *
+ * Tier thresholds (centered at 1000):
+ *   very_high : Elo >= 1400 — strong evidence this is a trigger
+ *   high      : 1200 <= Elo < 1400 — likely trigger
+ *   medium    : 900 <= Elo < 1200 — possible trigger
+ *   low       : Elo < 900 — unlikely trigger
+ */
+
+import type { ConfidenceTier, ConfidenceResult } from "./types";
+
+/* ------------------------------------------------------------------ */
+/* Thresholds                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Confidence tier boundaries.
+ * Order matters — checked from highest to lowest.
+ */
+const TIER_THRESHOLDS: { min: number; tier: ConfidenceTier }[] = [
+  { min: 1400, tier: "very_high" },
+  { min: 1200, tier: "high" },
+  { min: 900, tier: "medium" },
+];
+
+const DEFAULT_TIER: ConfidenceTier = "low";
+
+/* ------------------------------------------------------------------ */
+/* Mapping                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Map an Elo score to a confidence tier.
+ *
+ * @param eloScore — current Elo rating
+ * @returns confidence tier
+ */
+export function getConfidenceTier(eloScore: number): ConfidenceTier {
+  for (const { min, tier } of TIER_THRESHOLDS) {
+    if (eloScore >= min) return tier;
+  }
+  return DEFAULT_TIER;
+}
+
+/**
+ * Map multiple allergens' Elo scores to confidence tiers.
+ *
+ * @param allergenElos — array of { allergen_id, elo_score }
+ * @returns array of { allergen_id, elo_score, tier }
+ */
+export function getAllConfidenceTiers(
+  allergenElos: { allergen_id: string; elo_score: number }[],
+): ConfidenceResult[] {
+  return allergenElos.map(({ allergen_id, elo_score }) => ({
+    allergen_id,
+    elo_score,
+    tier: getConfidenceTier(elo_score),
+  }));
+}
+
+/**
+ * Get a human-readable label for a confidence tier.
+ *
+ * @param tier — confidence tier
+ * @returns display label
+ */
+export function getConfidenceLabel(tier: ConfidenceTier): string {
+  const labels: Record<ConfidenceTier, string> = {
+    very_high: "Very High",
+    high: "High",
+    medium: "Medium",
+    low: "Low",
+  };
+  return labels[tier];
+}

--- a/lib/engine/elo.ts
+++ b/lib/engine/elo.ts
@@ -1,0 +1,193 @@
+/**
+ * Elo Scoring Engine
+ *
+ * Implements Elo initialization from prior probability P(S),
+ * K-factor decay, and bounded rating updates.
+ *
+ * Server-side only — never import from client components.
+ *
+ * Formulas:
+ *   Initial Elo = ELO_CENTER + (P(S) - 0.5) * ELO_SPREAD
+ *   P(S) = base_elo * regional_presence / normalizer
+ *   K-factor = K_MAX / (1 + K_DECAY * total_signals)
+ *   New Elo = clamp(old_elo + K * weighted_delta, ELO_MIN, ELO_MAX)
+ */
+
+import type { Region } from "@/lib/supabase/types";
+import type { Allergen, AllergenElo, EloUpdate } from "./types";
+import { ELO_MIN, ELO_MAX, ELO_CENTER } from "./types";
+
+/* ------------------------------------------------------------------ */
+/* Constants                                                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Spread factor for mapping P(S) [0,1] to Elo range.
+ * With ELO_CENTER=1000 and SPREAD=800:
+ *   P(S)=0.0 → Elo 600
+ *   P(S)=0.5 → Elo 1000
+ *   P(S)=1.0 → Elo 1400
+ */
+const ELO_SPREAD = 800;
+
+/**
+ * K-factor parameters.
+ * K starts high (volatile early) and decays toward K_MIN as signals grow.
+ *   K = K_MAX / (1 + K_DECAY * total_signals)
+ *   Clamped at K_MIN to prevent total stagnation.
+ */
+const K_MAX = 64;
+const K_MIN = 8;
+const K_DECAY = 0.1;
+
+/* ------------------------------------------------------------------ */
+/* Region → field mapping                                              */
+/* ------------------------------------------------------------------ */
+
+const REGION_FIELD_MAP: Record<Region, keyof Allergen> = {
+  Northeast: "region_northeast",
+  Midwest: "region_midwest",
+  Northwest: "region_northwest",
+  "South Central": "region_south_central",
+  Southeast: "region_southeast",
+  Southwest: "region_southwest",
+};
+
+/* ------------------------------------------------------------------ */
+/* Prior Probability P(S)                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Calculate prior probability P(S) for an allergen in a given region.
+ *
+ * P(S) = (base_elo * regional_presence) / normalizer
+ *
+ * Where normalizer ensures all P(S) values sum to 1 across the
+ * allergen set for the region.
+ *
+ * @param allergen   — allergen record with base_elo and regional presence
+ * @param region     — user's home region
+ * @param allAllergens — full allergen set (needed for normalization)
+ * @returns P(S) in range [0, 1]
+ */
+export function calculatePriorProbability(
+  allergen: Allergen,
+  region: Region,
+  allAllergens: Allergen[],
+): number {
+  const field = REGION_FIELD_MAP[region];
+  const rawScore =
+    allergen.base_elo * (allergen[field] as number);
+
+  const totalScore = allAllergens.reduce((sum, a) => {
+    return sum + a.base_elo * (a[field] as number);
+  }, 0);
+
+  if (totalScore === 0) return 0;
+  return rawScore / totalScore;
+}
+
+/* ------------------------------------------------------------------ */
+/* Elo Initialization                                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Initialize Elo rating for an allergen based on its prior probability.
+ *
+ * Elo_init = ELO_CENTER + (P(S) - 0.5) * ELO_SPREAD
+ *
+ * Clamped to [ELO_MIN, ELO_MAX].
+ *
+ * @param priorProbability — P(S) in [0, 1]
+ * @returns initial Elo score
+ */
+export function initializeElo(priorProbability: number): number {
+  const raw = ELO_CENTER + (priorProbability - 0.5) * ELO_SPREAD;
+  return clampElo(raw);
+}
+
+/**
+ * Initialize Elo ratings for all allergens in a region.
+ *
+ * @param allergens — full allergen set
+ * @param region    — user's home region
+ * @returns array of { allergen_id, elo_score, positive_signals: 0, negative_signals: 0 }
+ */
+export function initializeAllElo(
+  allergens: Allergen[],
+  region: Region,
+): AllergenElo[] {
+  return allergens.map((allergen) => {
+    const pS = calculatePriorProbability(allergen, region, allergens);
+    return {
+      allergen_id: allergen.id,
+      elo_score: initializeElo(pS),
+      positive_signals: 0,
+      negative_signals: 0,
+    };
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* K-Factor                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Calculate K-factor based on total check-in signals.
+ *
+ * K = max(K_MIN, K_MAX / (1 + K_DECAY * total_signals))
+ *
+ * Early check-ins have high K (volatile ratings),
+ * later check-ins stabilize with low K.
+ *
+ * @param totalSignals — positive_signals + negative_signals
+ * @returns K-factor
+ */
+export function calculateKFactor(totalSignals: number): number {
+  const k = K_MAX / (1 + K_DECAY * totalSignals);
+  return Math.max(K_MIN, k);
+}
+
+/* ------------------------------------------------------------------ */
+/* Elo Update                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Update Elo rating for an allergen based on a weighted delta.
+ *
+ * New Elo = clamp(current_elo + K * weighted_delta, ELO_MIN, ELO_MAX)
+ *
+ * weighted_delta is the product of seasonal and symptom multipliers
+ * applied to a base signal (+1 for positive, -1 for negative).
+ *
+ * @param current      — current Elo record
+ * @param weightedDelta — combined signal after multipliers (can be negative)
+ * @returns EloUpdate with new score, delta applied, and K-factor used
+ */
+export function updateElo(
+  current: AllergenElo,
+  weightedDelta: number,
+): EloUpdate {
+  const totalSignals = current.positive_signals + current.negative_signals;
+  const k = calculateKFactor(totalSignals);
+  const delta = k * weightedDelta;
+  const newElo = clampElo(current.elo_score + delta);
+
+  return {
+    allergen_id: current.allergen_id,
+    new_elo: newElo,
+    delta: newElo - current.elo_score,
+    k_factor: k,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Clamp Elo score to valid bounds [ELO_MIN, ELO_MAX].
+ */
+export function clampElo(elo: number): number {
+  return Math.round(Math.max(ELO_MIN, Math.min(ELO_MAX, elo)));
+}

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -1,0 +1,60 @@
+/**
+ * Tournament Engine — Public API
+ *
+ * Server-side only — never import from client components.
+ * API keys would leak if this module were bundled for the browser.
+ */
+
+// Types
+export type {
+  Allergen,
+  AllergenElo,
+  EloUpdate,
+  Severity,
+  SeasonalEntry,
+  SeasonalMultiplierResult,
+  SymptomZone,
+  SymptomInput,
+  SymptomMultiplierResult,
+  ConfidenceTier,
+  ConfidenceResult,
+} from "./types";
+
+export {
+  ELO_MIN,
+  ELO_MAX,
+  ELO_CENTER,
+  SEASONAL_MULTIPLIER,
+} from "./types";
+
+// Elo scoring
+export {
+  calculatePriorProbability,
+  initializeElo,
+  initializeAllElo,
+  calculateKFactor,
+  updateElo,
+  clampElo,
+} from "./elo";
+
+// Seasonal calendar
+export {
+  getSeasonalMultiplier,
+  getSeasonalSeverity,
+  getAllSeasonalMultipliers,
+  isAllergenActive,
+} from "./seasonal";
+
+// Symptom specificity
+export {
+  checkSymptomGate,
+  calculateSymptomMultiplier,
+  getAllSymptomMultipliers,
+} from "./symptoms";
+
+// Confidence tiers
+export {
+  getConfidenceTier,
+  getAllConfidenceTiers,
+  getConfidenceLabel,
+} from "./confidence";

--- a/lib/engine/seasonal.ts
+++ b/lib/engine/seasonal.ts
@@ -1,0 +1,128 @@
+/**
+ * Seasonal Calendar Gate + Multipliers
+ *
+ * Looks up the seasonal severity for each allergen by region and month,
+ * then maps severity to an Elo multiplier.
+ *
+ * Server-side only — never import from client components.
+ *
+ * Multiplier mapping:
+ *   inactive → 0.0 (allergen completely suppressed this month)
+ *   mild     → 1.2
+ *   moderate → 2.0
+ *   severe   → 3.0
+ */
+
+import type { Region } from "@/lib/supabase/types";
+import type { SeasonalMultiplierResult, Severity } from "./types";
+import { SEASONAL_MULTIPLIER } from "./types";
+import calendarData from "@/lib/data/seasonal-calendar.json";
+
+/* ------------------------------------------------------------------ */
+/* Types for raw calendar JSON                                         */
+/* ------------------------------------------------------------------ */
+
+interface RawCalendarEntry {
+  allergen_id: string;
+  allergen_name: string;
+  region: string;
+  month: number;
+  severity: string;
+  activity_level: number;
+}
+
+/* ------------------------------------------------------------------ */
+/* Lookup                                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Get the seasonal multiplier for a single allergen in a given region/month.
+ *
+ * Returns 0.0 for inactive (completely suppresses the allergen) or
+ * if no calendar entry exists for the combination.
+ *
+ * @param allergenId — allergen identifier
+ * @param region     — user's region
+ * @param month      — 1-12
+ * @returns multiplier (0.0, 1.2, 2.0, or 3.0)
+ */
+export function getSeasonalMultiplier(
+  allergenId: string,
+  region: Region,
+  month: number,
+): number {
+  const entry = (calendarData as RawCalendarEntry[]).find(
+    (e) =>
+      e.allergen_id === allergenId &&
+      e.region === region &&
+      e.month === month,
+  );
+
+  if (!entry) return 0.0;
+
+  const severity = entry.severity as Severity;
+  return SEASONAL_MULTIPLIER[severity] ?? 0.0;
+}
+
+/**
+ * Get the seasonal severity for a single allergen in a given region/month.
+ *
+ * @param allergenId — allergen identifier
+ * @param region     — user's region
+ * @param month      — 1-12
+ * @returns severity string or "inactive" if not found
+ */
+export function getSeasonalSeverity(
+  allergenId: string,
+  region: Region,
+  month: number,
+): Severity {
+  const entry = (calendarData as RawCalendarEntry[]).find(
+    (e) =>
+      e.allergen_id === allergenId &&
+      e.region === region &&
+      e.month === month,
+  );
+
+  if (!entry) return "inactive";
+  return entry.severity as Severity;
+}
+
+/**
+ * Get seasonal multipliers for all allergens in a region/month.
+ *
+ * @param allergenIds — list of allergen IDs to look up
+ * @param region      — user's region
+ * @param month       — 1-12
+ * @returns array of { allergen_id, severity, multiplier }
+ */
+export function getAllSeasonalMultipliers(
+  allergenIds: string[],
+  region: Region,
+  month: number,
+): SeasonalMultiplierResult[] {
+  return allergenIds.map((allergenId) => {
+    const severity = getSeasonalSeverity(allergenId, region, month);
+    return {
+      allergen_id: allergenId,
+      severity,
+      multiplier: SEASONAL_MULTIPLIER[severity] ?? 0.0,
+    };
+  });
+}
+
+/**
+ * Check if an allergen is active (not suppressed) in a given region/month.
+ *
+ * @param allergenId — allergen identifier
+ * @param region     — user's region
+ * @param month      — 1-12
+ * @returns true if severity !== "inactive"
+ */
+export function isAllergenActive(
+  allergenId: string,
+  region: Region,
+  month: number,
+): boolean {
+  return getSeasonalMultiplier(allergenId, region, month) > 0;
+}

--- a/lib/engine/symptoms.ts
+++ b/lib/engine/symptoms.ts
@@ -1,0 +1,151 @@
+/**
+ * Symptom-Specificity Weighting
+ *
+ * Maps user-reported symptom zones to allergen categories, producing
+ * a specificity multiplier that boosts allergens whose typical
+ * presentation matches the reported symptoms.
+ *
+ * Server-side only — never import from client components.
+ *
+ * Zone → Category mapping:
+ *   eyes    → tree, grass (pollen conjunctivitis)
+ *   nose    → tree, grass, weed (allergic rhinitis)
+ *   throat  → mold, tree (post-nasal drip, spore irritation)
+ *   skin    → indoor, food (contact dermatitis, hives)
+ *   lungs   → mold, indoor (asthma, spore inhalation, SPP)
+ *   stomach → food (PFAS cross-reactivity, GI symptoms)
+ */
+
+import type { SymptomZone, SymptomInput, SymptomMultiplierResult } from "./types";
+
+/* ------------------------------------------------------------------ */
+/* Zone → Category mapping                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Maps each symptom zone to the allergen categories it indicates.
+ * An allergen matching more zones gets a higher multiplier.
+ */
+const ZONE_CATEGORY_MAP: Record<SymptomZone, string[]> = {
+  eyes: ["tree", "grass"],
+  nose: ["tree", "grass", "weed"],
+  throat: ["mold", "tree"],
+  skin: ["indoor", "food"],
+  lungs: ["mold", "indoor"],
+  stomach: ["food"],
+};
+
+/* ------------------------------------------------------------------ */
+/* Multiplier constants                                                */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Base multiplier when no zones match (neutral — no boost, no penalty).
+ */
+const BASE_MULTIPLIER = 1.0;
+
+/**
+ * Boost per matching zone. Stacks additively.
+ * 1 zone match  → 1.0 + 0.3 = 1.3x
+ * 2 zone matches → 1.0 + 0.6 = 1.6x
+ * 3 zone matches → 1.0 + 0.9 = 1.9x
+ */
+const ZONE_MATCH_BOOST = 0.3;
+
+/**
+ * Maximum multiplier cap to prevent runaway scoring.
+ */
+const MAX_MULTIPLIER = 2.5;
+
+/* ------------------------------------------------------------------ */
+/* Symptom Gate                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Check the global symptom gate.
+ *
+ * When global_severity is 0 (no symptoms), all Elo weights are
+ * suppressed. The leaderboard switches to Environmental Forecast mode.
+ *
+ * @param symptoms — symptom input with global severity
+ * @returns true if symptoms are present (gate passes), false if suppressed
+ */
+export function checkSymptomGate(symptoms: SymptomInput): boolean {
+  return symptoms.global_severity > 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Specificity Multiplier                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Calculate symptom-specificity multiplier for a single allergen.
+ *
+ * Compares the allergen's category against the reported symptom zones.
+ * Each matching zone adds ZONE_MATCH_BOOST to the base multiplier.
+ *
+ * @param allergenCategory — the allergen's category (tree, grass, weed, mold, indoor, food)
+ * @param reportedZones    — symptom zones the user reported
+ * @returns { multiplier, matching_zones }
+ */
+export function calculateSymptomMultiplier(
+  allergenCategory: string,
+  reportedZones: SymptomZone[],
+): { multiplier: number; matching_zones: SymptomZone[] } {
+  if (reportedZones.length === 0) {
+    return { multiplier: BASE_MULTIPLIER, matching_zones: [] };
+  }
+
+  const matchingZones: SymptomZone[] = [];
+
+  for (const zone of reportedZones) {
+    const categories = ZONE_CATEGORY_MAP[zone];
+    if (categories.includes(allergenCategory)) {
+      matchingZones.push(zone);
+    }
+  }
+
+  const rawMultiplier =
+    BASE_MULTIPLIER + matchingZones.length * ZONE_MATCH_BOOST;
+  const multiplier = Math.min(rawMultiplier, MAX_MULTIPLIER);
+
+  return { multiplier, matching_zones: matchingZones };
+}
+
+/**
+ * Calculate symptom-specificity multipliers for all allergens.
+ *
+ * If the symptom gate fails (global_severity === 0), all multipliers
+ * are set to 0.0 (complete suppression).
+ *
+ * @param allergens — array of { allergen_id, category }
+ * @param symptoms  — symptom input with zones and global severity
+ * @returns array of multiplier results
+ */
+export function getAllSymptomMultipliers(
+  allergens: { allergen_id: string; category: string }[],
+  symptoms: SymptomInput,
+): SymptomMultiplierResult[] {
+  const gateOpen = checkSymptomGate(symptoms);
+
+  return allergens.map(({ allergen_id, category }) => {
+    if (!gateOpen) {
+      return {
+        allergen_id,
+        multiplier: 0.0,
+        matching_zones: [],
+      };
+    }
+
+    const { multiplier, matching_zones } = calculateSymptomMultiplier(
+      category,
+      symptoms.zones,
+    );
+
+    return {
+      allergen_id,
+      multiplier,
+      matching_zones,
+    };
+  });
+}

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -1,0 +1,123 @@
+/**
+ * Tournament Engine Types
+ *
+ * Shared type definitions for the Elo scoring engine.
+ * Server-side only — never import from client components.
+ */
+
+import type { Region } from "@/lib/supabase/types";
+
+/* ------------------------------------------------------------------ */
+/* Allergen data                                                       */
+/* ------------------------------------------------------------------ */
+
+/** Allergen record from seed data or database */
+export interface Allergen {
+  id: string;
+  common_name: string;
+  category: string;
+  base_elo: number;
+  region_northeast: number;
+  region_midwest: number;
+  region_northwest: number;
+  region_south_central: number;
+  region_southeast: number;
+  region_southwest: number;
+}
+
+/* ------------------------------------------------------------------ */
+/* Elo scoring                                                         */
+/* ------------------------------------------------------------------ */
+
+/** Per-user Elo record for a single allergen */
+export interface AllergenElo {
+  allergen_id: string;
+  elo_score: number;
+  positive_signals: number;
+  negative_signals: number;
+}
+
+/** Result of an Elo update calculation */
+export interface EloUpdate {
+  allergen_id: string;
+  new_elo: number;
+  delta: number;
+  k_factor: number;
+}
+
+/* ------------------------------------------------------------------ */
+/* Seasonal calendar                                                   */
+/* ------------------------------------------------------------------ */
+
+export type Severity = "inactive" | "mild" | "moderate" | "severe";
+
+export interface SeasonalEntry {
+  allergen_id: string;
+  region: Region;
+  month: number;
+  severity: Severity;
+  activity_level: number;
+}
+
+export interface SeasonalMultiplierResult {
+  allergen_id: string;
+  severity: Severity;
+  multiplier: number;
+}
+
+/* ------------------------------------------------------------------ */
+/* Symptoms                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Symptom zones that map to allergen categories.
+ * Each zone, when reported, boosts allergens with matching characteristics.
+ */
+export type SymptomZone =
+  | "eyes"       // Itchy/watery eyes — tree/grass pollen
+  | "nose"       // Sneezing/runny nose — most outdoor allergens
+  | "throat"     // Throat irritation — mold, some pollen
+  | "skin"       // Skin rash/hives — indoor allergens, food cross-reactivity
+  | "lungs"      // Cough/wheeze — mold spores, SPP, indoor
+  | "stomach";   // GI symptoms — food cross-reactivity (PFAS)
+
+export interface SymptomInput {
+  zones: SymptomZone[];
+  /** Global severity 0-3 (0 = no symptoms, triggers symptom gate) */
+  global_severity: number;
+}
+
+export interface SymptomMultiplierResult {
+  allergen_id: string;
+  multiplier: number;
+  matching_zones: SymptomZone[];
+}
+
+/* ------------------------------------------------------------------ */
+/* Confidence tiers                                                    */
+/* ------------------------------------------------------------------ */
+
+export type ConfidenceTier = "low" | "medium" | "high" | "very_high";
+
+export interface ConfidenceResult {
+  allergen_id: string;
+  elo_score: number;
+  tier: ConfidenceTier;
+}
+
+/* ------------------------------------------------------------------ */
+/* Constants                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Elo score bounds */
+export const ELO_MIN = 100;
+export const ELO_MAX = 3000;
+export const ELO_CENTER = 1000;
+
+/** Seasonal multiplier mapping */
+export const SEASONAL_MULTIPLIER: Record<Severity, number> = {
+  inactive: 0.0,
+  mild: 1.2,
+  moderate: 2.0,
+  severe: 3.0,
+};


### PR DESCRIPTION
## Summary

Closes #16 — Implement tournament engine — Elo initialization and scoring core

- **`lib/engine/types.ts`** — Shared types (Allergen, AllergenElo, EloUpdate, Severity, SymptomZone, ConfidenceTier), constants (ELO_MIN=100, ELO_MAX=3000, ELO_CENTER=1000), and seasonal multiplier mapping
- **`lib/engine/elo.ts`** — Prior probability P(S) calculation from base_elo × regional presence, Elo initialization from P(S), K-factor decay (K=64 at 0 signals → K=8 floor), and bounded rating updates
- **`lib/engine/seasonal.ts`** — Seasonal calendar gate reading from committed JSON data. Maps severity to multipliers: inactive=0.0x, mild=1.2x, moderate=2.0x, severe=3.0x
- **`lib/engine/symptoms.ts`** — Symptom-specificity weighting mapping 6 zones (eyes, nose, throat, skin, lungs, stomach) to allergen categories. Additive boost (+0.3x per matching zone, capped at 2.5x). Global symptom gate: severity 0 suppresses all scoring
- **`lib/engine/confidence.ts`** — Elo → confidence tier mapping: low (<900), medium (900-1199), high (1200-1399), very_high (>=1400)
- **`lib/engine/index.ts`** — Barrel export for clean public API

All engine code lives in `lib/engine/` (server-side only, never imported by client components).

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — all 118 tests pass (72 new + 46 existing)
- [ ] Verify Elo initialization produces correct starting ratings for known P(S) values
- [ ] Verify seasonal multiplier returns 0.0x for inactive, 3.0x for severe
- [ ] Verify symptom-specificity boost correctly weights matching zones
- [ ] Verify K-factor decays as check-in count increases
- [ ] Verify Elo stays within bounds (100-3000) after extreme inputs
- [ ] Verify confidence tiers map correctly at boundaries

### Test Coverage

| Module | Tests | Coverage |
|--------|-------|----------|
| `elo.ts` | 30 tests | Initialization, P(S), K-factor, update, clamping, bounds |
| `seasonal.ts` | 14 tests | Multipliers, severity lookup, active check, indoor year-round |
| `symptoms.ts` | 19 tests | Gate, zone matching, stacking, suppression, per-category |
| `confidence.ts` | 9 tests | All 4 tiers, boundaries, labels, batch mapping |

🤖 Generated with [Claude Code](https://claude.com/claude-code)