### PR TITLE
feat(apis): Google Pollen, OpenWeatherMap, and WAQI API clients

### DIFF
--- a/__tests__/api/aqi.test.ts
+++ b/__tests__/api/aqi.test.ts
@@ -1,0 +1,170 @@
+/**
+ * WAQI (World Air Quality Index) API Client Tests
+ *
+ * Validates AQI data fetching, pollutant extraction,
+ * and graceful fallback on errors.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getAqiData, AQI_DEFAULTS } from "@/lib/apis/aqi";
+
+/* ------------------------------------------------------------------ */
+/* Mock fetch                                                          */
+/* ------------------------------------------------------------------ */
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+/* ------------------------------------------------------------------ */
+/* Test data                                                           */
+/* ------------------------------------------------------------------ */
+
+const MOCK_AQI_RESPONSE = {
+  status: "ok",
+  data: {
+    aqi: 42,
+    dominentpol: "pm25",
+    iaqi: {
+      pm25: { v: 12.5 },
+      pm10: { v: 28.3 },
+      o3: { v: 18.0 },
+    },
+    city: {
+      name: "Nashville, Tennessee, USA",
+    },
+  },
+};
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("getAqiData", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, WAQI_API_TOKEN: "test-token" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("successful API response", () => {
+    it("returns AQI and pollutant data", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_AQI_RESPONSE),
+      });
+
+      const result = await getAqiData(36.1627, -86.7816);
+
+      expect(result.aqi).toBe(42);
+      expect(result.pm25).toBe(12.5);
+      expect(result.pm10).toBe(28.3);
+      expect(result.dominant_pollutant).toBe("pm25");
+      expect(result.station).toBe("Nashville, Tennessee, USA");
+    });
+
+    it("constructs correct URL with token and coordinates", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_AQI_RESPONSE),
+      });
+
+      await getAqiData(36.1627, -86.7816);
+
+      const calledUrl = mockFetch.mock.calls[0][0];
+      expect(calledUrl).toBe(
+        "https://api.waqi.info/feed/geo:36.1627;-86.7816/?token=test-token",
+      );
+    });
+
+    it("returns null for missing pollutant readings", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status: "ok",
+            data: {
+              aqi: 50,
+              iaqi: {}, // no pm25 or pm10
+              city: { name: "Test Station" },
+            },
+          }),
+      });
+
+      const result = await getAqiData(36.1627, -86.7816);
+      expect(result.aqi).toBe(50);
+      expect(result.pm25).toBeNull();
+      expect(result.pm10).toBeNull();
+    });
+
+    it("returns null dominant_pollutant when not provided", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status: "ok",
+            data: {
+              aqi: 30,
+              iaqi: { pm25: { v: 8 } },
+              city: { name: "Test" },
+            },
+          }),
+      });
+
+      const result = await getAqiData(36.1627, -86.7816);
+      expect(result.dominant_pollutant).toBeNull();
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns defaults when API token is missing", async () => {
+      delete process.env.WAQI_API_TOKEN;
+
+      const result = await getAqiData(36.1627, -86.7816);
+      expect(result).toEqual(AQI_DEFAULTS);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns defaults when API returns non-OK HTTP status", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+      const result = await getAqiData(36.1627, -86.7816);
+      expect(result).toEqual(AQI_DEFAULTS);
+    });
+
+    it("returns defaults when API returns error status in body", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            status: "error",
+            data: "Invalid key",
+          }),
+      });
+
+      const result = await getAqiData(36.1627, -86.7816);
+      expect(result).toEqual(AQI_DEFAULTS);
+    });
+
+    it("returns defaults when fetch throws network error", async () => {
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      const result = await getAqiData(36.1627, -86.7816);
+      expect(result).toEqual(AQI_DEFAULTS);
+    });
+
+    it("returns defaults when response data is null", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: "ok", data: null }),
+      });
+
+      const result = await getAqiData(36.1627, -86.7816);
+      expect(result).toEqual(AQI_DEFAULTS);
+    });
+  });
+});

