### PR TITLE
feat(leaderboard): add Trigger Champion and Final Four display

### DIFF
--- a/__tests__/api/leaderboard.test.ts
+++ b/__tests__/api/leaderboard.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Leaderboard API Route Tests
+ *
+ * Validates the GET /api/leaderboard endpoint:
+ * - Returns ranked allergens for authenticated users
+ * - Requires authentication
+ * - Never returns income_tier
+ * - Computes confidence tiers correctly
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/* ------------------------------------------------------------------ */
+/* Mock setup                                                          */
+/* ------------------------------------------------------------------ */
+
+const mockGetUser = vi.fn();
+const mockSingle = vi.fn();
+const mockOrder = vi.fn();
+const mockIs = vi.fn();
+const mockEq = vi.fn();
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  }),
+}));
+
+// Also mock next/headers to avoid cookie errors in test
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    getAll: () => [],
+    set: () => {},
+  }),
+}));
+
+import { GET } from "@/app/api/leaderboard/route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function setupAuth(user: { id: string } | null) {
+  mockGetUser.mockResolvedValue({
+    data: { user },
+    error: user ? null : { message: "Not authenticated" },
+  });
+}
+
+function setupProfile(profile: { fda_acknowledged: boolean } | null) {
+  // Profile query chain: from("user_profiles").select().eq().single()
+  const profileSingle = vi.fn().mockResolvedValue({
+    data: profile,
+    error: profile ? null : { message: "Not found" },
+  });
+  const profileEq = vi.fn().mockReturnValue({ single: profileSingle });
+  const profileSelect = vi.fn().mockReturnValue({ eq: profileEq });
+
+  return { select: profileSelect, eq: profileEq, single: profileSingle };
+}
+
+function setupSubscription(tier: string | null) {
+  const subSingle = vi.fn().mockResolvedValue({
+    data: tier ? { tier } : null,
+    error: null,
+  });
+  const subEq = vi.fn().mockReturnValue({ single: subSingle });
+  const subSelect = vi.fn().mockReturnValue({ eq: subEq });
+
+  return { select: subSelect, eq: subEq, single: subSingle };
+}
+
+function setupEloRows(
+  rows: Array<{
+    allergen_id: string;
+    elo_score: number;
+    positive_signals: number;
+    negative_signals: number;
+    allergens: { common_name: string; category: string };
+  }> | null
+) {
+  const eloOrder = vi.fn().mockResolvedValue({
+    data: rows,
+    error: rows === null ? { message: "Query error" } : null,
+  });
+  const eloIs = vi.fn().mockReturnValue({ order: eloOrder });
+  const eloEq = vi.fn().mockReturnValue({ is: eloIs });
+  const eloSelect = vi.fn().mockReturnValue({ eq: eloEq });
+
+  return { select: eloSelect, eq: eloEq, is: eloIs, order: eloOrder };
+}
+
+describe("GET /api/leaderboard", () => {
+  it("returns 401 when not authenticated", async () => {
+    setupAuth(null);
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns ranked allergens for authenticated user", async () => {
+    setupAuth({ id: "user-123" });
+
+    const profileMock = setupProfile({ fda_acknowledged: true });
+    const subMock = setupSubscription("free");
+    const eloMock = setupEloRows([
+      {
+        allergen_id: "oak",
+        elo_score: 1650,
+        positive_signals: 20,
+        negative_signals: 5,
+        allergens: { common_name: "Oak", category: "tree" },
+      },
+      {
+        allergen_id: "birch",
+        elo_score: 1500,
+        positive_signals: 5,
+        negative_signals: 2,
+        allergens: { common_name: "Birch", category: "tree" },
+      },
+    ]);
+
+    // Set up from() to return different mocks for different tables
+    let fromCallCount = 0;
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "user_profiles") {
+        return { select: profileMock.select };
+      }
+      if (table === "user_subscriptions") {
+        return { select: subMock.select };
+      }
+      if (table === "user_allergen_elo") {
+        return { select: eloMock.select };
+      }
+      return {};
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.allergens).toHaveLength(2);
+    expect(json.allergens[0].allergen_id).toBe("oak");
+    expect(json.allergens[0].rank).toBe(1);
+    expect(json.allergens[0].common_name).toBe("Oak");
+    expect(json.allergens[1].rank).toBe(2);
+    expect(json.isPremium).toBe(false);
+    expect(json.isEnvironmentalForecast).toBe(false);
+    expect(json.fdaAcknowledged).toBe(true);
+  });
+
+  it("does NOT include income_tier in response", async () => {
+    setupAuth({ id: "user-123" });
+
+    const profileMock = setupProfile({ fda_acknowledged: true });
+    const subMock = setupSubscription("free");
+    const eloMock = setupEloRows([
+      {
+        allergen_id: "oak",
+        elo_score: 1650,
+        positive_signals: 20,
+        negative_signals: 5,
+        allergens: { common_name: "Oak", category: "tree" },
+      },
+    ]);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "user_profiles") return { select: profileMock.select };
+      if (table === "user_subscriptions") return { select: subMock.select };
+      if (table === "user_allergen_elo") return { select: eloMock.select };
+      return {};
+    });
+
+    const response = await GET();
+    const text = await response.text();
+
+    expect(text).not.toContain("income_tier");
+  });
+
+  it("returns isEnvironmentalForecast=true when no Elo data", async () => {
+    setupAuth({ id: "user-123" });
+
+    const profileMock = setupProfile({ fda_acknowledged: false });
+    const subMock = setupSubscription("free");
+    const eloMock = setupEloRows([]);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "user_profiles") return { select: profileMock.select };
+      if (table === "user_subscriptions") return { select: subMock.select };
+      if (table === "user_allergen_elo") return { select: eloMock.select };
+      return {};
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(json.isEnvironmentalForecast).toBe(true);
+    expect(json.allergens).toHaveLength(0);
+  });
+
+  it("returns isPremium=true for madness_plus subscribers", async () => {
+    setupAuth({ id: "user-123" });
+
+    const profileMock = setupProfile({ fda_acknowledged: true });
+    const subMock = setupSubscription("madness_plus");
+    const eloMock = setupEloRows([]);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "user_profiles") return { select: profileMock.select };
+      if (table === "user_subscriptions") return { select: subMock.select };
+      if (table === "user_allergen_elo") return { select: eloMock.select };
+      return {};
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(json.isPremium).toBe(true);
+  });
+
+  it("computes confidence tiers correctly", async () => {
+    setupAuth({ id: "user-123" });
+
+    const profileMock = setupProfile({ fda_acknowledged: true });
+    const subMock = setupSubscription("free");
+    const eloMock = setupEloRows([
+      {
+        allergen_id: "a",
+        elo_score: 1800,
+        positive_signals: 25,
+        negative_signals: 10, // 35 total -> very_high
+        allergens: { common_name: "A", category: "tree" },
+      },
+      {
+        allergen_id: "b",
+        elo_score: 1600,
+        positive_signals: 10,
+        negative_signals: 5, // 15 total -> high
+        allergens: { common_name: "B", category: "grass" },
+      },
+      {
+        allergen_id: "c",
+        elo_score: 1400,
+        positive_signals: 5,
+        negative_signals: 3, // 8 total -> medium
+        allergens: { common_name: "C", category: "weed" },
+      },
+      {
+        allergen_id: "d",
+        elo_score: 1200,
+        positive_signals: 2,
+        negative_signals: 1, // 3 total -> low
+        allergens: { common_name: "D", category: "mold" },
+      },
+    ]);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "user_profiles") return { select: profileMock.select };
+      if (table === "user_subscriptions") return { select: subMock.select };
+      if (table === "user_allergen_elo") return { select: eloMock.select };
+      return {};
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(json.allergens[0].confidence_tier).toBe("very_high");
+    expect(json.allergens[1].confidence_tier).toBe("high");
+    expect(json.allergens[2].confidence_tier).toBe("medium");
+    expect(json.allergens[3].confidence_tier).toBe("low");
+  });
+});

