### PR TITLE
feat(forecast): Environmental Forecast mode with live data

### DIFF
--- a/__tests__/api/forecast.test.ts
+++ b/__tests__/api/forecast.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Forecast API Route Tests
+ *
+ * Tests the GET /api/forecast endpoint logic.
+ * Key assertions:
+ * - Authentication required
+ * - Environmental data fetched server-side from user's location
+ * - Graceful degradation when APIs fail
+ * - income_tier NEVER present in any response
+ * - Returns pollen, weather, AQI, and region data
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock modules before importing the route
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/weather", () => ({
+  getWeatherData: vi.fn(),
+  WEATHER_DEFAULTS: {
+    temp_f: null,
+    humidity_pct: null,
+    wind_mph: null,
+    wind_direction_deg: null,
+    rain_last_12h: false,
+    thunderstorm_6h: false,
+  },
+}));
+
+vi.mock("@/lib/apis/pollen", () => ({
+  getPollenData: vi.fn(),
+  POLLEN_DEFAULTS: {
+    upi_tree: null,
+    upi_grass: null,
+    upi_weed: null,
+    species: [],
+    date: null,
+  },
+}));
+
+vi.mock("@/lib/apis/aqi", () => ({
+  getAqiData: vi.fn(),
+  AQI_DEFAULTS: {
+    aqi: null,
+    pm25: null,
+    pm10: null,
+    dominant_pollutant: null,
+    station: null,
+  },
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import { getWeatherData } from "@/lib/apis/weather";
+import { getPollenData } from "@/lib/apis/pollen";
+import { getAqiData } from "@/lib/apis/aqi";
+import { GET } from "@/app/api/forecast/route";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function createMockSupabase({
+  user = { id: "user-123" },
+  profile = { home_lat: 33.749, home_lng: -84.388, home_region: "Southeast" },
+}: {
+  user?: { id: string } | null;
+  profile?: { home_lat: number | null; home_lng: number | null; home_region: string | null } | null;
+} = {}) {
+  const mockSingle = vi.fn().mockResolvedValue({ data: profile, error: null });
+  const mockEq = vi.fn().mockReturnValue({ single: mockSingle });
+  const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+  const mockFrom = vi.fn().mockReturnValue({ select: mockSelect });
+
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user },
+      }),
+    },
+    from: mockFrom,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("GET /api/forecast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const mockSupabase = createMockSupabase({ user: null });
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("returns environmental data for authenticated user with location", async () => {
+    const mockSupabase = createMockSupabase();
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+    vi.mocked(getWeatherData).mockResolvedValue({
+      temp_f: 72,
+      humidity_pct: 55,
+      wind_mph: 8.5,
+      wind_direction_deg: 180,
+      rain_last_12h: false,
+      thunderstorm_6h: false,
+    });
+
+    vi.mocked(getPollenData).mockResolvedValue({
+      upi_tree: 3,
+      upi_grass: 1,
+      upi_weed: 0,
+      species: [],
+      date: "2026-03-30",
+    });
+
+    vi.mocked(getAqiData).mockResolvedValue({
+      aqi: 42,
+      pm25: 12,
+      pm10: 18,
+      dominant_pollutant: "pm25",
+      station: "Downtown Monitor",
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.pollen.upi_tree).toBe(3);
+    expect(data.weather.temp_f).toBe(72);
+    expect(data.aqi.aqi).toBe(42);
+    expect(data.region).toBe("Southeast");
+  });
+
+  it("calls environmental APIs with user location", async () => {
+    const mockSupabase = createMockSupabase({
+      profile: { home_lat: 40.7128, home_lng: -74.006, home_region: "Northeast" },
+    });
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+    vi.mocked(getWeatherData).mockResolvedValue({
+      temp_f: 65,
+      humidity_pct: 60,
+      wind_mph: 12,
+      wind_direction_deg: 270,
+      rain_last_12h: true,
+      thunderstorm_6h: false,
+    });
+    vi.mocked(getPollenData).mockResolvedValue({
+      upi_tree: 2,
+      upi_grass: 0,
+      upi_weed: 1,
+      species: [],
+      date: "2026-03-30",
+    });
+    vi.mocked(getAqiData).mockResolvedValue({
+      aqi: 55,
+      pm25: 15,
+      pm10: 22,
+      dominant_pollutant: "pm25",
+      station: "Midtown",
+    });
+
+    await GET();
+
+    expect(getWeatherData).toHaveBeenCalledWith(40.7128, -74.006);
+    expect(getPollenData).toHaveBeenCalledWith(40.7128, -74.006);
+    expect(getAqiData).toHaveBeenCalledWith(40.7128, -74.006);
+  });
+
+  it("returns defaults when user has no location", async () => {
+    const mockSupabase = createMockSupabase({
+      profile: { home_lat: null, home_lng: null, home_region: null },
+    });
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.pollen.upi_tree).toBeNull();
+    expect(data.weather.temp_f).toBeNull();
+    expect(data.aqi.aqi).toBeNull();
+    expect(data.region).toBeNull();
+
+    // APIs should NOT be called when there's no location
+    expect(getWeatherData).not.toHaveBeenCalled();
+    expect(getPollenData).not.toHaveBeenCalled();
+    expect(getAqiData).not.toHaveBeenCalled();
+  });
+
+  it("gracefully degrades when weather API fails", async () => {
+    const mockSupabase = createMockSupabase();
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+    vi.mocked(getWeatherData).mockRejectedValue(new Error("API down"));
+    vi.mocked(getPollenData).mockResolvedValue({
+      upi_tree: 3,
+      upi_grass: 1,
+      upi_weed: 0,
+      species: [],
+      date: "2026-03-30",
+    });
+    vi.mocked(getAqiData).mockResolvedValue({
+      aqi: 42,
+      pm25: 12,
+      pm10: 18,
+      dominant_pollutant: "pm25",
+      station: "Downtown",
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    // Weather should fall back to defaults
+    expect(data.weather.temp_f).toBeNull();
+    // Other APIs should still work
+    expect(data.pollen.upi_tree).toBe(3);
+    expect(data.aqi.aqi).toBe(42);
+  });
+
+  it("never includes income_tier in response", async () => {
+    const mockSupabase = createMockSupabase();
+    vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+    vi.mocked(getWeatherData).mockResolvedValue({
+      temp_f: 72,
+      humidity_pct: 55,
+      wind_mph: 8.5,
+      wind_direction_deg: 180,
+      rain_last_12h: false,
+      thunderstorm_6h: false,
+    });
+    vi.mocked(getPollenData).mockResolvedValue({
+      upi_tree: 3,
+      upi_grass: 1,
+      upi_weed: 0,
+      species: [],
+      date: "2026-03-30",
+    });
+    vi.mocked(getAqiData).mockResolvedValue({
+      aqi: 42,
+      pm25: 12,
+      pm10: 18,
+      dominant_pollutant: "pm25",
+      station: "Downtown",
+    });
+
+    const response = await GET();
+    const text = await response.text();
+
+    expect(text).not.toContain("income_tier");
+  });
+});

--- a/__tests__/components/leaderboard/environmental-forecast.test.tsx
+++ b/__tests__/components/leaderboard/environmental-forecast.test.tsx
@@ -1,12 +1,82 @@
 /**
  * Environmental Forecast Tests
  *
- * Validates the display when severity = 0 (no symptoms).
+ * Validates the Environmental Forecast display:
+ * - Loading state
+ * - No data state
+ * - Full data rendering (pollen, AQI, weather)
+ * - Good news messaging
+ * - FDA disclaimer present
+ * - Graceful handling of partial data
  */
 
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { EnvironmentalForecast } from "@/components/leaderboard/environmental-forecast";
+import type { ForecastData } from "@/components/leaderboard/environmental-forecast";
+
+/* ------------------------------------------------------------------ */
+/* Test data                                                           */
+/* ------------------------------------------------------------------ */
+
+const fullForecastData: ForecastData = {
+  pollen: {
+    upi_tree: 3,
+    upi_grass: 1,
+    upi_weed: 0,
+    species: [
+      { display_name: "Oak", index: { value: 3, category: "Moderate" } },
+      { display_name: "Birch", index: { value: 2, category: "Low" } },
+    ],
+    date: "2026-03-30",
+  },
+  weather: {
+    temp_f: 72,
+    humidity_pct: 55,
+    wind_mph: 8.5,
+    wind_direction_deg: 180,
+    rain_last_12h: false,
+    thunderstorm_6h: false,
+  },
+  aqi: {
+    aqi: 42,
+    pm25: 12,
+    pm10: 18,
+    dominant_pollutant: "pm25",
+    station: "Downtown Monitor",
+  },
+  region: "Southeast",
+};
+
+const emptyForecastData: ForecastData = {
+  pollen: {
+    upi_tree: null,
+    upi_grass: null,
+    upi_weed: null,
+    species: [],
+    date: null,
+  },
+  weather: {
+    temp_f: null,
+    humidity_pct: null,
+    wind_mph: null,
+    wind_direction_deg: null,
+    rain_last_12h: false,
+    thunderstorm_6h: false,
+  },
+  aqi: {
+    aqi: null,
+    pm25: null,
+    pm10: null,
+    dominant_pollutant: null,
+    station: null,
+  },
+  region: null,
+};
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
 
 describe("EnvironmentalForecast", () => {
   it("renders the component", () => {
@@ -14,15 +84,154 @@ describe("EnvironmentalForecast", () => {
     expect(screen.getByTestId("environmental-forecast")).toBeDefined();
   });
 
-  it("displays the mode title", () => {
-    render(<EnvironmentalForecast />);
-    expect(screen.getByText("Environmental Forecast Mode")).toBeDefined();
+  it("displays good news messaging when no symptoms", () => {
+    render(<EnvironmentalForecast data={fullForecastData} />);
+    expect(screen.getByText("No Symptoms Today")).toBeDefined();
   });
 
-  it("shows a message about no symptoms", () => {
-    render(<EnvironmentalForecast />);
-    expect(
-      screen.getByText(/No symptoms reported/)
-    ).toBeDefined();
+  it("shows FDA disclaimer", () => {
+    render(<EnvironmentalForecast data={fullForecastData} />);
+    expect(screen.getByTestId("fda-disclaimer")).toBeDefined();
+  });
+
+  describe("loading state", () => {
+    it("shows loading skeleton when loading", () => {
+      render(<EnvironmentalForecast loading={true} />);
+      expect(screen.getByTestId("forecast-loading")).toBeDefined();
+    });
+  });
+
+  describe("no data state", () => {
+    it("shows no-data message when data is null", () => {
+      render(<EnvironmentalForecast data={null} />);
+      expect(screen.getByTestId("forecast-no-data")).toBeDefined();
+    });
+
+    it("shows no-data message when all values are null", () => {
+      render(<EnvironmentalForecast data={emptyForecastData} />);
+      expect(screen.getByTestId("forecast-no-data")).toBeDefined();
+    });
+  });
+
+  describe("full data rendering", () => {
+    it("renders pollen levels", () => {
+      render(<EnvironmentalForecast data={fullForecastData} />);
+      expect(screen.getByText("Pollen Levels")).toBeDefined();
+      expect(screen.getByText("Tree Pollen")).toBeDefined();
+      expect(screen.getByText("Grass Pollen")).toBeDefined();
+      expect(screen.getByText("Weed Pollen")).toBeDefined();
+    });
+
+    it("renders pollen level labels correctly", () => {
+      render(<EnvironmentalForecast data={fullForecastData} />);
+      // UPI 3 = "Moderate" (appears for tree pollen + Oak species), UPI 1 = "Very Low", UPI 0 = "None"
+      expect(screen.getAllByText("Moderate").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Very Low")).toBeDefined();
+      expect(screen.getByText("None")).toBeDefined();
+    });
+
+    it("renders active pollen species", () => {
+      render(<EnvironmentalForecast data={fullForecastData} />);
+      expect(screen.getByText("Active Species")).toBeDefined();
+      expect(screen.getByText("Oak")).toBeDefined();
+      expect(screen.getByText("Birch")).toBeDefined();
+    });
+
+    it("renders AQI data", () => {
+      render(<EnvironmentalForecast data={fullForecastData} />);
+      expect(screen.getByText("Air Quality")).toBeDefined();
+      expect(screen.getByText("42")).toBeDefined();
+      expect(screen.getByText("Good")).toBeDefined();
+    });
+
+    it("renders PM2.5 and PM10 values", () => {
+      render(<EnvironmentalForecast data={fullForecastData} />);
+      expect(screen.getByText("PM2.5")).toBeDefined();
+      expect(screen.getByText("12 ug/m3")).toBeDefined();
+      expect(screen.getByText("PM10")).toBeDefined();
+      expect(screen.getByText("18 ug/m3")).toBeDefined();
+    });
+
+    it("renders weather data", () => {
+      render(<EnvironmentalForecast data={fullForecastData} />);
+      expect(screen.getByText("Weather Conditions")).toBeDefined();
+      expect(screen.getByText("72\u00B0F")).toBeDefined();
+      expect(screen.getByText("55%")).toBeDefined();
+      expect(screen.getByText("8.5 mph S")).toBeDefined();
+    });
+
+    it("renders region label", () => {
+      render(<EnvironmentalForecast data={fullForecastData} />);
+      expect(screen.getByTestId("forecast-region")).toBeDefined();
+      expect(screen.getByText(/Southeast/)).toBeDefined();
+    });
+
+    it("does not show allergen rankings", () => {
+      render(<EnvironmentalForecast data={fullForecastData} />);
+      expect(screen.queryByTestId("trigger-champion-card")).toBeNull();
+      expect(screen.queryByTestId("final-four-card")).toBeNull();
+      expect(screen.queryByTestId("ranked-allergen-row")).toBeNull();
+    });
+  });
+
+  describe("partial data", () => {
+    it("handles missing AQI gracefully", () => {
+      const partialData: ForecastData = {
+        ...fullForecastData,
+        aqi: {
+          aqi: null,
+          pm25: null,
+          pm10: null,
+          dominant_pollutant: null,
+          station: null,
+        },
+      };
+      render(<EnvironmentalForecast data={partialData} />);
+      expect(
+        screen.getByText("AQI data unavailable for your location.")
+      ).toBeDefined();
+    });
+
+    it("handles missing weather gracefully", () => {
+      const partialData: ForecastData = {
+        ...fullForecastData,
+        weather: {
+          temp_f: null,
+          humidity_pct: null,
+          wind_mph: null,
+          wind_direction_deg: null,
+          rain_last_12h: false,
+          thunderstorm_6h: false,
+        },
+      };
+      render(<EnvironmentalForecast data={partialData} />);
+      expect(
+        screen.getByText("Weather data unavailable for your location.")
+      ).toBeDefined();
+    });
+
+    it("shows rain detected when raining", () => {
+      const rainyData: ForecastData = {
+        ...fullForecastData,
+        weather: {
+          ...fullForecastData.weather,
+          rain_last_12h: true,
+        },
+      };
+      render(<EnvironmentalForecast data={rainyData} />);
+      expect(screen.getByText("Rain detected")).toBeDefined();
+    });
+
+    it("shows thunderstorm activity", () => {
+      const stormyData: ForecastData = {
+        ...fullForecastData,
+        weather: {
+          ...fullForecastData.weather,
+          thunderstorm_6h: true,
+        },
+      };
+      render(<EnvironmentalForecast data={stormyData} />);
+      expect(screen.getByText("Thunderstorm nearby")).toBeDefined();
+    });
   });
 });

--- a/__tests__/components/leaderboard/leaderboard.test.tsx
+++ b/__tests__/components/leaderboard/leaderboard.test.tsx
@@ -165,7 +165,7 @@ describe("Leaderboard", () => {
       );
       expect(screen.getByTestId("environmental-forecast")).toBeDefined();
       expect(
-        screen.getByText("Environmental Forecast Mode")
+        screen.getByText("Environmental Forecast")
       ).toBeDefined();
     });
 

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -69,7 +69,42 @@ export default async function DashboardPage() {
     .order("elo_score", { ascending: false });
 
   const eloRows = (rawEloRows ?? []) as unknown as EloRowWithAllergen[];
-  const isEnvironmentalForecast = eloRows.length === 0;
+
+  // Determine if we should show Environmental Forecast mode.
+  // Forecast mode activates when the user's most recent check-in has severity = 0,
+  // OR when they have no Elo data yet (first-time user).
+  let isEnvironmentalForecast = eloRows.length === 0;
+
+  type CheckinSeverityQuery = {
+    select: (cols: string) => {
+      eq: (col: string, val: string) => {
+        is: (col: string, val: null) => {
+          order: (col: string, opts: { ascending: boolean }) => {
+            limit: (n: number) => {
+              single: () => Promise<{
+                data: { severity: number } | null;
+                error: { message: string } | null;
+              }>;
+            };
+          };
+        };
+      };
+    };
+  };
+
+  const { data: latestCheckin } = await (
+    supabase.from("symptom_checkins") as unknown as CheckinSeverityQuery
+  )
+    .select("severity")
+    .eq("user_id", user.id)
+    .is("child_id", null)
+    .order("checked_in_at", { ascending: false })
+    .limit(1)
+    .single();
+
+  if (latestCheckin?.severity === 0) {
+    isEnvironmentalForecast = true;
+  }
 
   return (
     <div

--- a/app/api/checkin/route.ts
+++ b/app/api/checkin/route.ts
@@ -41,6 +41,7 @@ interface CheckinRequestBody {
 interface CheckinSuccessResponse {
   success: true;
   checkin_id: string;
+  symptom_gate_passed: boolean;
   trigger_champion: string | null;
   final_four: string[];
 }
@@ -492,6 +493,7 @@ export async function POST(
     return NextResponse.json({
       success: true as const,
       checkin_id: checkinId,
+      symptom_gate_passed: runResult.symptom_gate_passed,
       trigger_champion: triggerChampionId,
       final_four: finalFourIds,
     });

--- a/app/api/forecast/route.ts
+++ b/app/api/forecast/route.ts
@@ -1,0 +1,131 @@
+/**
+ * GET /api/forecast
+ *
+ * Environmental Forecast endpoint. Returns current pollen, AQI, and weather
+ * data for the authenticated user's home location. Used when the dashboard
+ * displays Environmental Forecast mode (severity = 0).
+ *
+ * Server-side only — API keys never exposed to client.
+ * Graceful degradation: if any environmental API fails, that section
+ * returns null values rather than failing the entire request.
+ *
+ * IMPORTANT: income_tier is NEVER included in any API response.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getWeatherData, WEATHER_DEFAULTS } from "@/lib/apis/weather";
+import { getPollenData, POLLEN_DEFAULTS } from "@/lib/apis/pollen";
+import { getAqiData, AQI_DEFAULTS } from "@/lib/apis/aqi";
+import type { WeatherResult } from "@/lib/apis/weather";
+import type { PollenResult } from "@/lib/apis/pollen";
+import type { AqiResult } from "@/lib/apis/aqi";
+
+/* ------------------------------------------------------------------ */
+/* Response types                                                      */
+/* ------------------------------------------------------------------ */
+
+export interface ForecastSuccessResponse {
+  success: true;
+  pollen: PollenResult;
+  weather: WeatherResult;
+  aqi: AqiResult;
+  region: string | null;
+}
+
+interface ForecastErrorResponse {
+  success: false;
+  error: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* Route handler                                                       */
+/* ------------------------------------------------------------------ */
+
+export async function GET(): Promise<
+  NextResponse<ForecastSuccessResponse | ForecastErrorResponse>
+> {
+  try {
+    // Authenticate
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false as const, error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    // Fetch user profile for location data
+    type ProfileQuery = {
+      select: (cols: string) => {
+        eq: (col: string, val: string) => {
+          single: () => Promise<{
+            data: {
+              home_lat: number | null;
+              home_lng: number | null;
+              home_region: string | null;
+            } | null;
+            error: { message: string } | null;
+          }>;
+        };
+      };
+    };
+
+    const { data: profile } = await (
+      supabase.from("user_profiles") as unknown as ProfileQuery
+    )
+      .select("home_lat, home_lng, home_region")
+      .eq("id", user.id)
+      .single();
+
+    const lat = profile?.home_lat ?? null;
+    const lng = profile?.home_lng ?? null;
+    const region = profile?.home_region ?? null;
+
+    // Fetch environmental data (graceful degradation)
+    let weather: WeatherResult = WEATHER_DEFAULTS;
+    let pollen: PollenResult = POLLEN_DEFAULTS;
+    let aqi: AqiResult = AQI_DEFAULTS;
+
+    if (lat !== null && lng !== null) {
+      const [weatherResult, pollenResult, aqiResult] =
+        await Promise.allSettled([
+          getWeatherData(lat, lng),
+          getPollenData(lat, lng),
+          getAqiData(lat, lng),
+        ]);
+
+      weather =
+        weatherResult.status === "fulfilled"
+          ? weatherResult.value
+          : WEATHER_DEFAULTS;
+      pollen =
+        pollenResult.status === "fulfilled"
+          ? pollenResult.value
+          : POLLEN_DEFAULTS;
+      aqi =
+        aqiResult.status === "fulfilled" ? aqiResult.value : AQI_DEFAULTS;
+    }
+
+    return NextResponse.json({
+      success: true as const,
+      pollen,
+      weather,
+      aqi,
+      region,
+    });
+  } catch (error) {
+    console.error("Forecast error:", error);
+    return NextResponse.json(
+      {
+        success: false as const,
+        error: "An unexpected error occurred fetching forecast data",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/checkin/types.ts
+++ b/components/checkin/types.ts
@@ -194,6 +194,7 @@ export interface CheckinRequest {
 export interface CheckinResponse {
   success: true;
   checkin_id: string;
+  symptom_gate_passed: boolean;
   trigger_champion: string | null;
   final_four: string[];
 }

--- a/components/leaderboard/environmental-forecast.tsx
+++ b/components/leaderboard/environmental-forecast.tsx
@@ -2,56 +2,476 @@
  * Environmental Forecast Mode
  *
  * Displayed when the user's global severity is 0 (no symptoms).
- * Instead of showing ranked allergens, this mode shows a positive
- * message indicating the user is symptom-free.
+ * Instead of showing ranked allergens, this mode shows current
+ * environmental conditions: pollen levels, AQI, and weather.
+ *
+ * All data is informational only — no causal claims.
+ * FDA disclaimer is required on this surface.
  */
 
-export function EnvironmentalForecast() {
+import { FdaDisclaimer } from "@/components/shared/fda-disclaimer";
+import type { PollenResult } from "@/lib/apis/pollen";
+import type { WeatherResult } from "@/lib/apis/weather";
+import type { AqiResult } from "@/lib/apis/aqi";
+
+/* ------------------------------------------------------------------ */
+/* Types                                                               */
+/* ------------------------------------------------------------------ */
+
+export interface ForecastData {
+  pollen: PollenResult;
+  weather: WeatherResult;
+  aqi: AqiResult;
+  region: string | null;
+}
+
+export interface EnvironmentalForecastProps {
+  /** Environmental data from /api/forecast. Null when loading or unavailable. */
+  data?: ForecastData | null;
+  /** Whether data is currently loading */
+  loading?: boolean;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/** Map UPI (0-5) to a human-readable label */
+function upiLabel(value: number | null): string {
+  if (value === null) return "Unavailable";
+  if (value === 0) return "None";
+  if (value === 1) return "Very Low";
+  if (value === 2) return "Low";
+  if (value === 3) return "Moderate";
+  if (value === 4) return "High";
+  return "Very High";
+}
+
+/** Map UPI (0-5) to a color */
+function upiColor(value: number | null): string {
+  if (value === null) return "#6b7280";
+  if (value <= 1) return "#16a34a";
+  if (value <= 2) return "#65a30d";
+  if (value <= 3) return "#ca8a04";
+  if (value <= 4) return "#ea580c";
+  return "#dc2626";
+}
+
+/** Map AQI to a human-readable label */
+function aqiLabel(value: number | null): string {
+  if (value === null) return "Unavailable";
+  if (value <= 50) return "Good";
+  if (value <= 100) return "Moderate";
+  if (value <= 150) return "Unhealthy for Sensitive Groups";
+  if (value <= 200) return "Unhealthy";
+  if (value <= 300) return "Very Unhealthy";
+  return "Hazardous";
+}
+
+/** Map AQI to a color */
+function aqiColor(value: number | null): string {
+  if (value === null) return "#6b7280";
+  if (value <= 50) return "#16a34a";
+  if (value <= 100) return "#ca8a04";
+  if (value <= 150) return "#ea580c";
+  if (value <= 200) return "#dc2626";
+  return "#7c2d12";
+}
+
+/** Wind direction degrees to compass label */
+function windDirection(deg: number | null): string {
+  if (deg === null) return "";
+  const directions = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+  const index = Math.round(deg / 45) % 8;
+  return directions[index];
+}
+
+/* ------------------------------------------------------------------ */
+/* Sub-components                                                      */
+/* ------------------------------------------------------------------ */
+
+function DataCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
     <div
-      data-testid="environmental-forecast"
-      className="rounded-xl border border-green-200 bg-green-50 p-6 text-center"
+      className="rounded-lg border border-gray-200 bg-white p-4"
       style={{
-        borderRadius: "0.75rem",
-        border: "1px solid #bbf7d0",
-        backgroundColor: "#f0fdf4",
+        borderRadius: "0.5rem",
+        border: "1px solid #e5e7eb",
+        backgroundColor: "#ffffff",
+        padding: "1rem",
+      }}
+    >
+      <h3
+        className="mb-3 text-sm font-semibold text-gray-700"
+        style={{
+          fontSize: "0.875rem",
+          fontWeight: 600,
+          color: "#374151",
+          marginBottom: "0.75rem",
+          margin: "0 0 0.75rem 0",
+        }}
+      >
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function DataRow({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between py-1"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "0.25rem 0",
+      }}
+    >
+      <span
+        className="text-sm text-gray-600"
+        style={{ fontSize: "0.875rem", color: "#4b5563" }}
+      >
+        {label}
+      </span>
+      <span
+        className="text-sm font-medium"
+        style={{
+          fontSize: "0.875rem",
+          fontWeight: 500,
+          color: color ?? "#111827",
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div
+      data-testid="forecast-loading"
+      className="space-y-4"
+      style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+    >
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="h-24 animate-pulse rounded-lg bg-gray-100"
+          style={{
+            height: "6rem",
+            borderRadius: "0.5rem",
+            backgroundColor: "#f3f4f6",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function NoDataMessage() {
+  return (
+    <div
+      data-testid="forecast-no-data"
+      className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center"
+      style={{
+        borderRadius: "0.5rem",
+        border: "1px solid #e5e7eb",
+        backgroundColor: "#f9fafb",
         padding: "1.5rem",
         textAlign: "center",
       }}
     >
-      <span
-        className="mb-3 block text-4xl"
-        style={{
-          display: "block",
-          fontSize: "2.25rem",
-          marginBottom: "0.75rem",
-        }}
-        aria-hidden="true"
-      >
-        &#x2600;
-      </span>
-      <h2
-        className="mb-2 text-lg font-bold text-green-800"
-        style={{
-          fontSize: "1.125rem",
-          fontWeight: 700,
-          color: "#166534",
-          marginBottom: "0.5rem",
-        }}
-      >
-        Environmental Forecast Mode
-      </h2>
       <p
-        className="text-sm text-green-700"
+        className="text-sm text-gray-600"
+        style={{ fontSize: "0.875rem", color: "#4b5563", margin: 0 }}
+      >
+        Environmental data is not available. Please ensure your home location is
+        set in your profile to receive local forecasts.
+      </p>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Main component                                                      */
+/* ------------------------------------------------------------------ */
+
+export function EnvironmentalForecast({
+  data,
+  loading = false,
+}: EnvironmentalForecastProps) {
+  const hasAnyData =
+    data &&
+    (data.pollen.upi_tree !== null ||
+      data.pollen.upi_grass !== null ||
+      data.pollen.upi_weed !== null ||
+      data.aqi.aqi !== null ||
+      data.weather.temp_f !== null);
+
+  return (
+    <div
+      data-testid="environmental-forecast"
+      className="space-y-4"
+      style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+    >
+      {/* Good news banner */}
+      <div
+        className="rounded-xl border border-green-200 bg-green-50 p-5"
         style={{
-          fontSize: "0.875rem",
-          color: "#15803d",
-          margin: 0,
+          borderRadius: "0.75rem",
+          border: "1px solid #bbf7d0",
+          backgroundColor: "#f0fdf4",
+          padding: "1.25rem",
         }}
       >
-        No symptoms reported. Your allergen rankings will appear here once you
-        log symptom data through daily check-ins.
-      </p>
+        <div
+          className="flex items-center gap-3"
+          style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}
+        >
+          <span
+            className="text-2xl"
+            style={{ fontSize: "1.5rem" }}
+            aria-hidden="true"
+          >
+            &#x2600;
+          </span>
+          <div>
+            <h2
+              className="text-base font-bold text-green-800"
+              style={{
+                fontSize: "1rem",
+                fontWeight: 700,
+                color: "#166534",
+                margin: 0,
+              }}
+            >
+              No Symptoms Today
+            </h2>
+            <p
+              className="mt-1 text-sm text-green-700"
+              style={{
+                fontSize: "0.875rem",
+                color: "#15803d",
+                margin: "0.25rem 0 0 0",
+              }}
+            >
+              Great news! Here is what is currently in the air around you.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* FDA Disclaimer */}
+      <FdaDisclaimer variant="compact" />
+
+      {/* Loading state */}
+      {loading && <LoadingSkeleton />}
+
+      {/* No data state */}
+      {!loading && !hasAnyData && <NoDataMessage />}
+
+      {/* Environmental data cards */}
+      {!loading && hasAnyData && data && (
+        <>
+          {/* Pollen Card */}
+          <DataCard title="Pollen Levels">
+            <DataRow
+              label="Tree Pollen"
+              value={upiLabel(data.pollen.upi_tree)}
+              color={upiColor(data.pollen.upi_tree)}
+            />
+            <DataRow
+              label="Grass Pollen"
+              value={upiLabel(data.pollen.upi_grass)}
+              color={upiColor(data.pollen.upi_grass)}
+            />
+            <DataRow
+              label="Weed Pollen"
+              value={upiLabel(data.pollen.upi_weed)}
+              color={upiColor(data.pollen.upi_weed)}
+            />
+            {data.pollen.species.length > 0 && (
+              <div
+                className="mt-2 border-t border-gray-100 pt-2"
+                style={{
+                  marginTop: "0.5rem",
+                  borderTop: "1px solid #f3f4f6",
+                  paddingTop: "0.5rem",
+                }}
+              >
+                <p
+                  className="mb-1 text-xs font-medium text-gray-500"
+                  style={{
+                    fontSize: "0.75rem",
+                    fontWeight: 500,
+                    color: "#6b7280",
+                    margin: "0 0 0.25rem 0",
+                  }}
+                >
+                  Active Species
+                </p>
+                {data.pollen.species
+                  .filter((s) => s.index.value > 0)
+                  .slice(0, 5)
+                  .map((species) => (
+                    <DataRow
+                      key={species.display_name}
+                      label={species.display_name}
+                      value={species.index.category}
+                      color={upiColor(species.index.value)}
+                    />
+                  ))}
+              </div>
+            )}
+          </DataCard>
+
+          {/* AQI Card */}
+          <DataCard title="Air Quality">
+            {data.aqi.aqi !== null ? (
+              <>
+                <div
+                  className="mb-2 flex items-baseline gap-2"
+                  style={{
+                    display: "flex",
+                    alignItems: "baseline",
+                    gap: "0.5rem",
+                    marginBottom: "0.5rem",
+                  }}
+                >
+                  <span
+                    className="text-2xl font-bold"
+                    style={{
+                      fontSize: "1.5rem",
+                      fontWeight: 700,
+                      color: aqiColor(data.aqi.aqi),
+                    }}
+                  >
+                    {data.aqi.aqi}
+                  </span>
+                  <span
+                    className="text-sm font-medium"
+                    style={{
+                      fontSize: "0.875rem",
+                      fontWeight: 500,
+                      color: aqiColor(data.aqi.aqi),
+                    }}
+                  >
+                    {aqiLabel(data.aqi.aqi)}
+                  </span>
+                </div>
+                {data.aqi.pm25 !== null && (
+                  <DataRow
+                    label="PM2.5"
+                    value={`${data.aqi.pm25} ug/m3`}
+                  />
+                )}
+                {data.aqi.pm10 !== null && (
+                  <DataRow
+                    label="PM10"
+                    value={`${data.aqi.pm10} ug/m3`}
+                  />
+                )}
+                {data.aqi.dominant_pollutant && (
+                  <DataRow
+                    label="Dominant Pollutant"
+                    value={data.aqi.dominant_pollutant.toUpperCase()}
+                  />
+                )}
+                {data.aqi.station && (
+                  <p
+                    className="mt-2 text-xs text-gray-400"
+                    style={{
+                      fontSize: "0.75rem",
+                      color: "#9ca3af",
+                      marginTop: "0.5rem",
+                      margin: "0.5rem 0 0 0",
+                    }}
+                  >
+                    Station: {data.aqi.station}
+                  </p>
+                )}
+              </>
+            ) : (
+              <p
+                className="text-sm text-gray-500"
+                style={{ fontSize: "0.875rem", color: "#6b7280", margin: 0 }}
+              >
+                AQI data unavailable for your location.
+              </p>
+            )}
+          </DataCard>
+
+          {/* Weather Card */}
+          <DataCard title="Weather Conditions">
+            {data.weather.temp_f !== null ? (
+              <>
+                <DataRow
+                  label="Temperature"
+                  value={`${data.weather.temp_f}\u00B0F`}
+                />
+                {data.weather.humidity_pct !== null && (
+                  <DataRow
+                    label="Humidity"
+                    value={`${data.weather.humidity_pct}%`}
+                  />
+                )}
+                {data.weather.wind_mph !== null && (
+                  <DataRow
+                    label="Wind"
+                    value={`${data.weather.wind_mph} mph ${windDirection(data.weather.wind_direction_deg)}`}
+                  />
+                )}
+                {data.weather.rain_last_12h && (
+                  <DataRow label="Precipitation" value="Rain detected" />
+                )}
+                {data.weather.thunderstorm_6h && (
+                  <DataRow label="Storm Activity" value="Thunderstorm nearby" />
+                )}
+              </>
+            ) : (
+              <p
+                className="text-sm text-gray-500"
+                style={{ fontSize: "0.875rem", color: "#6b7280", margin: 0 }}
+              >
+                Weather data unavailable for your location.
+              </p>
+            )}
+          </DataCard>
+
+          {/* Region info */}
+          {data.region && (
+            <p
+              className="text-center text-xs text-gray-400"
+              style={{
+                fontSize: "0.75rem",
+                color: "#9ca3af",
+                textAlign: "center",
+                margin: 0,
+              }}
+              data-testid="forecast-region"
+            >
+              Region: {data.region}
+            </p>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/components/leaderboard/index.ts
+++ b/components/leaderboard/index.ts
@@ -13,6 +13,7 @@ export { BlurOverlay } from "./blur-overlay";
 export { ConfidenceBadge } from "./confidence-badge";
 export { CategoryIcon } from "./category-icon";
 export { EnvironmentalForecast } from "./environmental-forecast";
+export type { ForecastData, EnvironmentalForecastProps } from "./environmental-forecast";
 
 export type {
   RankedAllergen,

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -14,12 +14,13 @@
  * - First-time FDA acknowledgment gate
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FdaDisclaimer } from "@/components/shared/fda-disclaimer";
 import { DisclaimerModal } from "@/components/shared/disclaimer-modal";
 import { TriggerChampionCard } from "./trigger-champion-card";
 import { FinalFour } from "./final-four";
 import { EnvironmentalForecast } from "./environmental-forecast";
+import type { ForecastData } from "./environmental-forecast";
 import { ConfidenceBadge } from "./confidence-badge";
 import { CategoryIcon } from "./category-icon";
 import type { RankedAllergen } from "./types";
@@ -45,6 +46,39 @@ export function Leaderboard({
   userId,
 }: LeaderboardClientProps) {
   const [acknowledged, setAcknowledged] = useState(fdaAcknowledged);
+  const [forecastData, setForecastData] = useState<ForecastData | null>(null);
+  const [forecastLoading, setForecastLoading] = useState(false);
+
+  // Fetch environmental forecast data when in forecast mode
+  useEffect(() => {
+    if (!isEnvironmentalForecast || !acknowledged) return;
+
+    let cancelled = false;
+    setForecastLoading(true);
+
+    fetch(`${window.location.origin}/api/forecast`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled && data.success) {
+          setForecastData({
+            pollen: data.pollen,
+            weather: data.weather,
+            aqi: data.aqi,
+            region: data.region,
+          });
+        }
+      })
+      .catch(() => {
+        // Graceful degradation — forecast shows "no data" state
+      })
+      .finally(() => {
+        if (!cancelled) setForecastLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isEnvironmentalForecast, acknowledged]);
 
   // First-time gate: must acknowledge FDA disclaimer
   if (!acknowledged) {
@@ -77,10 +111,9 @@ export function Leaderboard({
             margin: 0,
           }}
         >
-          Your Allergen Leaderboard
+          Environmental Forecast
         </h1>
-        <FdaDisclaimer />
-        <EnvironmentalForecast />
+        <EnvironmentalForecast data={forecastData} loading={forecastLoading} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Adds `GET /api/forecast` route that fetches real-time pollen, AQI, and weather data from the user's home location
- Enhances `EnvironmentalForecast` component to display pollen levels (tree/grass/weed + active species), AQI with PM2.5/PM10, and weather conditions
- Updates dashboard to detect `severity=0` from the latest check-in and switch to Environmental Forecast mode
- Adds `symptom_gate_passed` to the check-in API response for client-side awareness
- Includes FDA disclaimer in forecast mode per regulatory requirements
- Graceful degradation when environmental APIs are unavailable

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] All 503 tests pass (48 test files)
- [ ] Verify severity=0 check-in triggers Environmental Forecast on dashboard
- [ ] Verify severity>0 on next check-in returns to leaderboard
- [ ] Verify FDA disclaimer is visible in forecast mode
- [ ] Verify no allergen rankings shown in forecast mode
- [ ] Verify graceful degradation when APIs return null data

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)