--- a/__tests__/api/pollen.test.ts
+++ b/__tests__/api/pollen.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Google Pollen API Client Tests
+ *
+ * Validates pollen data fetching, UPI extraction, species parsing,
+ * and graceful fallback on API errors.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getPollenData, POLLEN_DEFAULTS } from "@/lib/apis/pollen";
+
+/* ------------------------------------------------------------------ */
+/* Mock fetch                                                          */
+/* ------------------------------------------------------------------ */
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+/* ------------------------------------------------------------------ */
+/* Test data                                                           */
+/* ------------------------------------------------------------------ */
+
+const MOCK_POLLEN_RESPONSE = {
+  dailyInfo: [
+    {
+      date: { year: 2026, month: 3, day: 30 },
+      pollenTypeInfo: [
+        {
+          code: "TREE",
+          indexInfo: { value: 4, category: "Very High" },
+          plantInfo: [
+            {
+              displayName: "Oak",
+              indexInfo: { value: 4, category: "Very High" },
+            },
+            {
+              displayName: "Cedar",
+              indexInfo: { value: 3, category: "High" },
+            },
+          ],
+        },
+        {
+          code: "GRASS",
+          indexInfo: { value: 2, category: "Moderate" },
+          plantInfo: [
+            {
+              displayName: "Bermuda",
+              indexInfo: { value: 2, category: "Moderate" },
+            },
+          ],
+        },
+        {
+          code: "WEED",
+          indexInfo: { value: 1, category: "Low" },
+          plantInfo: [],
+        },
+      ],
+    },
+  ],
+};
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("getPollenData", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, GOOGLE_POLLEN_API_KEY: "test-key" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("successful API response", () => {
+    it("returns UPI values for tree, grass, and weed", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_POLLEN_RESPONSE),
+      });
+
+      const result = await getPollenData(36.1627, -86.7816);
+
+      expect(result.upi_tree).toBe(4);
+      expect(result.upi_grass).toBe(2);
+      expect(result.upi_weed).toBe(1);
+    });
+
+    it("extracts species data from plantInfo", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_POLLEN_RESPONSE),
+      });
+
+      const result = await getPollenData(36.1627, -86.7816);
+
+      expect(result.species).toHaveLength(3);
+      expect(result.species[0]).toEqual({
+        display_name: "Oak",
+        index: { value: 4, category: "Very High" },
+      });
+      expect(result.species[1]).toEqual({
+        display_name: "Cedar",
+        index: { value: 3, category: "High" },
+      });
+      expect(result.species[2]).toEqual({
+        display_name: "Bermuda",
+        index: { value: 2, category: "Moderate" },
+      });
+    });
+
+    it("formats date as YYYY-MM-DD", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_POLLEN_RESPONSE),
+      });
+
+      const result = await getPollenData(36.1627, -86.7816);
+      expect(result.date).toBe("2026-03-30");
+    });
+
+    it("passes correct parameters to the API", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_POLLEN_RESPONSE),
+      });
+
+      await getPollenData(36.1627, -86.7816);
+
+      const calledUrl = new URL(mockFetch.mock.calls[0][0]);
+      expect(calledUrl.origin + calledUrl.pathname).toBe(
+        "https://pollen.googleapis.com/v1/forecast:lookup",
+      );
+      expect(calledUrl.searchParams.get("key")).toBe("test-key");
+      expect(calledUrl.searchParams.get("location.latitude")).toBe("36.1627");
+      expect(calledUrl.searchParams.get("location.longitude")).toBe("-86.7816");
+      expect(calledUrl.searchParams.get("days")).toBe("1");
+    });
+  });
+
+  describe("missing data handling", () => {
+    it("returns null UPI when pollen type is missing", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            dailyInfo: [
+              {
+                date: { year: 2026, month: 3, day: 30 },
+                pollenTypeInfo: [
+                  { code: "TREE", indexInfo: { value: 3 } },
+                  // GRASS and WEED missing
+                ],
+              },
+            ],
+          }),
+      });
+
+      const result = await getPollenData(36.1627, -86.7816);
+      expect(result.upi_tree).toBe(3);
+      expect(result.upi_grass).toBeNull();
+      expect(result.upi_weed).toBeNull();
+    });
+
+    it("returns defaults for empty dailyInfo", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ dailyInfo: [] }),
+      });
+
+      const result = await getPollenData(36.1627, -86.7816);
+      expect(result).toEqual(POLLEN_DEFAULTS);
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns defaults when API key is missing", async () => {
+      delete process.env.GOOGLE_POLLEN_API_KEY;
+
+      const result = await getPollenData(36.1627, -86.7816);
+      expect(result).toEqual(POLLEN_DEFAULTS);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns defaults when API returns non-OK status", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 403 });
+
+      const result = await getPollenData(36.1627, -86.7816);
+      expect(result).toEqual(POLLEN_DEFAULTS);
+    });
+
+    it("returns defaults when fetch throws network error", async () => {
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      const result = await getPollenData(36.1627, -86.7816);
+      expect(result).toEqual(POLLEN_DEFAULTS);
+    });
+
+    it("returns defaults when response JSON is malformed", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(null),
+      });
+
+      const result = await getPollenData(36.1627, -86.7816);
+      expect(result).toEqual(POLLEN_DEFAULTS);
+    });
+  });
+});