--- a/__tests__/components/leaderboard/blur-overlay.test.tsx
+++ b/__tests__/components/leaderboard/blur-overlay.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Blur Overlay Tests
+ *
+ * Validates the freemium gate that blurs content for free-tier users.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BlurOverlay } from "@/components/leaderboard/blur-overlay";
+
+describe("BlurOverlay", () => {
+  it("renders children inside a blur wrapper", () => {
+    render(
+      <BlurOverlay>
+        <span data-testid="child">Content</span>
+      </BlurOverlay>
+    );
+    expect(screen.getByTestId("child")).toBeDefined();
+  });
+
+  it("renders the blur overlay container", () => {
+    render(
+      <BlurOverlay>
+        <span>Content</span>
+      </BlurOverlay>
+    );
+    expect(screen.getByTestId("blur-overlay")).toBeDefined();
+  });
+
+  it("shows lock overlay with upgrade message", () => {
+    render(
+      <BlurOverlay>
+        <span>Content</span>
+      </BlurOverlay>
+    );
+    expect(screen.getByTestId("blur-lock-overlay")).toBeDefined();
+    expect(
+      screen.getByText("Upgrade to Madness+ to reveal")
+    ).toBeDefined();
+  });
+
+  it("marks blurred children as aria-hidden", () => {
+    render(
+      <BlurOverlay>
+        <span>Content</span>
+      </BlurOverlay>
+    );
+    // The blur wrapper has aria-hidden="true"
+    const overlay = screen.getByTestId("blur-overlay");
+    const blurredDiv = overlay.querySelector("[aria-hidden='true']");
+    expect(blurredDiv).not.toBeNull();
+  });
+});

--- a/__tests__/components/leaderboard/environmental-forecast.test.tsx
+++ b/__tests__/components/leaderboard/environmental-forecast.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * Environmental Forecast Tests
+ *
+ * Validates the display when severity = 0 (no symptoms).
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EnvironmentalForecast } from "@/components/leaderboard/environmental-forecast";
+
+describe("EnvironmentalForecast", () => {
+  it("renders the component", () => {
+    render(<EnvironmentalForecast />);
+    expect(screen.getByTestId("environmental-forecast")).toBeDefined();
+  });
+
+  it("displays the mode title", () => {
+    render(<EnvironmentalForecast />);
+    expect(screen.getByText("Environmental Forecast Mode")).toBeDefined();
+  });
+
+  it("shows a message about no symptoms", () => {
+    render(<EnvironmentalForecast />);
+    expect(
+      screen.getByText(/No symptoms reported/)
+    ).toBeDefined();
+  });
+});

--- a/__tests__/components/leaderboard/final-four.test.tsx
+++ b/__tests__/components/leaderboard/final-four.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Final Four Tests
+ *
+ * Validates the bracket-style display of allergens ranked #2-#4,
+ * including blur behavior for free-tier vs premium users.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FinalFour } from "@/components/leaderboard/final-four";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+const mockAllergens: RankedAllergen[] = [
+  {
+    allergen_id: "birch",
+    common_name: "Birch",
+    category: "tree",
+    elo_score: 1500,
+    confidence_tier: "medium",
+    rank: 2,
+  },
+  {
+    allergen_id: "ragweed",
+    common_name: "Ragweed",
+    category: "weed",
+    elo_score: 1450,
+    confidence_tier: "high",
+    rank: 3,
+  },
+  {
+    allergen_id: "bermuda_grass",
+    common_name: "Bermuda Grass",
+    category: "grass",
+    elo_score: 1400,
+    confidence_tier: "low",
+    rank: 4,
+  },
+];
+
+describe("FinalFour", () => {
+  describe("premium user (unblurred)", () => {
+    it("renders all three allergen cards", () => {
+      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      const cards = screen.getAllByTestId("final-four-card");
+      expect(cards.length).toBe(3);
+    });
+
+    it("shows allergen names", () => {
+      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      const names = screen.getAllByTestId("final-four-name");
+      expect(names[0].textContent).toBe("Birch");
+      expect(names[1].textContent).toBe("Ragweed");
+      expect(names[2].textContent).toBe("Bermuda Grass");
+    });
+
+    it("shows rank badges", () => {
+      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      const ranks = screen.getAllByTestId("final-four-rank");
+      expect(ranks[0].textContent).toBe("#2");
+      expect(ranks[1].textContent).toBe("#3");
+      expect(ranks[2].textContent).toBe("#4");
+    });
+
+    it("shows Elo scores", () => {
+      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      const scores = screen.getAllByTestId("final-four-elo");
+      expect(scores[0].textContent).toBe("Elo 1500");
+      expect(scores[1].textContent).toBe("Elo 1450");
+      expect(scores[2].textContent).toBe("Elo 1400");
+    });
+
+    it("does not show blur overlay", () => {
+      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      expect(screen.queryByTestId("blur-overlay")).toBeNull();
+    });
+  });
+
+  describe("free-tier user (blurred)", () => {
+    it("renders the blur overlay", () => {
+      render(<FinalFour allergens={mockAllergens} isBlurred={true} />);
+      expect(screen.getByTestId("blur-overlay")).toBeDefined();
+    });
+
+    it("shows the lock overlay with upgrade message", () => {
+      render(<FinalFour allergens={mockAllergens} isBlurred={true} />);
+      expect(screen.getByTestId("blur-lock-overlay")).toBeDefined();
+      expect(
+        screen.getByText("Upgrade to Madness+ to reveal")
+      ).toBeDefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null for empty allergens array", () => {
+      const { container } = render(
+        <FinalFour allergens={[]} isBlurred={false} />
+      );
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("renders correctly with fewer than 3 allergens", () => {
+      render(
+        <FinalFour allergens={mockAllergens.slice(0, 1)} isBlurred={false} />
+      );
+      const cards = screen.getAllByTestId("final-four-card");
+      expect(cards.length).toBe(1);
+    });
+  });
+});

--- a/__tests__/components/leaderboard/leaderboard.test.tsx
+++ b/__tests__/components/leaderboard/leaderboard.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Leaderboard Component Tests
+ *
+ * Validates the full leaderboard orchestration:
+ * - Trigger Champion rendering
+ * - Final Four rendering with blur/unblur
+ * - FDA disclaimer visibility
+ * - Environmental Forecast mode
+ * - First-time FDA acknowledgment gate
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Leaderboard } from "@/components/leaderboard/leaderboard";
+import { FDA_DISCLAIMER_LABEL } from "@/components/shared/fda-disclaimer";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+/* ------------------------------------------------------------------ */
+/* Mock Supabase client (required by DisclaimerModal)                  */
+/* ------------------------------------------------------------------ */
+
+const mockUpdate = vi.fn();
+const mockEq = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEq.mockResolvedValue({ error: null });
+  mockUpdate.mockReturnValue({ eq: mockEq });
+  mockFrom.mockReturnValue({ update: mockUpdate });
+});
+
+/* ------------------------------------------------------------------ */
+/* Test data                                                           */
+/* ------------------------------------------------------------------ */
+
+const mockAllergens: RankedAllergen[] = [
+  {
+    allergen_id: "oak",
+    common_name: "Oak",
+    category: "tree",
+    elo_score: 1650,
+    confidence_tier: "very_high",
+    rank: 1,
+  },
+  {
+    allergen_id: "birch",
+    common_name: "Birch",
+    category: "tree",
+    elo_score: 1500,
+    confidence_tier: "high",
+    rank: 2,
+  },
+  {
+    allergen_id: "ragweed",
+    common_name: "Ragweed",
+    category: "weed",
+    elo_score: 1450,
+    confidence_tier: "medium",
+    rank: 3,
+  },
+  {
+    allergen_id: "bermuda_grass",
+    common_name: "Bermuda Grass",
+    category: "grass",
+    elo_score: 1400,
+    confidence_tier: "low",
+    rank: 4,
+  },
+  {
+    allergen_id: "dust_mites",
+    common_name: "Dust Mites",
+    category: "indoor",
+    elo_score: 1350,
+    confidence_tier: "medium",
+    rank: 5,
+  },
+];
+
+const defaultProps = {
+  allergens: mockAllergens,
+  isPremium: false,
+  isEnvironmentalForecast: false,
+  fdaAcknowledged: true,
+  userId: "user-123",
+};
+
+describe("Leaderboard", () => {
+  describe("normal mode (acknowledged, has data)", () => {
+    it("renders the leaderboard container", () => {
+      render(<Leaderboard {...defaultProps} />);
+      expect(screen.getByTestId("leaderboard")).toBeDefined();
+    });
+
+    it("renders the Trigger Champion card with correct name", () => {
+      render(<Leaderboard {...defaultProps} />);
+      expect(screen.getByTestId("trigger-champion-card")).toBeDefined();
+      expect(screen.getByTestId("champion-name").textContent).toBe("Oak");
+    });
+
+    it("renders the FDA disclaimer", () => {
+      render(<Leaderboard {...defaultProps} />);
+      expect(screen.getByText(FDA_DISCLAIMER_LABEL)).toBeDefined();
+      expect(screen.getByTestId("fda-disclaimer")).toBeDefined();
+    });
+
+    it("renders the Final Four section", () => {
+      render(<Leaderboard {...defaultProps} />);
+      expect(screen.getByText("Final Four")).toBeDefined();
+    });
+
+    it("renders the full rankings section for allergens beyond top 4", () => {
+      render(<Leaderboard {...defaultProps} />);
+      expect(screen.getByText("Full Rankings")).toBeDefined();
+      const rows = screen.getAllByTestId("ranked-allergen-row");
+      expect(rows.length).toBe(1); // Only #5 (Dust Mites)
+    });
+
+    it("shows Dust Mites in full rankings", () => {
+      render(<Leaderboard {...defaultProps} />);
+      expect(screen.getByText("Dust Mites")).toBeDefined();
+    });
+  });
+
+  describe("free-tier user (blurred Final Four)", () => {
+    it("blurs the Final Four for free-tier users", () => {
+      render(<Leaderboard {...defaultProps} isPremium={false} />);
+      expect(screen.getByTestId("blur-overlay")).toBeDefined();
+    });
+
+    it("shows Trigger Champion unblurred even for free tier", () => {
+      render(<Leaderboard {...defaultProps} isPremium={false} />);
+      expect(screen.getByTestId("trigger-champion-card")).toBeDefined();
+      expect(screen.getByTestId("champion-name").textContent).toBe("Oak");
+    });
+  });
+
+  describe("premium user (unblurred)", () => {
+    it("does not blur the Final Four for premium users", () => {
+      render(<Leaderboard {...defaultProps} isPremium={true} />);
+      expect(screen.queryByTestId("blur-overlay")).toBeNull();
+    });
+
+    it("shows all Final Four cards clearly", () => {
+      render(<Leaderboard {...defaultProps} isPremium={true} />);
+      const cards = screen.getAllByTestId("final-four-card");
+      expect(cards.length).toBe(3); // #2, #3, #4
+    });
+  });
+
+  describe("Environmental Forecast mode", () => {
+    it("shows Environmental Forecast when severity = 0", () => {
+      render(
+        <Leaderboard
+          {...defaultProps}
+          isEnvironmentalForecast={true}
+          allergens={[]}
+        />
+      );
+      expect(screen.getByTestId("environmental-forecast")).toBeDefined();
+      expect(
+        screen.getByText("Environmental Forecast Mode")
+      ).toBeDefined();
+    });
+
+    it("does not show Trigger Champion in forecast mode", () => {
+      render(
+        <Leaderboard
+          {...defaultProps}
+          isEnvironmentalForecast={true}
+          allergens={[]}
+        />
+      );
+      expect(screen.queryByTestId("trigger-champion-card")).toBeNull();
+    });
+
+    it("still shows FDA disclaimer in forecast mode", () => {
+      render(
+        <Leaderboard
+          {...defaultProps}
+          isEnvironmentalForecast={true}
+          allergens={[]}
+        />
+      );
+      expect(screen.getByTestId("fda-disclaimer")).toBeDefined();
+    });
+  });
+
+  describe("FDA disclaimer gate", () => {
+    it("shows disclaimer modal when not yet acknowledged", () => {
+      render(<Leaderboard {...defaultProps} fdaAcknowledged={false} />);
+      expect(screen.getByTestId("disclaimer-modal")).toBeDefined();
+      expect(screen.queryByTestId("leaderboard")).toBeNull();
+    });
+
+    it("shows leaderboard when already acknowledged", () => {
+      render(<Leaderboard {...defaultProps} fdaAcknowledged={true} />);
+      expect(screen.queryByTestId("disclaimer-modal")).toBeNull();
+      expect(screen.getByTestId("leaderboard")).toBeDefined();
+    });
+  });
+
+  describe("with only champion (no Final Four)", () => {
+    it("renders champion without Final Four section", () => {
+      render(
+        <Leaderboard
+          {...defaultProps}
+          allergens={[mockAllergens[0]]}
+        />
+      );
+      expect(screen.getByTestId("trigger-champion-card")).toBeDefined();
+      expect(screen.queryByText("Final Four")).toBeNull();
+      expect(screen.queryByText("Full Rankings")).toBeNull();
+    });
+  });
+});