--- a/__tests__/api/weather.test.ts
+++ b/__tests__/api/weather.test.ts
@@ -1,0 +1,211 @@
+/**
+ * OpenWeatherMap API Client Tests
+ *
+ * Validates weather data fetching, unit conversions,
+ * thunderstorm detection, and graceful fallback on errors.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getWeatherData,
+  WEATHER_DEFAULTS,
+  kelvinToFahrenheit,
+  msToMph,
+  isThunderstorm,
+} from "@/lib/apis/weather";
+
+/* ------------------------------------------------------------------ */
+/* Mock fetch                                                          */
+/* ------------------------------------------------------------------ */
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+/* ------------------------------------------------------------------ */
+/* Test data                                                           */
+/* ------------------------------------------------------------------ */
+
+const MOCK_WEATHER_RESPONSE = {
+  main: {
+    temp: 295.15, // 71.6°F → rounds to 72°F
+    humidity: 65,
+  },
+  wind: {
+    speed: 4.47, // ~10.0 mph
+    deg: 180,
+  },
+  weather: [{ id: 500, main: "Rain", description: "light rain" }],
+  rain: { "1h": 0.5 },
+};
+
+const THUNDERSTORM_RESPONSE = {
+  ...MOCK_WEATHER_RESPONSE,
+  weather: [{ id: 211, main: "Thunderstorm", description: "thunderstorm" }],
+};
+
+/* ------------------------------------------------------------------ */
+/* Unit conversion tests                                               */
+/* ------------------------------------------------------------------ */
+
+describe("kelvinToFahrenheit", () => {
+  it("converts 273.15 K to 32°F (freezing point)", () => {
+    expect(kelvinToFahrenheit(273.15)).toBe(32);
+  });
+
+  it("converts 373.15 K to 212°F (boiling point)", () => {
+    expect(kelvinToFahrenheit(373.15)).toBe(212);
+  });
+
+  it("converts 295.15 K to 72°F (room temp)", () => {
+    expect(kelvinToFahrenheit(295.15)).toBe(72);
+  });
+});
+
+describe("msToMph", () => {
+  it("converts 1 m/s to ~2.2 mph", () => {
+    expect(msToMph(1)).toBe(2.2);
+  });
+
+  it("converts 0 m/s to 0 mph", () => {
+    expect(msToMph(0)).toBe(0);
+  });
+
+  it("converts 10 m/s to ~22.4 mph", () => {
+    expect(msToMph(10)).toBe(22.4);
+  });
+});
+
+describe("isThunderstorm", () => {
+  it("returns true for thunderstorm codes (200-232)", () => {
+    expect(isThunderstorm([{ id: 200 }])).toBe(true);
+    expect(isThunderstorm([{ id: 211 }])).toBe(true);
+    expect(isThunderstorm([{ id: 232 }])).toBe(true);
+  });
+
+  it("returns false for non-thunderstorm codes", () => {
+    expect(isThunderstorm([{ id: 500 }])).toBe(false);
+    expect(isThunderstorm([{ id: 800 }])).toBe(false);
+    expect(isThunderstorm([{ id: 199 }])).toBe(false);
+    expect(isThunderstorm([{ id: 233 }])).toBe(false);
+  });
+
+  it("returns false for undefined weather array", () => {
+    expect(isThunderstorm(undefined)).toBe(false);
+  });
+
+  it("detects thunderstorm in mixed conditions", () => {
+    expect(isThunderstorm([{ id: 500 }, { id: 210 }])).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* API client tests                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("getWeatherData", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, OPENWEATHER_API_KEY: "test-key" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("successful API response", () => {
+    it("returns converted weather data", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_WEATHER_RESPONSE),
+      });
+
+      const result = await getWeatherData(36.1627, -86.7816);
+
+      expect(result.temp_f).toBe(72);
+      expect(result.humidity_pct).toBe(65);
+      expect(result.wind_mph).toBe(10);
+      expect(result.wind_direction_deg).toBe(180);
+      expect(result.rain_last_12h).toBe(true);
+      expect(result.thunderstorm_6h).toBe(false);
+    });
+
+    it("detects thunderstorm conditions", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(THUNDERSTORM_RESPONSE),
+      });
+
+      const result = await getWeatherData(36.1627, -86.7816);
+      expect(result.thunderstorm_6h).toBe(true);
+    });
+
+    it("detects no rain when rain object is missing", async () => {
+      const noRain = { ...MOCK_WEATHER_RESPONSE, rain: undefined };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(noRain),
+      });
+
+      const result = await getWeatherData(36.1627, -86.7816);
+      expect(result.rain_last_12h).toBe(false);
+    });
+
+    it("passes correct parameters to the API", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(MOCK_WEATHER_RESPONSE),
+      });
+
+      await getWeatherData(36.1627, -86.7816);
+
+      const calledUrl = new URL(mockFetch.mock.calls[0][0]);
+      expect(calledUrl.origin + calledUrl.pathname).toBe(
+        "https://api.openweathermap.org/data/2.5/weather",
+      );
+      expect(calledUrl.searchParams.get("lat")).toBe("36.1627");
+      expect(calledUrl.searchParams.get("lon")).toBe("-86.7816");
+      expect(calledUrl.searchParams.get("appid")).toBe("test-key");
+    });
+  });
+
+  describe("missing data handling", () => {
+    it("returns null fields when main/wind objects are missing", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ weather: [] }),
+      });
+
+      const result = await getWeatherData(36.1627, -86.7816);
+      expect(result.temp_f).toBeNull();
+      expect(result.humidity_pct).toBeNull();
+      expect(result.wind_mph).toBeNull();
+      expect(result.wind_direction_deg).toBeNull();
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns defaults when API key is missing", async () => {
+      delete process.env.OPENWEATHER_API_KEY;
+
+      const result = await getWeatherData(36.1627, -86.7816);
+      expect(result).toEqual(WEATHER_DEFAULTS);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns defaults when API returns non-OK status", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 401 });
+
+      const result = await getWeatherData(36.1627, -86.7816);
+      expect(result).toEqual(WEATHER_DEFAULTS);
+    });
+
+    it("returns defaults when fetch throws network error", async () => {
+      mockFetch.mockRejectedValue(new Error("Network failure"));
+
+      const result = await getWeatherData(36.1627, -86.7816);
+      expect(result).toEqual(WEATHER_DEFAULTS);
+    });
+  });
+});