--- a/__tests__/components/leaderboard/trigger-champion-card.test.tsx
+++ b/__tests__/components/leaderboard/trigger-champion-card.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Trigger Champion Card Tests
+ *
+ * Validates that the #1 ranked allergen is displayed prominently
+ * with the correct name, Elo score, and confidence tier badge.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TriggerChampionCard } from "@/components/leaderboard/trigger-champion-card";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+const mockChampion: RankedAllergen = {
+  allergen_id: "oak",
+  common_name: "Oak",
+  category: "tree",
+  elo_score: 1650,
+  confidence_tier: "high",
+  rank: 1,
+};
+
+describe("TriggerChampionCard", () => {
+  it("renders the allergen name", () => {
+    render(<TriggerChampionCard allergen={mockChampion} />);
+    expect(screen.getByTestId("champion-name").textContent).toBe("Oak");
+  });
+
+  it("renders the Elo score", () => {
+    render(<TriggerChampionCard allergen={mockChampion} />);
+    expect(screen.getByTestId("champion-elo").textContent).toBe("Elo 1650");
+  });
+
+  it('displays "Trigger Champion" header', () => {
+    render(<TriggerChampionCard allergen={mockChampion} />);
+    expect(screen.getByText("Trigger Champion")).toBeDefined();
+  });
+
+  it("renders the confidence badge", () => {
+    render(<TriggerChampionCard allergen={mockChampion} />);
+    const badge = screen.getByTestId("confidence-badge");
+    expect(badge.textContent).toBe("High");
+    expect(badge.getAttribute("data-tier")).toBe("high");
+  });
+
+  it("renders the category icon", () => {
+    render(<TriggerChampionCard allergen={mockChampion} />);
+    const icon = screen.getByTestId("category-icon");
+    expect(icon.getAttribute("data-category")).toBe("tree");
+  });
+
+  it("has the correct test ID", () => {
+    render(<TriggerChampionCard allergen={mockChampion} />);
+    expect(screen.getByTestId("trigger-champion-card")).toBeDefined();
+  });
+});