--- a/lib/apis/aqi.ts
+++ b/lib/apis/aqi.ts
@@ -1,0 +1,105 @@
+/**
+ * WAQI (World Air Quality Index) API Client
+ *
+ * Fetches real-time air quality data including AQI, PM2.5, and PM10.
+ * Used by the tournament engine as an environmental factor in
+ * allergen exposure modeling.
+ *
+ * Server-side only — API token must never be exposed to the client.
+ *
+ * Reference: https://aqicn.org/json-api/doc/
+ */
+
+/* ------------------------------------------------------------------ */
+/* Types                                                               */
+/* ------------------------------------------------------------------ */
+
+export interface AqiResult {
+  /** Overall Air Quality Index (0-500+) */
+  aqi: number | null;
+  /** PM2.5 concentration (ug/m3) */
+  pm25: number | null;
+  /** PM10 concentration (ug/m3) */
+  pm10: number | null;
+  /** Dominant pollutant identifier */
+  dominant_pollutant: string | null;
+  /** Station name providing the data */
+  station: string | null;
+}
+
+/* ------------------------------------------------------------------ */
+/* Defaults                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Returned when API is unreachable or token is missing */
+export const AQI_DEFAULTS: AqiResult = {
+  aqi: null,
+  pm25: null,
+  pm10: null,
+  dominant_pollutant: null,
+  station: null,
+};
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Extract a specific pollutant value from the WAQI iaqi object.
+ * WAQI returns individual pollutant readings as { v: number }.
+ */
+function extractIaqi(
+  iaqi: Record<string, { v: number }> | undefined,
+  key: string,
+): number | null {
+  if (!iaqi) return null;
+  const entry = iaqi[key];
+  return typeof entry?.v === "number" ? entry.v : null;
+}
+
+/* ------------------------------------------------------------------ */
+/* API Client                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Fetch air quality data from WAQI for a location.
+ *
+ * Uses the geo-based feed endpoint which returns the nearest
+ * monitoring station's data for the given coordinates.
+ *
+ * @param lat — latitude
+ * @param lng — longitude
+ * @returns AqiResult with AQI and particulate data, or defaults if API fails
+ */
+export async function getAqiData(
+  lat: number,
+  lng: number,
+): Promise<AqiResult> {
+  const apiToken = process.env.WAQI_API_TOKEN;
+  if (!apiToken) return AQI_DEFAULTS;
+
+  try {
+    const url = `https://api.waqi.info/feed/geo:${lat};${lng}/?token=${apiToken}`;
+
+    const response = await fetch(url);
+    if (!response.ok) return AQI_DEFAULTS;
+
+    const data = await response.json();
+
+    if (data.status !== "ok" || !data.data) return AQI_DEFAULTS;
+
+    const feed = data.data;
+
+    return {
+      aqi: typeof feed.aqi === "number" ? feed.aqi : null,
+      pm25: extractIaqi(feed.iaqi, "pm25"),
+      pm10: extractIaqi(feed.iaqi, "pm10"),
+      dominant_pollutant:
+        typeof feed.dominentpol === "string" ? feed.dominentpol : null,
+      station:
+        typeof feed.city?.name === "string" ? feed.city.name : null,
+    };
+  } catch {
+    return AQI_DEFAULTS;
+  }
+}

--- a/lib/apis/pollen.ts
+++ b/lib/apis/pollen.ts
@@ -1,0 +1,163 @@
+/**
+ * Google Pollen API Client
+ *
+ * Fetches species-level pollen data on a 1x1km grid tile.
+ * Returns Universal Pollen Index (UPI) values (0-5 scale) for
+ * tree, grass, and weed categories.
+ *
+ * Server-side only — API key must never be exposed to the client.
+ *
+ * Reference: https://developers.google.com/maps/documentation/pollen
+ */
+
+/* ------------------------------------------------------------------ */
+/* Types                                                               */
+/* ------------------------------------------------------------------ */
+
+export interface PollenIndex {
+  /** UPI value (0-5 scale) */
+  value: number;
+  /** Human-readable category */
+  category: string;
+}
+
+export interface PollenSpeciesInfo {
+  /** Species display name */
+  display_name: string;
+  /** UPI index for this species */
+  index: PollenIndex;
+}
+
+export interface PollenResult {
+  /** Tree pollen UPI (0-5), null if unavailable */
+  upi_tree: number | null;
+  /** Grass pollen UPI (0-5), null if unavailable */
+  upi_grass: number | null;
+  /** Weed pollen UPI (0-5), null if unavailable */
+  upi_weed: number | null;
+  /** Individual species data when available */
+  species: PollenSpeciesInfo[];
+  /** Data timestamp from API */
+  date: string | null;
+}
+
+/* ------------------------------------------------------------------ */
+/* Defaults                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Returned when API is unreachable or key is missing */
+export const POLLEN_DEFAULTS: PollenResult = {
+  upi_tree: null,
+  upi_grass: null,
+  upi_weed: null,
+  species: [],
+  date: null,
+};
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Extract UPI value for a pollen type from the API response.
+ * The API returns pollenTypeInfo as an array of objects with
+ * code (TREE, GRASS, WEED) and indexInfo containing the UPI value.
+ */
+function extractUpi(
+  pollenTypes: Array<{ code: string; indexInfo?: { value?: number } }> | undefined,
+  code: string,
+): number | null {
+  if (!pollenTypes) return null;
+  const entry = pollenTypes.find((p) => p.code === code);
+  const value = entry?.indexInfo?.value;
+  return typeof value === "number" ? value : null;
+}
+
+/**
+ * Extract species-level data from the API response.
+ */
+function extractSpecies(
+  pollenTypes: Array<{
+    code: string;
+    healthRecommendations?: string[];
+    plantInfo?: Array<{
+      displayName?: string;
+      indexInfo?: { value?: number; category?: string };
+    }>;
+  }> | undefined,
+): PollenSpeciesInfo[] {
+  if (!pollenTypes) return [];
+
+  const species: PollenSpeciesInfo[] = [];
+  for (const type of pollenTypes) {
+    if (!type.plantInfo) continue;
+    for (const plant of type.plantInfo) {
+      if (plant.displayName && plant.indexInfo?.value != null) {
+        species.push({
+          display_name: plant.displayName,
+          index: {
+            value: plant.indexInfo.value,
+            category: plant.indexInfo.category ?? "unknown",
+          },
+        });
+      }
+    }
+  }
+  return species;
+}
+
+/* ------------------------------------------------------------------ */
+/* API Client                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Fetch pollen data for a location from the Google Pollen API.
+ *
+ * Returns UPI (Universal Pollen Index) values for tree, grass, and
+ * weed categories on a 1x1km grid tile.
+ *
+ * @param lat — latitude
+ * @param lng — longitude
+ * @returns PollenResult with UPI values, or defaults if API fails
+ */
+export async function getPollenData(
+  lat: number,
+  lng: number,
+): Promise<PollenResult> {
+  const apiKey = process.env.GOOGLE_POLLEN_API_KEY;
+  if (!apiKey) return POLLEN_DEFAULTS;
+
+  try {
+    const url = new URL(
+      "https://pollen.googleapis.com/v1/forecast:lookup",
+    );
+    url.searchParams.set("key", apiKey);
+    url.searchParams.set("location.longitude", lng.toString());
+    url.searchParams.set("location.latitude", lat.toString());
+    url.searchParams.set("days", "1");
+    url.searchParams.set("plantsDescription", "true");
+
+    const response = await fetch(url.toString());
+    if (!response.ok) return POLLEN_DEFAULTS;
+
+    const data = await response.json();
+
+    // The API returns dailyInfo as an array; we want today's entry
+    const today = data?.dailyInfo?.[0];
+    if (!today) return POLLEN_DEFAULTS;
+
+    const pollenTypes = today.pollenTypeInfo;
+
+    return {
+      upi_tree: extractUpi(pollenTypes, "TREE"),
+      upi_grass: extractUpi(pollenTypes, "GRASS"),
+      upi_weed: extractUpi(pollenTypes, "WEED"),
+      species: extractSpecies(pollenTypes),
+      date: today.date
+        ? `${today.date.year}-${String(today.date.month).padStart(2, "0")}-${String(today.date.day).padStart(2, "0")}`
+        : null,
+    };
+  } catch {
+    return POLLEN_DEFAULTS;
+  }
+}