--- a/app/(app)/dashboard/dashboard-leaderboard.tsx
+++ b/app/(app)/dashboard/dashboard-leaderboard.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * Dashboard Leaderboard Wrapper
+ *
+ * Client component that receives server-fetched data and renders
+ * the Leaderboard component. This separation keeps data fetching
+ * in the server component while allowing client interactivity
+ * (FDA disclaimer acknowledgment, etc.).
+ */
+
+import { Leaderboard } from "@/components/leaderboard";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+import type { ConfidenceTier } from "@/lib/engine/types";
+
+/** Shape of an Elo row from the server component's Supabase query */
+interface EloRow {
+  allergen_id: string;
+  elo_score: number;
+  positive_signals: number;
+  negative_signals: number;
+  allergens: {
+    common_name: string;
+    category: string;
+  };
+}
+
+interface DashboardLeaderboardProps {
+  eloRows: EloRow[];
+  isPremium: boolean;
+  isEnvironmentalForecast: boolean;
+  fdaAcknowledged: boolean;
+  userId: string;
+}
+
+function computeConfidenceTier(totalSignals: number): ConfidenceTier {
+  if (totalSignals >= 30) return "very_high";
+  if (totalSignals >= 14) return "high";
+  if (totalSignals >= 7) return "medium";
+  return "low";
+}
+
+export function DashboardLeaderboard({
+  eloRows,
+  isPremium,
+  isEnvironmentalForecast,
+  fdaAcknowledged,
+  userId,
+}: DashboardLeaderboardProps) {
+  const allergens: RankedAllergen[] = eloRows.map((row, index) => ({
+    allergen_id: row.allergen_id,
+    common_name: row.allergens.common_name,
+    category: row.allergens.category as RankedAllergen["category"],
+    elo_score: row.elo_score,
+    confidence_tier: computeConfidenceTier(
+      row.positive_signals + row.negative_signals
+    ),
+    rank: index + 1,
+  }));
+
+  return (
+    <Leaderboard
+      allergens={allergens}
+      isPremium={isPremium}
+      isEnvironmentalForecast={isEnvironmentalForecast}
+      fdaAcknowledged={fdaAcknowledged}
+      userId={userId}
+    />
+  );
+}

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,6 +1,23 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { SignOutButton } from "./sign-out-button";
+import { DashboardLeaderboard } from "./dashboard-leaderboard";
+
+/**
+ * Shape returned by the Supabase join query.
+ * Defined explicitly because the generated types do not include
+ * foreign-key relationships for `!inner` joins.
+ */
+interface EloRowWithAllergen {
+  allergen_id: string;
+  elo_score: number;
+  positive_signals: number;
+  negative_signals: number;
+  allergens: {
+    common_name: string;
+    category: string;
+  };
+}
 
 export default async function DashboardPage() {
   const supabase = await createClient();
@@ -12,13 +29,99 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
+  // Fetch profile for FDA acknowledgment status
+  const { data: profileData } = await supabase
+    .from("user_profiles")
+    .select("fda_acknowledged")
+    .eq("id", user.id)
+    .single();
+
+  const profile = profileData as { fda_acknowledged: boolean } | null;
+
+  // Fetch subscription tier
+  const { data: subscriptionData } = await supabase
+    .from("user_subscriptions")
+    .select("tier")
+    .eq("user_id", user.id)
+    .single();
+
+  const subscription = subscriptionData as { tier: string } | null;
+  const tier = subscription?.tier ?? "free";
+  const isPremium = tier === "madness_plus" || tier === "madness_family";
+
+  // Fetch allergen Elo rankings
+  const { data: rawEloRows } = await supabase
+    .from("user_allergen_elo")
+    .select(
+      `
+      allergen_id,
+      elo_score,
+      positive_signals,
+      negative_signals,
+      allergens!inner (
+        common_name,
+        category
+      )
+    `
+    )
+    .eq("user_id", user.id)
+    .is("child_id", null)
+    .order("elo_score", { ascending: false });
+
+  const eloRows = (rawEloRows ?? []) as unknown as EloRowWithAllergen[];
+  const isEnvironmentalForecast = eloRows.length === 0;
+
   return (
-    <div className="mx-auto max-w-2xl px-4 py-12">
-      <h1 className="mb-2 text-2xl font-bold text-gray-900">
-        Welcome to Allergy Madness
-      </h1>
-      <p className="mb-6 text-gray-600">Signed in as {user.email}</p>
-      <SignOutButton />
+    <div
+      className="mx-auto max-w-2xl px-4 py-8"
+      style={{
+        maxWidth: "42rem",
+        margin: "0 auto",
+        padding: "2rem 1rem",
+      }}
+    >
+      <div
+        className="mb-6 flex items-center justify-between"
+        style={{
+          marginBottom: "1.5rem",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>
+          <h1
+            className="text-2xl font-bold text-gray-900"
+            style={{
+              fontSize: "1.5rem",
+              fontWeight: 700,
+              color: "#111827",
+              margin: 0,
+            }}
+          >
+            Welcome to Allergy Madness
+          </h1>
+          <p
+            className="text-sm text-gray-600"
+            style={{
+              fontSize: "0.875rem",
+              color: "#4b5563",
+              margin: "0.25rem 0 0 0",
+            }}
+          >
+            Signed in as {user.email}
+          </p>
+        </div>
+        <SignOutButton />
+      </div>
+
+      <DashboardLeaderboard
+        eloRows={eloRows}
+        isPremium={isPremium}
+        isEnvironmentalForecast={isEnvironmentalForecast}
+        fdaAcknowledged={profile?.fda_acknowledged ?? false}
+        userId={user.id}
+      />
     </div>
   );
 }

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import type { ConfidenceTier } from "@/lib/engine/types";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+/**
+ * Shape returned by the Supabase join query.
+ * Defined explicitly because the generated types do not include
+ * foreign-key relationships for `!inner` joins.
+ */
+interface EloRowWithAllergen {
+  allergen_id: string;
+  elo_score: number;
+  positive_signals: number;
+  negative_signals: number;
+  allergens: {
+    common_name: string;
+    category: string;
+  };
+}
+
+/**
+ * GET /api/leaderboard
+ *
+ * Returns the authenticated user's allergen leaderboard.
+ * Joins user_allergen_elo with allergens to produce ranked results.
+ *
+ * Security:
+ * - Requires authenticated user (RLS enforces row-level access)
+ * - NEVER returns income_tier
+ * - Returns subscription tier for freemium gating
+ */
+export async function GET() {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch user profile for fda_acknowledged
+  const { data: profileData, error: profileError } = await supabase
+    .from("user_profiles")
+    .select("fda_acknowledged")
+    .eq("id", user.id)
+    .single();
+
+  if (profileError) {
+    return NextResponse.json(
+      { error: "Failed to load profile" },
+      { status: 500 }
+    );
+  }
+
+  const profile = profileData as { fda_acknowledged: boolean } | null;
+
+  // Fetch subscription tier
+  const { data: subscriptionData } = await supabase
+    .from("user_subscriptions")
+    .select("tier")
+    .eq("user_id", user.id)
+    .single();
+
+  const subscription = subscriptionData as { tier: string } | null;
+  const tier = subscription?.tier ?? "free";
+  const isPremium = tier === "madness_plus" || tier === "madness_family";
+
+  // Fetch user's allergen Elo scores, joined with allergen info
+  const { data: rawEloRows, error: eloError } = await supabase
+    .from("user_allergen_elo")
+    .select(
+      `
+      allergen_id,
+      elo_score,
+      positive_signals,
+      negative_signals,
+      allergens!inner (
+        common_name,
+        category
+      )
+    `
+    )
+    .eq("user_id", user.id)
+    .is("child_id", null)
+    .order("elo_score", { ascending: false });
+
+  if (eloError) {
+    return NextResponse.json(
+      { error: "Failed to load leaderboard" },
+      { status: 500 }
+    );
+  }
+
+  const eloRows = (rawEloRows ?? []) as unknown as EloRowWithAllergen[];
+
+  // Determine if this is Environmental Forecast mode
+  // (no Elo data means no symptoms have been processed)
+  const isEnvironmentalForecast = eloRows.length === 0;
+
+  // Map to ranked allergens with confidence tiers
+  const allergens: RankedAllergen[] = eloRows.map((row, index) => ({
+    allergen_id: row.allergen_id,
+    common_name: row.allergens.common_name,
+    category: row.allergens.category as RankedAllergen["category"],
+    elo_score: row.elo_score,
+    confidence_tier: computeConfidenceTier(
+      row.positive_signals + row.negative_signals
+    ),
+    rank: index + 1,
+  }));
+
+  return NextResponse.json({
+    allergens,
+    isPremium,
+    isEnvironmentalForecast,
+    fdaAcknowledged: profile?.fda_acknowledged ?? false,
+  });
+}
+
+/**
+ * Compute confidence tier based on total signal count.
+ * More signals = higher confidence in the ranking.
+ */
+function computeConfidenceTier(totalSignals: number): ConfidenceTier {
+  if (totalSignals >= 30) return "very_high";
+  if (totalSignals >= 14) return "high";
+  if (totalSignals >= 7) return "medium";
+  return "low";
+}

--- a/components/leaderboard/blur-overlay.tsx
+++ b/components/leaderboard/blur-overlay.tsx
@@ -1,0 +1,70 @@
+/**
+ * Blur Overlay
+ *
+ * Freemium gate overlay that blurs content for free-tier users.
+ * Shows a lock icon with pulse animation and upgrade prompt.
+ */
+
+import type { BlurOverlayProps } from "./types";
+
+export function BlurOverlay({ children }: BlurOverlayProps) {
+  return (
+    <div
+      data-testid="blur-overlay"
+      className="relative"
+      style={{ position: "relative" }}
+    >
+      {/* Blurred content */}
+      <div
+        className="pointer-events-none select-none blur-md"
+        style={{
+          filter: "blur(8px)",
+          pointerEvents: "none",
+          userSelect: "none",
+        }}
+        aria-hidden="true"
+      >
+        {children}
+      </div>
+
+      {/* Lock overlay */}
+      <div
+        data-testid="blur-lock-overlay"
+        className="absolute inset-0 flex flex-col items-center justify-center"
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <span
+          className="mb-2 text-3xl"
+          style={{
+            fontSize: "1.875rem",
+            marginBottom: "0.5rem",
+            animation: "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite",
+          }}
+          aria-hidden="true"
+        >
+          &#x1F512;
+        </span>
+        <p
+          className="text-sm font-medium text-gray-600"
+          style={{
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            color: "#4b5563",
+          }}
+        >
+          Upgrade to Madness+ to reveal
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/leaderboard/category-icon.tsx
+++ b/components/leaderboard/category-icon.tsx
@@ -1,0 +1,38 @@
+/**
+ * Category Icon
+ *
+ * Renders a text-based icon representing the allergen category.
+ * Uses Unicode symbols to avoid image dependency.
+ */
+
+import type { AllergenCategory } from "@/lib/supabase/types";
+
+interface CategoryIconProps {
+  category: AllergenCategory;
+}
+
+const CATEGORY_ICONS: Record<AllergenCategory, { icon: string; label: string }> = {
+  tree: { icon: "\u{1F333}", label: "Tree pollen" },
+  grass: { icon: "\u{1F33F}", label: "Grass pollen" },
+  weed: { icon: "\u{1F33E}", label: "Weed pollen" },
+  mold: { icon: "\u{1F344}", label: "Mold" },
+  indoor: { icon: "\u{1F3E0}", label: "Indoor allergen" },
+  food: { icon: "\u{1F34E}", label: "Food allergen" },
+};
+
+export function CategoryIcon({ category }: CategoryIconProps) {
+  const config = CATEGORY_ICONS[category];
+
+  return (
+    <span
+      role="img"
+      aria-label={config.label}
+      data-testid="category-icon"
+      data-category={category}
+      className="text-lg"
+      style={{ fontSize: "1.125rem" }}
+    >
+      {config.icon}
+    </span>
+  );
+}

--- a/components/leaderboard/confidence-badge.tsx
+++ b/components/leaderboard/confidence-badge.tsx
@@ -1,0 +1,66 @@
+/**
+ * Confidence Tier Badge
+ *
+ * Displays a color-coded badge indicating the confidence level
+ * of an allergen's ranking (low / medium / high / very high).
+ */
+
+import type { ConfidenceTier } from "@/lib/engine/types";
+
+interface ConfidenceBadgeProps {
+  tier: ConfidenceTier;
+}
+
+const TIER_CONFIG: Record<
+  ConfidenceTier,
+  { label: string; bgColor: string; textColor: string; tailwind: string }
+> = {
+  low: {
+    label: "Low",
+    bgColor: "#dbeafe",
+    textColor: "#1e40af",
+    tailwind: "bg-blue-100 text-blue-800",
+  },
+  medium: {
+    label: "Medium",
+    bgColor: "#fef9c3",
+    textColor: "#854d0e",
+    tailwind: "bg-yellow-100 text-yellow-800",
+  },
+  high: {
+    label: "High",
+    bgColor: "#fed7aa",
+    textColor: "#9a3412",
+    tailwind: "bg-orange-100 text-orange-800",
+  },
+  very_high: {
+    label: "Very High",
+    bgColor: "#fecaca",
+    textColor: "#991b1b",
+    tailwind: "bg-red-100 text-red-800",
+  },
+};
+
+export function ConfidenceBadge({ tier }: ConfidenceBadgeProps) {
+  const config = TIER_CONFIG[tier];
+
+  return (
+    <span
+      data-testid="confidence-badge"
+      data-tier={tier}
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${config.tailwind}`}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        borderRadius: "9999px",
+        padding: "0.125rem 0.5rem",
+        fontSize: "0.75rem",
+        fontWeight: 500,
+        backgroundColor: config.bgColor,
+        color: config.textColor,
+      }}
+    >
+      {config.label}
+    </span>
+  );
+}

--- a/components/leaderboard/environmental-forecast.tsx
+++ b/components/leaderboard/environmental-forecast.tsx
@@ -1,0 +1,57 @@
+/**
+ * Environmental Forecast Mode
+ *
+ * Displayed when the user's global severity is 0 (no symptoms).
+ * Instead of showing ranked allergens, this mode shows a positive
+ * message indicating the user is symptom-free.
+ */
+
+export function EnvironmentalForecast() {
+  return (
+    <div
+      data-testid="environmental-forecast"
+      className="rounded-xl border border-green-200 bg-green-50 p-6 text-center"
+      style={{
+        borderRadius: "0.75rem",
+        border: "1px solid #bbf7d0",
+        backgroundColor: "#f0fdf4",
+        padding: "1.5rem",
+        textAlign: "center",
+      }}
+    >
+      <span
+        className="mb-3 block text-4xl"
+        style={{
+          display: "block",
+          fontSize: "2.25rem",
+          marginBottom: "0.75rem",
+        }}
+        aria-hidden="true"
+      >
+        &#x2600;
+      </span>
+      <h2
+        className="mb-2 text-lg font-bold text-green-800"
+        style={{
+          fontSize: "1.125rem",
+          fontWeight: 700,
+          color: "#166534",
+          marginBottom: "0.5rem",
+        }}
+      >
+        Environmental Forecast Mode
+      </h2>
+      <p
+        className="text-sm text-green-700"
+        style={{
+          fontSize: "0.875rem",
+          color: "#15803d",
+          margin: 0,
+        }}
+      >
+        No symptoms reported. Your allergen rankings will appear here once you
+        log symptom data through daily check-ins.
+      </p>
+    </div>
+  );
+}

--- a/components/leaderboard/final-four.tsx
+++ b/components/leaderboard/final-four.tsx
@@ -1,0 +1,122 @@
+/**
+ * Final Four Display
+ *
+ * Bracket-style display of allergens ranked #2-#4.
+ * Free-tier users see these blurred; premium users see them clearly.
+ */
+
+import type { FinalFourProps } from "./types";
+import { ConfidenceBadge } from "./confidence-badge";
+import { CategoryIcon } from "./category-icon";
+import { BlurOverlay } from "./blur-overlay";
+import type { RankedAllergen } from "./types";
+
+function FinalFourCard({ allergen }: { allergen: RankedAllergen }) {
+  return (
+    <div
+      data-testid="final-four-card"
+      className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+      style={{
+        borderRadius: "0.5rem",
+        border: "1px solid #e5e7eb",
+        backgroundColor: "#ffffff",
+        padding: "1rem",
+        boxShadow: "0 1px 2px 0 rgba(0,0,0,.05)",
+      }}
+    >
+      {/* Rank badge */}
+      <div
+        className="mb-2 flex items-center justify-between"
+        style={{
+          marginBottom: "0.5rem",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <span
+          data-testid="final-four-rank"
+          className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-600"
+          style={{
+            display: "flex",
+            height: "1.5rem",
+            width: "1.5rem",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: "9999px",
+            backgroundColor: "#f3f4f6",
+            fontSize: "0.75rem",
+            fontWeight: 700,
+            color: "#4b5563",
+          }}
+        >
+          #{allergen.rank}
+        </span>
+        <ConfidenceBadge tier={allergen.confidence_tier} />
+      </div>
+
+      {/* Allergen info */}
+      <div
+        className="flex items-center gap-2"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+        }}
+      >
+        <CategoryIcon category={allergen.category} />
+        <div>
+          <p
+            data-testid="final-four-name"
+            className="text-sm font-semibold text-gray-900"
+            style={{
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              color: "#111827",
+              margin: 0,
+            }}
+          >
+            {allergen.common_name}
+          </p>
+          <p
+            data-testid="final-four-elo"
+            className="text-xs text-gray-500"
+            style={{
+              fontSize: "0.75rem",
+              color: "#6b7280",
+              margin: 0,
+            }}
+          >
+            Elo {allergen.elo_score}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function FinalFour({ allergens, isBlurred }: FinalFourProps) {
+  if (allergens.length === 0) return null;
+
+  const content = (
+    <div
+      data-testid="final-four-grid"
+      className="grid grid-cols-1 gap-3 sm:grid-cols-3"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+        gap: "0.75rem",
+      }}
+    >
+      {allergens.map((allergen) => (
+        <FinalFourCard key={allergen.allergen_id} allergen={allergen} />
+      ))}
+    </div>
+  );
+
+  if (isBlurred) {
+    return <BlurOverlay>{content}</BlurOverlay>;
+  }
+
+  return content;
+}

--- a/components/leaderboard/index.ts
+++ b/components/leaderboard/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Leaderboard Components
+ *
+ * Re-exports for the allergen leaderboard display surface.
+ */
+
+export { Leaderboard } from "./leaderboard";
+export type { LeaderboardClientProps } from "./leaderboard";
+
+export { TriggerChampionCard } from "./trigger-champion-card";
+export { FinalFour } from "./final-four";
+export { BlurOverlay } from "./blur-overlay";
+export { ConfidenceBadge } from "./confidence-badge";
+export { CategoryIcon } from "./category-icon";
+export { EnvironmentalForecast } from "./environmental-forecast";
+
+export type {
+  RankedAllergen,
+  LeaderboardProps,
+  TriggerChampionCardProps,
+  FinalFourProps,
+  AllergenRankRowProps,
+  BlurOverlayProps,
+} from "./types";

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+/**
+ * Leaderboard
+ *
+ * Main container component for the allergen leaderboard display.
+ * Orchestrates the Trigger Champion, Final Four, and full ranked list.
+ *
+ * Features:
+ * - Trigger Champion (#1) always visible
+ * - Final Four (#2-4) blurred for free tier, visible for premium
+ * - FDA disclaimer always visible
+ * - Environmental Forecast mode when severity = 0
+ * - First-time FDA acknowledgment gate
+ */
+
+import { useState } from "react";
+import { FdaDisclaimer } from "@/components/shared/fda-disclaimer";
+import { DisclaimerModal } from "@/components/shared/disclaimer-modal";
+import { TriggerChampionCard } from "./trigger-champion-card";
+import { FinalFour } from "./final-four";
+import { EnvironmentalForecast } from "./environmental-forecast";
+import { ConfidenceBadge } from "./confidence-badge";
+import { CategoryIcon } from "./category-icon";
+import type { RankedAllergen } from "./types";
+
+export interface LeaderboardClientProps {
+  /** Ranked allergens sorted by Elo descending */
+  allergens: RankedAllergen[];
+  /** Whether the user has premium access */
+  isPremium: boolean;
+  /** Whether severity is 0 (Environmental Forecast mode) */
+  isEnvironmentalForecast: boolean;
+  /** Whether the user has already acknowledged the FDA disclaimer */
+  fdaAcknowledged: boolean;
+  /** Authenticated user ID */
+  userId: string;
+}
+
+export function Leaderboard({
+  allergens,
+  isPremium,
+  isEnvironmentalForecast,
+  fdaAcknowledged,
+  userId,
+}: LeaderboardClientProps) {
+  const [acknowledged, setAcknowledged] = useState(fdaAcknowledged);
+
+  // First-time gate: must acknowledge FDA disclaimer
+  if (!acknowledged) {
+    return (
+      <DisclaimerModal
+        userId={userId}
+        onAcknowledge={() => setAcknowledged(true)}
+      />
+    );
+  }
+
+  // Environmental Forecast mode when severity = 0
+  if (isEnvironmentalForecast) {
+    return (
+      <div
+        data-testid="leaderboard"
+        className="mx-auto max-w-2xl space-y-6 px-4 py-6"
+        style={{
+          maxWidth: "42rem",
+          margin: "0 auto",
+          padding: "1.5rem 1rem",
+        }}
+      >
+        <h1
+          className="text-2xl font-bold text-gray-900"
+          style={{
+            fontSize: "1.5rem",
+            fontWeight: 700,
+            color: "#111827",
+            margin: 0,
+          }}
+        >
+          Your Allergen Leaderboard
+        </h1>
+        <FdaDisclaimer />
+        <EnvironmentalForecast />
+      </div>
+    );
+  }
+
+  const champion = allergens[0] ?? null;
+  const finalFour = allergens.slice(1, 4);
+
+  return (
+    <div
+      data-testid="leaderboard"
+      className="mx-auto max-w-2xl space-y-6 px-4 py-6"
+      style={{
+        maxWidth: "42rem",
+        margin: "0 auto",
+        padding: "1.5rem 1rem",
+      }}
+    >
+      <h1
+        className="text-2xl font-bold text-gray-900"
+        style={{
+          fontSize: "1.5rem",
+          fontWeight: 700,
+          color: "#111827",
+          margin: "0 0 1.5rem 0",
+        }}
+      >
+        Your Allergen Leaderboard
+      </h1>
+
+      {/* FDA Disclaimer — always visible */}
+      <FdaDisclaimer />
+
+      {/* Trigger Champion */}
+      {champion && (
+        <div style={{ marginTop: "1.5rem" }}>
+          <TriggerChampionCard allergen={champion} />
+        </div>
+      )}
+
+      {/* Final Four (#2-#4) */}
+      {finalFour.length > 0 && (
+        <div style={{ marginTop: "1.5rem" }}>
+          <h2
+            className="mb-3 text-lg font-semibold text-gray-800"
+            style={{
+              fontSize: "1.125rem",
+              fontWeight: 600,
+              color: "#1f2937",
+              marginBottom: "0.75rem",
+            }}
+          >
+            Final Four
+          </h2>
+          <FinalFour allergens={finalFour} isBlurred={!isPremium} />
+        </div>
+      )}
+
+      {/* Full Ranked List (beyond top 4) */}
+      {allergens.length > 4 && (
+        <div style={{ marginTop: "1.5rem" }}>
+          <h2
+            className="mb-3 text-lg font-semibold text-gray-800"
+            style={{
+              fontSize: "1.125rem",
+              fontWeight: 600,
+              color: "#1f2937",
+              marginBottom: "0.75rem",
+            }}
+          >
+            Full Rankings
+          </h2>
+          <div
+            data-testid="full-rankings"
+            className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white"
+            style={{
+              borderRadius: "0.5rem",
+              border: "1px solid #e5e7eb",
+              backgroundColor: "#ffffff",
+              overflow: "hidden",
+            }}
+          >
+            {allergens.slice(4).map((allergen) => (
+              <div
+                key={allergen.allergen_id}
+                data-testid="ranked-allergen-row"
+                className="flex items-center justify-between px-4 py-3"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "0.75rem 1rem",
+                  borderBottom: "1px solid #f3f4f6",
+                }}
+              >
+                <div
+                  className="flex items-center gap-3"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.75rem",
+                  }}
+                >
+                  <span
+                    className="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-500"
+                    style={{
+                      display: "flex",
+                      height: "1.75rem",
+                      width: "1.75rem",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      borderRadius: "9999px",
+                      backgroundColor: "#f3f4f6",
+                      fontSize: "0.75rem",
+                      fontWeight: 700,
+                      color: "#6b7280",
+                    }}
+                  >
+                    #{allergen.rank}
+                  </span>
+                  <CategoryIcon category={allergen.category} />
+                  <span
+                    className="text-sm font-medium text-gray-900"
+                    style={{
+                      fontSize: "0.875rem",
+                      fontWeight: 500,
+                      color: "#111827",
+                    }}
+                  >
+                    {allergen.common_name}
+                  </span>
+                </div>
+                <div
+                  className="flex items-center gap-2"
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "0.5rem",
+                  }}
+                >
+                  <span
+                    className="text-xs text-gray-500"
+                    style={{ fontSize: "0.75rem", color: "#6b7280" }}
+                  >
+                    {allergen.elo_score}
+                  </span>
+                  <ConfidenceBadge tier={allergen.confidence_tier} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/leaderboard/trigger-champion-card.tsx
+++ b/components/leaderboard/trigger-champion-card.tsx
@@ -1,0 +1,107 @@
+/**
+ * Trigger Champion Card
+ *
+ * Prominently displays the #1 ranked allergen — the user's
+ * "Trigger Champion". This is always visible, even on free tier.
+ */
+
+import type { TriggerChampionCardProps } from "./types";
+import { ConfidenceBadge } from "./confidence-badge";
+import { CategoryIcon } from "./category-icon";
+
+export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
+  return (
+    <div
+      data-testid="trigger-champion-card"
+      className="rounded-xl border-2 border-amber-400 bg-gradient-to-br from-amber-50 to-orange-50 p-6 shadow-lg"
+      style={{
+        borderRadius: "0.75rem",
+        border: "2px solid #fbbf24",
+        background: "linear-gradient(to bottom right, #fffbeb, #fff7ed)",
+        padding: "1.5rem",
+        boxShadow:
+          "0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -4px rgba(0,0,0,.1)",
+      }}
+    >
+      {/* Crown / header */}
+      <div
+        className="mb-3 flex items-center gap-2"
+        style={{
+          marginBottom: "0.75rem",
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+        }}
+      >
+        <span
+          className="text-2xl"
+          style={{ fontSize: "1.5rem" }}
+          aria-hidden="true"
+        >
+          &#x1F451;
+        </span>
+        <h2
+          className="text-sm font-bold uppercase tracking-wider text-amber-700"
+          style={{
+            fontSize: "0.75rem",
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+            color: "#b45309",
+            margin: 0,
+          }}
+        >
+          Trigger Champion
+        </h2>
+      </div>
+
+      {/* Allergen name + category */}
+      <div
+        className="mb-3 flex items-center gap-3"
+        style={{
+          marginBottom: "0.75rem",
+          display: "flex",
+          alignItems: "center",
+          gap: "0.75rem",
+        }}
+      >
+        <CategoryIcon category={allergen.category} />
+        <h3
+          data-testid="champion-name"
+          className="text-2xl font-bold text-gray-900"
+          style={{
+            fontSize: "1.5rem",
+            fontWeight: 700,
+            color: "#111827",
+            margin: 0,
+          }}
+        >
+          {allergen.common_name}
+        </h3>
+      </div>
+
+      {/* Elo score + confidence */}
+      <div
+        className="flex items-center gap-3"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.75rem",
+        }}
+      >
+        <span
+          data-testid="champion-elo"
+          className="text-lg font-semibold text-gray-700"
+          style={{
+            fontSize: "1.125rem",
+            fontWeight: 600,
+            color: "#374151",
+          }}
+        >
+          Elo {allergen.elo_score}
+        </span>
+        <ConfidenceBadge tier={allergen.confidence_tier} />
+      </div>
+    </div>
+  );
+}

--- a/components/leaderboard/types.ts
+++ b/components/leaderboard/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Leaderboard Component Types
+ *
+ * Shared type definitions for the leaderboard display components.
+ * These types are client-safe — no server-only data (income_tier)
+ * is included.
+ */
+
+import type { ConfidenceTier } from "@/lib/engine/types";
+import type { AllergenCategory } from "@/lib/supabase/types";
+
+/** A ranked allergen for display on the leaderboard */
+export interface RankedAllergen {
+  allergen_id: string;
+  common_name: string;
+  category: AllergenCategory;
+  elo_score: number;
+  confidence_tier: ConfidenceTier;
+  rank: number;
+}
+
+/** Props for the full leaderboard container */
+export interface LeaderboardProps {
+  /** Ranked allergens sorted by Elo descending */
+  allergens: RankedAllergen[];
+  /** Whether the user has premium access (Madness+ or referral-unlocked) */
+  isPremium: boolean;
+  /** Whether severity is 0 (triggers Environmental Forecast mode) */
+  isEnvironmentalForecast: boolean;
+}
+
+/** Props for the Trigger Champion card */
+export interface TriggerChampionCardProps {
+  /** The #1 ranked allergen */
+  allergen: RankedAllergen;
+}
+
+/** Props for the Final Four bracket display */
+export interface FinalFourProps {
+  /** Allergens ranked #2-#4 */
+  allergens: RankedAllergen[];
+  /** Whether to blur for free-tier users */
+  isBlurred: boolean;
+}
+
+/** Props for a single allergen row in the ranked list */
+export interface AllergenRankRowProps {
+  allergen: RankedAllergen;
+  /** Whether this row should be blurred (free-tier gate) */
+  isBlurred: boolean;
+}
+
+/** Props for the blur overlay */
+export interface BlurOverlayProps {
+  children: React.ReactNode;
+}


### PR DESCRIPTION
## Summary

- Implements the primary leaderboard output surface (#20) with Trigger Champion (#1 allergen), Final Four (#2-#4 bracket display), and full rankings
- Adds freemium blur overlay for free-tier users (champion visible, Final Four blurred with upgrade prompt)
- Integrates FDA disclaimer banner and first-time acknowledgment gate before leaderboard access
- Includes Environmental Forecast mode when severity = 0 (no symptoms reported)
- Adds `GET /api/leaderboard` authenticated endpoint with confidence tier computation
- Updates dashboard page to fetch and render leaderboard data via server component + client wrapper
- All components use dual styling (Tailwind classes + inline styles) for pre-Tailwind rendering

## Files Changed

**New Components (8 files):**
- `components/leaderboard/leaderboard.tsx` — Main orchestrator with FDA gate, forecast mode
- `components/leaderboard/trigger-champion-card.tsx` — Prominent #1 allergen display
- `components/leaderboard/final-four.tsx` — Bracket-style #2-#4 display
- `components/leaderboard/blur-overlay.tsx` — Freemium gate with lock icon
- `components/leaderboard/environmental-forecast.tsx` — Severity=0 mode
- `components/leaderboard/confidence-badge.tsx` — Color-coded confidence tier badge
- `components/leaderboard/category-icon.tsx` — Unicode category icons
- `components/leaderboard/types.ts` — Shared type definitions
- `components/leaderboard/index.ts` — Barrel exports

**API Route:**
- `app/api/leaderboard/route.ts` — Authenticated GET endpoint, joins Elo + allergen data

**Dashboard Integration:**
- `app/(app)/dashboard/page.tsx` — Updated to fetch and pass leaderboard data
- `app/(app)/dashboard/dashboard-leaderboard.tsx` — Client bridge component

**Tests (6 files, 38 test cases):**
- Trigger Champion renders correctly with name, Elo, confidence badge
- Free-tier sees #2-#4 blurred, premium sees all unblurred
- FDA disclaimer is always visible
- First-time user must acknowledge before seeing results
- Environmental Forecast mode when severity = 0
- API returns correct data, never exposes income_tier
- Confidence tier computation (low/medium/high/very_high)

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (307 tests, 0 failures)
- [ ] Manual: Verify leaderboard renders on dashboard with mock data
- [ ] Manual: Verify blur overlay appears for free-tier users
- [ ] Manual: Verify FDA modal blocks access until acknowledged
- [ ] Manual: Verify Environmental Forecast shows when no Elo data exists

Closes #20

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>