--- a/lib/apis/weather.ts
+++ b/lib/apis/weather.ts
@@ -1,0 +1,139 @@
+/**
+ * OpenWeatherMap API Client
+ *
+ * Fetches current weather conditions: wind speed/direction, humidity,
+ * temperature, and precipitation data. Used by the Monte Carlo
+ * simulation for pollen dispersion modeling.
+ *
+ * Server-side only — API key must never be exposed to the client.
+ *
+ * Reference: https://openweathermap.org/current
+ */
+
+/* ------------------------------------------------------------------ */
+/* Types                                                               */
+/* ------------------------------------------------------------------ */
+
+export interface WeatherResult {
+  /** Temperature in Fahrenheit */
+  temp_f: number | null;
+  /** Relative humidity percentage (0-100) */
+  humidity_pct: number | null;
+  /** Wind speed in mph */
+  wind_mph: number | null;
+  /** Wind direction in degrees (0-360, 0=N, 90=E, 180=S, 270=W) */
+  wind_direction_deg: number | null;
+  /** Rain detected in last 12 hours (approximated from 1h/3h rain) */
+  rain_last_12h: boolean;
+  /** Thunderstorm detected in last 6 hours (from weather condition codes) */
+  thunderstorm_6h: boolean;
+}
+
+/* ------------------------------------------------------------------ */
+/* Defaults                                                            */
+/* ------------------------------------------------------------------ */
+
+/** Returned when API is unreachable or key is missing */
+export const WEATHER_DEFAULTS: WeatherResult = {
+  temp_f: null,
+  humidity_pct: null,
+  wind_mph: null,
+  wind_direction_deg: null,
+  rain_last_12h: false,
+  thunderstorm_6h: false,
+};
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/** Convert Kelvin to Fahrenheit */
+export function kelvinToFahrenheit(kelvin: number): number {
+  return Math.round(((kelvin - 273.15) * 9) / 5 + 32);
+}
+
+/** Convert m/s to mph */
+export function msToMph(ms: number): number {
+  return Math.round(ms * 2.237 * 10) / 10;
+}
+
+/**
+ * Check if any weather condition code indicates a thunderstorm.
+ * OpenWeatherMap codes 200-232 are thunderstorm conditions.
+ */
+export function isThunderstorm(
+  weather: Array<{ id: number }> | undefined,
+): boolean {
+  if (!weather) return false;
+  return weather.some((w) => w.id >= 200 && w.id <= 232);
+}
+
+/**
+ * Check if rain is present from the rain object.
+ * OpenWeatherMap provides rain.1h and rain.3h in mm.
+ * We consider any rain > 0 as rain detected.
+ */
+function hasRain(
+  rain: { "1h"?: number; "3h"?: number } | undefined,
+): boolean {
+  if (!rain) return false;
+  return (rain["1h"] ?? 0) > 0 || (rain["3h"] ?? 0) > 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* API Client                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Fetch current weather data from OpenWeatherMap.
+ *
+ * Returns temperature, humidity, wind, and precipitation data
+ * needed for Monte Carlo pollen dispersion simulation.
+ *
+ * @param lat — latitude
+ * @param lng — longitude
+ * @returns WeatherResult with current conditions, or defaults if API fails
+ */
+export async function getWeatherData(
+  lat: number,
+  lng: number,
+): Promise<WeatherResult> {
+  const apiKey = process.env.OPENWEATHER_API_KEY;
+  if (!apiKey) return WEATHER_DEFAULTS;
+
+  try {
+    const url = new URL(
+      "https://api.openweathermap.org/data/2.5/weather",
+    );
+    url.searchParams.set("lat", lat.toString());
+    url.searchParams.set("lon", lng.toString());
+    url.searchParams.set("appid", apiKey);
+    // Units: standard (Kelvin) — we convert manually for precision
+
+    const response = await fetch(url.toString());
+    if (!response.ok) return WEATHER_DEFAULTS;
+
+    const data = await response.json();
+
+    return {
+      temp_f:
+        typeof data.main?.temp === "number"
+          ? kelvinToFahrenheit(data.main.temp)
+          : null,
+      humidity_pct:
+        typeof data.main?.humidity === "number"
+          ? data.main.humidity
+          : null,
+      wind_mph:
+        typeof data.wind?.speed === "number"
+          ? msToMph(data.wind.speed)
+          : null,
+      wind_direction_deg:
+        typeof data.wind?.deg === "number" ? data.wind.deg : null,
+      rain_last_12h: hasRain(data.rain),
+      thunderstorm_6h: isThunderstorm(data.weather),
+    };
+  } catch {
+    return WEATHER_DEFAULTS;
+  }
+}


### PR DESCRIPTION
## Summary

Implements ticket #21 — External API clients for Google Pollen, OpenWeatherMap, and WAQI.

- **`lib/apis/pollen.ts`** — Google Pollen API client. Fetches species-level UPI (Universal Pollen Index, 0-5 scale) for tree, grass, and weed categories on a 1x1km grid tile. Extracts individual species data from `plantInfo`. Env: `GOOGLE_POLLEN_API_KEY`.
- **`lib/apis/weather.ts`** — OpenWeatherMap client. Fetches current conditions: temperature (Kelvin→F), humidity, wind speed (m/s→mph) and direction, rain detection, and thunderstorm detection (weather codes 200-232). Env: `OPENWEATHER_API_KEY`.
- **`lib/apis/aqi.ts`** — WAQI (World Air Quality Index) client. Fetches AQI, PM2.5, PM10, dominant pollutant, and station name from nearest monitoring station. Env: `WAQI_API_TOKEN`.

### Design Decisions

- **Graceful fallback pattern**: All three clients return typed default objects (null values) when API keys are missing or requests fail — consistent with existing `batchdata.ts` and `census.ts` clients.
- **No caching in client layer**: TTL caching (pollen: 1hr, weather: 30min, AQI: 1hr) will be implemented at the tournament engine orchestration layer, not in individual clients, to keep the clients pure and testable.
- **Unit conversions exported**: `kelvinToFahrenheit`, `msToMph`, `isThunderstorm` are exported for direct testing and potential reuse.
- **Fields match schema**: Return types align with `symptom_checkins` columns: `pollen_upi_tree`, `pollen_upi_grass`, `pollen_upi_weed`, `aqi`, `humidity_pct`, `temp_f`, `wind_mph`, `wind_direction_deg`, `rain_last_12h`, `thunderstorm_6h`.

## Test Plan

- [x] Pollen: returns UPI values for tree/grass/weed from API response
- [x] Pollen: extracts species data from plantInfo
- [x] Pollen: returns defaults when API key missing, HTTP error, network error
- [x] Weather: converts Kelvin→F and m/s→mph correctly
- [x] Weather: detects thunderstorm codes (200-232) and rain
- [x] Weather: returns defaults on API failure
- [x] AQI: extracts AQI, PM2.5, PM10, dominant pollutant, station
- [x] AQI: returns defaults when token missing, API error, network error
- [x] All 214 tests pass (37 new), lint clean, typecheck clean

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)