### PR TITLE
feat(subscription): add freemium gate and subscription scaffolding

### DIFF
--- a/__tests__/components/subscription/blur-overlay.test.tsx
+++ b/__tests__/components/subscription/blur-overlay.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * BlurOverlay Component Tests
+ *
+ * Tests the freemium blur overlay with optional UpgradeCta integration.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BlurOverlay } from "@/components/leaderboard/blur-overlay";
+
+describe("BlurOverlay", () => {
+  it("renders blurred content with lock icon", () => {
+    render(
+      <BlurOverlay>
+        <div data-testid="inner-content">Secret content</div>
+      </BlurOverlay>,
+    );
+
+    expect(screen.getByTestId("blur-overlay")).toBeTruthy();
+    expect(screen.getByTestId("blur-lock-overlay")).toBeTruthy();
+    // Content is rendered but blurred (aria-hidden)
+    expect(screen.getByTestId("inner-content")).toBeTruthy();
+  });
+
+  it("shows default upgrade text when showUpgradeCta is false", () => {
+    render(
+      <BlurOverlay>
+        <div>Content</div>
+      </BlurOverlay>,
+    );
+
+    expect(screen.getByText("Upgrade to Madness+ to reveal")).toBeTruthy();
+  });
+
+  it("shows UpgradeCta when showUpgradeCta is true", () => {
+    render(
+      <BlurOverlay showUpgradeCta featureLabel="Final Four" referralsNeeded={2}>
+        <div>Content</div>
+      </BlurOverlay>,
+    );
+
+    expect(screen.getByTestId("upgrade-cta")).toBeTruthy();
+    expect(screen.getByText("Unlock Final Four")).toBeTruthy();
+    // Default text should NOT be shown
+    expect(
+      screen.queryByText("Upgrade to Madness+ to reveal"),
+    ).toBeNull();
+  });
+
+  it("renders pulse animation on lock icon", () => {
+    render(
+      <BlurOverlay>
+        <div>Content</div>
+      </BlurOverlay>,
+    );
+
+    const lockOverlay = screen.getByTestId("blur-lock-overlay");
+    const lockIcon = lockOverlay.querySelector("span[aria-hidden='true']");
+    expect(lockIcon).toBeTruthy();
+    expect(lockIcon?.getAttribute("style")).toContain("pulse");
+  });
+});

--- a/__tests__/components/subscription/premium-badge.test.tsx
+++ b/__tests__/components/subscription/premium-badge.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * PremiumBadge Component Tests
+ *
+ * Tests the premium badge display for different subscription tiers.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PremiumBadge } from "@/components/subscription/premium-badge";
+
+describe("PremiumBadge", () => {
+  it("renders locked badge for free tier", () => {
+    render(<PremiumBadge tier="free" />);
+
+    expect(screen.getByTestId("premium-badge-locked")).toBeTruthy();
+    expect(screen.getByText("Premium")).toBeTruthy();
+  });
+
+  it("renders premium badge for madness_plus", () => {
+    render(<PremiumBadge tier="madness_plus" />);
+
+    expect(screen.getByTestId("premium-badge")).toBeTruthy();
+    expect(screen.getByText("Madness+")).toBeTruthy();
+  });
+
+  it("renders premium badge for madness_family", () => {
+    render(<PremiumBadge tier="madness_family" />);
+
+    expect(screen.getByTestId("premium-badge")).toBeTruthy();
+    expect(screen.getByText("Madness+")).toBeTruthy();
+  });
+
+  it("defaults to free tier when no tier provided", () => {
+    render(<PremiumBadge />);
+
+    expect(screen.getByTestId("premium-badge-locked")).toBeTruthy();
+  });
+
+  it("hides icon in compact mode", () => {
+    const { container } = render(
+      <PremiumBadge tier="madness_plus" compact />,
+    );
+
+    // In compact mode, no aria-hidden icon span
+    const icons = container.querySelectorAll("[aria-hidden='true']");
+    expect(icons.length).toBe(0);
+  });
+});

--- a/__tests__/components/subscription/upgrade-cta.test.tsx
+++ b/__tests__/components/subscription/upgrade-cta.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * UpgradeCta Component Tests
+ *
+ * Tests the upgrade call-to-action component for free-tier users.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { UpgradeCta } from "@/components/subscription/upgrade-cta";
+
+describe("UpgradeCta", () => {
+  it("renders with default props", () => {
+    render(<UpgradeCta />);
+
+    expect(screen.getByTestId("upgrade-cta")).toBeTruthy();
+    expect(screen.getByText("Unlock premium features")).toBeTruthy();
+    expect(screen.getByTestId("upgrade-cta-subscribe")).toBeTruthy();
+  });
+
+  it("renders custom feature label", () => {
+    render(<UpgradeCta feature="Final Four details" />);
+
+    expect(screen.getByText("Unlock Final Four details")).toBeTruthy();
+  });
+
+  it("shows referral count when referrals needed", () => {
+    render(<UpgradeCta referralsNeeded={2} />);
+
+    expect(screen.getByTestId("upgrade-cta-referral")).toBeTruthy();
+    expect(
+      screen.getByText(/invite 2 friends to unlock for free/i),
+    ).toBeTruthy();
+  });
+
+  it("uses singular 'friend' when 1 referral needed", () => {
+    render(<UpgradeCta referralsNeeded={1} />);
+
+    expect(
+      screen.getByText(/invite 1 friend to unlock for free/i),
+    ).toBeTruthy();
+  });
+
+  it("hides referral CTA when referrals not needed", () => {
+    render(<UpgradeCta referralsNeeded={0} />);
+
+    expect(screen.queryByTestId("upgrade-cta-referral")).toBeNull();
+  });
+});

--- a/__tests__/subscription/check.test.ts
+++ b/__tests__/subscription/check.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Subscription Check Tests
+ *
+ * Tests the subscription status checker and feature gating logic.
+ *
+ * Key scenarios:
+ * - PAYWALL_ENABLED=false: all features accessible (workshop mode)
+ * - PAYWALL_ENABLED=true + free tier: no premium features
+ * - PAYWALL_ENABLED=true + madness_plus: all premium features
+ * - PAYWALL_ENABLED=true + referral_unlocked: all premium features
+ * - Expired subscription: treated as free
+ * - hasFeatureAccess synchronous check
+ *
+ * IMPORTANT: income_tier must NEVER appear in any test output.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/* ------------------------------------------------------------------ */
+/* Mock Supabase client factory                                        */
+/* ------------------------------------------------------------------ */
+
+interface MockSubData {
+  tier?: string;
+  expires_at?: string | null;
+}
+
+interface MockProfileData {
+  features_unlocked?: boolean;
+}
+
+function createMockSupabase(
+  sub: MockSubData | null = null,
+  profile: MockProfileData | null = null,
+) {
+  const mockFrom = vi.fn((table: string) => {
+    const chain = {
+      select: () => ({
+        eq: (_col: string, _val: string) => ({
+          eq: () => ({
+            single: async () => ({
+              data: table === "user_profiles" ? profile : null,
+              error: null,
+            }),
+            maybeSingle: async () => ({
+              data: table === "user_subscriptions" ? sub : null,
+              error: null,
+            }),
+          }),
+          single: async () => ({
+            data: table === "user_profiles" ? profile : null,
+            error: null,
+          }),
+          maybeSingle: async () => ({
+            data: table === "user_subscriptions" ? sub : null,
+            error: null,
+          }),
+        }),
+      }),
+    };
+    return chain;
+  });
+
+  return { from: mockFrom } as never;
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests with PAYWALL_ENABLED = false (workshop mode)                  */
+/* ------------------------------------------------------------------ */
+
+describe("subscription check — paywall disabled (workshop mode)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_PAYWALL_ENABLED", "false");
+  });
+
+  it("getAccessStatus returns isPremium=true when paywall disabled", async () => {
+    const { getAccessStatus } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase();
+
+    const status = await getAccessStatus(supabase, "user-1");
+
+    expect(status.isPremium).toBe(true);
+    expect(status.tier).toBe("free");
+    expect(status.subscriptionActive).toBe(false);
+    expect(status.referralUnlocked).toBe(false);
+  });
+
+  it("isFeatureAvailable returns true for all features when paywall disabled", async () => {
+    const { isFeatureAvailable } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase();
+
+    expect(await isFeatureAvailable(supabase, "user-1", "final_four")).toBe(
+      true,
+    );
+    expect(await isFeatureAvailable(supabase, "user-1", "pdf_report")).toBe(
+      true,
+    );
+    expect(
+      await isFeatureAvailable(supabase, "user-1", "detailed_confidence"),
+    ).toBe(true);
+  });
+
+  it("hasFeatureAccess returns true for any status when paywall disabled", async () => {
+    const { hasFeatureAccess } = await import("@/lib/subscription/check");
+
+    const freeStatus = {
+      tier: "free" as const,
+      subscriptionActive: false,
+      referralUnlocked: false,
+      isPremium: false,
+    };
+
+    expect(hasFeatureAccess(freeStatus, "final_four")).toBe(true);
+    expect(hasFeatureAccess(freeStatus, "pdf_report")).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Tests with PAYWALL_ENABLED = true                                   */
+/* ------------------------------------------------------------------ */
+
+describe("subscription check — paywall enabled", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_PAYWALL_ENABLED", "true");
+  });
+
+  it("free tier user has no premium access", async () => {
+    const { getAccessStatus } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase(null, { features_unlocked: false });
+
+    const status = await getAccessStatus(supabase, "user-1");
+
+    expect(status.isPremium).toBe(false);
+    expect(status.tier).toBe("free");
+    expect(status.subscriptionActive).toBe(false);
+    expect(status.referralUnlocked).toBe(false);
+  });
+
+  it("madness_plus subscriber has premium access", async () => {
+    const { getAccessStatus } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase(
+      { tier: "madness_plus", expires_at: null },
+      { features_unlocked: false },
+    );
+
+    const status = await getAccessStatus(supabase, "user-1");
+
+    expect(status.isPremium).toBe(true);
+    expect(status.tier).toBe("madness_plus");
+    expect(status.subscriptionActive).toBe(true);
+  });
+
+  it("expired subscription treated as free", async () => {
+    const { getAccessStatus } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase(
+      { tier: "madness_plus", expires_at: "2020-01-01T00:00:00Z" },
+      { features_unlocked: false },
+    );
+
+    const status = await getAccessStatus(supabase, "user-1");
+
+    expect(status.isPremium).toBe(false);
+    expect(status.subscriptionActive).toBe(false);
+  });
+
+  it("referral_unlocked grants premium access regardless of tier", async () => {
+    const { getAccessStatus } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase(null, { features_unlocked: true });
+
+    const status = await getAccessStatus(supabase, "user-1");
+
+    expect(status.isPremium).toBe(true);
+    expect(status.referralUnlocked).toBe(true);
+    expect(status.tier).toBe("free");
+  });
+
+  it("isFeatureAvailable returns false for free tier", async () => {
+    const { isFeatureAvailable } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase(null, { features_unlocked: false });
+
+    expect(await isFeatureAvailable(supabase, "user-1", "final_four")).toBe(
+      false,
+    );
+    expect(await isFeatureAvailable(supabase, "user-1", "pdf_report")).toBe(
+      false,
+    );
+  });
+
+  it("isFeatureAvailable returns true for referral-unlocked users", async () => {
+    const { isFeatureAvailable } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase(null, { features_unlocked: true });
+
+    expect(await isFeatureAvailable(supabase, "user-1", "final_four")).toBe(
+      true,
+    );
+    expect(await isFeatureAvailable(supabase, "user-1", "pdf_report")).toBe(
+      true,
+    );
+  });
+
+  it("isFeatureAvailable returns true for active madness_plus subscriber", async () => {
+    const { isFeatureAvailable } = await import("@/lib/subscription/check");
+    const supabase = createMockSupabase(
+      { tier: "madness_plus", expires_at: null },
+      { features_unlocked: false },
+    );
+
+    expect(await isFeatureAvailable(supabase, "user-1", "final_four")).toBe(
+      true,
+    );
+    expect(
+      await isFeatureAvailable(supabase, "user-1", "detailed_confidence"),
+    ).toBe(true);
+  });
+
+  it("hasFeatureAccess respects isPremium flag", async () => {
+    const { hasFeatureAccess } = await import("@/lib/subscription/check");
+
+    const premiumStatus = {
+      tier: "madness_plus" as const,
+      subscriptionActive: true,
+      referralUnlocked: false,
+      isPremium: true,
+    };
+
+    expect(hasFeatureAccess(premiumStatus, "final_four")).toBe(true);
+
+    const freeStatus = {
+      tier: "free" as const,
+      subscriptionActive: false,
+      referralUnlocked: false,
+      isPremium: false,
+    };
+
+    expect(hasFeatureAccess(freeStatus, "final_four")).toBe(false);
+  });
+});

--- a/__tests__/subscription/constants.test.ts
+++ b/__tests__/subscription/constants.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Subscription Constants Tests
+ *
+ * Validates the subscription tier configuration and feature mapping.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("subscription constants", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("PAYWALL_ENABLED defaults to false when env not set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAYWALL_ENABLED", "");
+    const { PAYWALL_ENABLED } = await import("@/lib/subscription/constants");
+    expect(PAYWALL_ENABLED).toBe(false);
+  });
+
+  it("PAYWALL_ENABLED is true when env is 'true'", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAYWALL_ENABLED", "true");
+    const { PAYWALL_ENABLED } = await import("@/lib/subscription/constants");
+    expect(PAYWALL_ENABLED).toBe(true);
+  });
+
+  it("PAYWALL_ENABLED is false for non-'true' values", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PAYWALL_ENABLED", "1");
+    const { PAYWALL_ENABLED } = await import("@/lib/subscription/constants");
+    expect(PAYWALL_ENABLED).toBe(false);
+  });
+
+  it("free tier has no features", async () => {
+    const { TIER_FEATURES } = await import("@/lib/subscription/constants");
+    expect(TIER_FEATURES.free).toEqual([]);
+  });
+
+  it("madness_plus tier has all premium features", async () => {
+    const { TIER_FEATURES } = await import("@/lib/subscription/constants");
+    expect(TIER_FEATURES.madness_plus).toContain("final_four");
+    expect(TIER_FEATURES.madness_plus).toContain("pdf_report");
+    expect(TIER_FEATURES.madness_plus).toContain("detailed_confidence");
+  });
+
+  it("madness_family tier has all premium features", async () => {
+    const { TIER_FEATURES } = await import("@/lib/subscription/constants");
+    expect(TIER_FEATURES.madness_family).toContain("final_four");
+    expect(TIER_FEATURES.madness_family).toContain("pdf_report");
+    expect(TIER_FEATURES.madness_family).toContain("detailed_confidence");
+  });
+
+  it("PREMIUM_TIERS contains madness_plus and madness_family", async () => {
+    const { PREMIUM_TIERS } = await import("@/lib/subscription/constants");
+    expect(PREMIUM_TIERS).toContain("madness_plus");
+    expect(PREMIUM_TIERS).toContain("madness_family");
+    expect(PREMIUM_TIERS).not.toContain("free");
+  });
+});

--- a/app/api/subscription/route.ts
+++ b/app/api/subscription/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Subscription Status API
+ *
+ * GET /api/subscription
+ *
+ * Returns the authenticated user's subscription and access status.
+ * Used by client components to determine feature availability.
+ *
+ * IMPORTANT: income_tier is NEVER included in responses.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { getAccessStatus, PAYWALL_ENABLED } from "@/lib/subscription";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const status = await getAccessStatus(supabase, user.id);
+
+    return NextResponse.json({
+      success: true,
+      paywall_enabled: PAYWALL_ENABLED,
+      ...status,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/components/leaderboard/blur-overlay.tsx
+++ b/components/leaderboard/blur-overlay.tsx
@@ -3,11 +3,18 @@
  *
  * Freemium gate overlay that blurs content for free-tier users.
  * Shows a lock icon with pulse animation and upgrade prompt.
+ * Optionally shows the UpgradeCta component for subscription/referral prompts.
  */
 
 import type { BlurOverlayProps } from "./types";
+import { UpgradeCta } from "@/components/subscription/upgrade-cta";
 
-export function BlurOverlay({ children }: BlurOverlayProps) {
+export function BlurOverlay({
+  children,
+  referralsNeeded,
+  featureLabel,
+  showUpgradeCta = false,
+}: BlurOverlayProps) {
   return (
     <div
       data-testid="blur-overlay"
@@ -54,16 +61,26 @@ export function BlurOverlay({ children }: BlurOverlayProps) {
         >
           &#x1F512;
         </span>
-        <p
-          className="text-sm font-medium text-gray-600"
-          style={{
-            fontSize: "0.875rem",
-            fontWeight: 500,
-            color: "#4b5563",
-          }}
-        >
-          Upgrade to Madness+ to reveal
-        </p>
+        {!showUpgradeCta && (
+          <p
+            className="text-sm font-medium text-gray-600"
+            style={{
+              fontSize: "0.875rem",
+              fontWeight: 500,
+              color: "#4b5563",
+            }}
+          >
+            Upgrade to Madness+ to reveal
+          </p>
+        )}
+        {showUpgradeCta && (
+          <div style={{ marginTop: "0.5rem" }}>
+            <UpgradeCta
+              feature={featureLabel}
+              referralsNeeded={referralsNeeded}
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/components/leaderboard/types.ts
+++ b/components/leaderboard/types.ts
@@ -53,4 +53,10 @@ export interface AllergenRankRowProps {
 /** Props for the blur overlay */
 export interface BlurOverlayProps {
   children: React.ReactNode;
+  /** Number of referrals still needed to unlock (passed to UpgradeCta) */
+  referralsNeeded?: number;
+  /** Feature name for contextual CTA messaging */
+  featureLabel?: string;
+  /** Whether to show the upgrade CTA below the lock icon */
+  showUpgradeCta?: boolean;
 }

--- a/components/subscription/index.ts
+++ b/components/subscription/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Subscription Components
+ *
+ * Re-exports for subscription-related UI components.
+ */
+
+export { UpgradeCta } from "./upgrade-cta";
+export type { UpgradeCtaProps } from "./upgrade-cta";
+export { PremiumBadge } from "./premium-badge";
+export type { PremiumBadgeProps } from "./premium-badge";

--- a/components/subscription/premium-badge.tsx
+++ b/components/subscription/premium-badge.tsx
@@ -1,0 +1,74 @@
+/**
+ * Premium Badge
+ *
+ * Small badge indicating a feature requires premium access.
+ * Shown next to gated features in the UI.
+ *
+ * Dual styling: Tailwind utility classes + inline styles.
+ */
+
+import type { SubscriptionTier } from "@/lib/subscription/types";
+
+export interface PremiumBadgeProps {
+  /** The user's current tier (affects badge display) */
+  tier?: SubscriptionTier;
+  /** Compact variant for inline use */
+  compact?: boolean;
+}
+
+export function PremiumBadge({
+  tier = "free",
+  compact = false,
+}: PremiumBadgeProps) {
+  const isPremium = tier !== "free";
+
+  if (isPremium) {
+    return (
+      <span
+        data-testid="premium-badge"
+        className="inline-flex items-center gap-1 rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.25rem",
+          borderRadius: "9999px",
+          backgroundColor: "#f3e8ff",
+          paddingLeft: "0.5rem",
+          paddingRight: "0.5rem",
+          paddingTop: "0.125rem",
+          paddingBottom: "0.125rem",
+          fontSize: "0.75rem",
+          fontWeight: 500,
+          color: "#7c3aed",
+        }}
+      >
+        {!compact && <span aria-hidden="true">&#x2B50;</span>}
+        Madness+
+      </span>
+    );
+  }
+
+  return (
+    <span
+      data-testid="premium-badge-locked"
+      className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "0.25rem",
+        borderRadius: "9999px",
+        backgroundColor: "#f3f4f6",
+        paddingLeft: "0.5rem",
+        paddingRight: "0.5rem",
+        paddingTop: "0.125rem",
+        paddingBottom: "0.125rem",
+        fontSize: "0.75rem",
+        fontWeight: 500,
+        color: "#6b7280",
+      }}
+    >
+      {!compact && <span aria-hidden="true">&#x1F512;</span>}
+      Premium
+    </span>
+  );
+}

--- a/components/subscription/upgrade-cta.tsx
+++ b/components/subscription/upgrade-cta.tsx
@@ -1,0 +1,105 @@
+/**
+ * Upgrade CTA (Call to Action)
+ *
+ * Prompts free-tier users to upgrade to Madness+ or unlock via referrals.
+ * Shown alongside the blur overlay on gated content.
+ *
+ * Dual styling: Tailwind utility classes + inline styles.
+ */
+
+"use client";
+
+export interface UpgradeCtaProps {
+  /** The feature being gated (for contextual messaging) */
+  feature?: string;
+  /** Number of referrals still needed to unlock (0 if already unlocked) */
+  referralsNeeded?: number;
+}
+
+export function UpgradeCta({
+  feature = "premium features",
+  referralsNeeded = 3,
+}: UpgradeCtaProps) {
+  return (
+    <div
+      data-testid="upgrade-cta"
+      className="mx-auto max-w-md rounded-xl border border-purple-200 bg-gradient-to-br from-purple-50 to-white p-6 text-center shadow-md"
+      style={{
+        maxWidth: "28rem",
+        margin: "0 auto",
+        borderRadius: "0.75rem",
+        border: "1px solid #e9d5ff",
+        background: "linear-gradient(to bottom right, #faf5ff, #ffffff)",
+        padding: "1.5rem",
+        textAlign: "center",
+        boxShadow:
+          "0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1)",
+      }}
+    >
+      <h3
+        className="mb-2 text-lg font-bold text-purple-900"
+        style={{
+          fontSize: "1.125rem",
+          fontWeight: 700,
+          color: "#581c87",
+          marginBottom: "0.5rem",
+        }}
+      >
+        Unlock {feature}
+      </h3>
+      <p
+        className="mb-4 text-sm text-gray-600"
+        style={{
+          fontSize: "0.875rem",
+          color: "#4b5563",
+          marginBottom: "1rem",
+        }}
+      >
+        Get the full picture of your allergen triggers with Madness+.
+      </p>
+
+      {/* Primary CTA — Madness+ */}
+      <button
+        type="button"
+        data-testid="upgrade-cta-subscribe"
+        className="mb-3 w-full rounded-lg bg-purple-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-700"
+        style={{
+          width: "100%",
+          borderRadius: "0.5rem",
+          backgroundColor: "#9333ea",
+          paddingLeft: "1rem",
+          paddingRight: "1rem",
+          paddingTop: "0.625rem",
+          paddingBottom: "0.625rem",
+          fontSize: "0.875rem",
+          fontWeight: 600,
+          color: "#ffffff",
+          border: "none",
+          cursor: "pointer",
+          marginBottom: "0.75rem",
+          boxShadow: "0 1px 2px 0 rgba(0,0,0,.05)",
+        }}
+        onClick={() => {
+          // Placeholder — will connect to RevenueCat paywall
+        }}
+      >
+        Upgrade to Madness+
+      </button>
+
+      {/* Secondary CTA — Referral unlock */}
+      {referralsNeeded > 0 && (
+        <p
+          data-testid="upgrade-cta-referral"
+          className="text-xs text-gray-500"
+          style={{
+            fontSize: "0.75rem",
+            color: "#6b7280",
+          }}
+        >
+          Or invite {referralsNeeded} friend{referralsNeeded !== 1 ? "s" : ""}{" "}
+          to unlock for free
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/subscription/check.ts
+++ b/lib/subscription/check.ts
@@ -1,0 +1,188 @@
+/**
+ * Subscription Status Checker
+ *
+ * Server-side utility that determines a user's premium access status
+ * by combining subscription tier, expiry, and referral unlock state.
+ *
+ * Key behavior:
+ * - PAYWALL_ENABLED=false: all users treated as premium (workshop mode)
+ * - PAYWALL_ENABLED=true: checks subscription + referral status
+ * - Referral unlock is permanent and independent of subscription
+ *
+ * IMPORTANT: income_tier is NEVER included in any output.
+ */
+
+import { PAYWALL_ENABLED, PREMIUM_TIERS, TIER_FEATURES } from "./constants";
+import type { AccessStatus, PremiumFeature, SubscriptionTier } from "./types";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+
+type SupabaseDB = SupabaseClient<Database>;
+
+/* ------------------------------------------------------------------ */
+/* Type-safe query helpers (same pattern as referral/tracking.ts)      */
+/* ------------------------------------------------------------------ */
+
+interface SubscriptionRow {
+  tier: SubscriptionTier;
+  expires_at: string | null;
+}
+
+interface ProfileRow {
+  features_unlocked: boolean;
+}
+
+interface EqResult<T> {
+  eq: (col: string, val: string) => EqResult<T>;
+  single: () => Promise<{
+    data: T | null;
+    error: { message: string } | null;
+  }>;
+  maybeSingle: () => Promise<{
+    data: T | null;
+    error: { message: string } | null;
+  }>;
+}
+
+interface QueryChain<T> {
+  select: (columns: string) => EqResult<T>;
+}
+
+/**
+ * Get the full access status for a user.
+ *
+ * Queries user_subscriptions and user_profiles to determine whether
+ * the user has premium access via subscription or referral.
+ *
+ * @param supabase - Authenticated Supabase client
+ * @param userId - The authenticated user's ID
+ * @returns AccessStatus with tier, active state, and premium flag
+ */
+export async function getAccessStatus(
+  supabase: SupabaseDB,
+  userId: string,
+): Promise<AccessStatus> {
+  // If paywall is disabled, everyone is premium
+  if (!PAYWALL_ENABLED) {
+    return {
+      tier: "free",
+      subscriptionActive: false,
+      referralUnlocked: false,
+      isPremium: true,
+    };
+  }
+
+  // Fetch subscription and referral status in parallel
+  const subQuery = supabase.from(
+    "user_subscriptions",
+  ) as unknown as QueryChain<SubscriptionRow>;
+  const profileQuery = supabase.from(
+    "user_profiles",
+  ) as unknown as QueryChain<ProfileRow>;
+
+  const [subResult, profileResult] = await Promise.all([
+    subQuery.select("tier, expires_at").eq("user_id", userId).maybeSingle(),
+    profileQuery.select("features_unlocked").eq("id", userId).single(),
+  ]);
+
+  const subscription = subResult.data;
+  const profile = profileResult.data;
+
+  const tier: SubscriptionTier = subscription?.tier ?? "free";
+  const referralUnlocked = profile?.features_unlocked ?? false;
+
+  // Check if subscription is active (not expired)
+  const subscriptionActive =
+    PREMIUM_TIERS.includes(tier) && isSubscriptionActive(subscription);
+
+  // Premium = active subscription OR permanent referral unlock
+  const isPremium = subscriptionActive || referralUnlocked;
+
+  return {
+    tier,
+    subscriptionActive,
+    referralUnlocked,
+    isPremium,
+  };
+}
+
+/**
+ * Check if a specific premium feature is available to the user.
+ *
+ * This is the primary API for gating features. It encapsulates the
+ * PAYWALL_ENABLED check, subscription tier, and referral status.
+ *
+ * @param supabase - Authenticated Supabase client
+ * @param userId - The authenticated user's ID
+ * @param feature - The premium feature to check
+ * @returns true if the user can access the feature
+ */
+export async function isFeatureAvailable(
+  supabase: SupabaseDB,
+  userId: string,
+  feature: PremiumFeature,
+): Promise<boolean> {
+  // Paywall off = everything available
+  if (!PAYWALL_ENABLED) {
+    return true;
+  }
+
+  const status = await getAccessStatus(supabase, userId);
+
+  // Referral unlock grants all premium features
+  if (status.referralUnlocked) {
+    return true;
+  }
+
+  // Check tier-based feature access
+  if (status.subscriptionActive) {
+    return TIER_FEATURES[status.tier].includes(feature);
+  }
+
+  return false;
+}
+
+/**
+ * Synchronous check for whether a user has premium access.
+ *
+ * Use this when you already have the access status (e.g., from a
+ * server component that passed it as a prop). Does not query the DB.
+ *
+ * @param status - Pre-fetched AccessStatus
+ * @param feature - The premium feature to check
+ * @returns true if the user can access the feature
+ */
+export function hasFeatureAccess(
+  status: AccessStatus,
+  feature: PremiumFeature,
+): boolean {
+  // Paywall off = everything available
+  if (!PAYWALL_ENABLED) {
+    return true;
+  }
+
+  if (status.isPremium) {
+    return true;
+  }
+
+  if (status.subscriptionActive) {
+    return TIER_FEATURES[status.tier].includes(feature);
+  }
+
+  return false;
+}
+
+/* ------------------------------------------------------------------ */
+/* Internal helpers                                                     */
+/* ------------------------------------------------------------------ */
+
+function isSubscriptionActive(
+  subscription: SubscriptionRow | null,
+): boolean {
+  if (!subscription) return false;
+
+  // No expiry means lifetime / non-expiring subscription
+  if (!subscription.expires_at) return true;
+
+  return new Date(subscription.expires_at) > new Date();
+}

--- a/lib/subscription/constants.ts
+++ b/lib/subscription/constants.ts
@@ -1,0 +1,37 @@
+/**
+ * Subscription Constants
+ *
+ * Centralized configuration for the freemium gate system.
+ *
+ * PAYWALL_ENABLED controls whether the freemium gate is active.
+ * When false (default for workshop/development), all features are
+ * accessible regardless of subscription or referral status.
+ */
+
+import type { PremiumFeature, SubscriptionTier } from "./types";
+
+/**
+ * Whether the paywall is enabled.
+ * Reads from NEXT_PUBLIC_PAYWALL_ENABLED env var.
+ * Defaults to false (workshop mode — everything unlocked).
+ */
+export const PAYWALL_ENABLED =
+  process.env.NEXT_PUBLIC_PAYWALL_ENABLED === "true";
+
+/**
+ * Map of which features each tier can access.
+ * When PAYWALL_ENABLED is false, this map is bypassed entirely.
+ */
+export const TIER_FEATURES: Record<SubscriptionTier, PremiumFeature[]> = {
+  free: [],
+  madness_plus: ["final_four", "pdf_report", "detailed_confidence"],
+  madness_family: ["final_four", "pdf_report", "detailed_confidence"],
+};
+
+/**
+ * Tiers that grant full premium access (bypass feature checks).
+ */
+export const PREMIUM_TIERS: SubscriptionTier[] = [
+  "madness_plus",
+  "madness_family",
+];

--- a/lib/subscription/index.ts
+++ b/lib/subscription/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Subscription System
+ *
+ * Re-exports for the freemium gate and subscription scaffolding.
+ *
+ * Usage:
+ *   import { isFeatureAvailable, PAYWALL_ENABLED } from "@/lib/subscription";
+ */
+
+export { PAYWALL_ENABLED, TIER_FEATURES, PREMIUM_TIERS } from "./constants";
+export { getAccessStatus, isFeatureAvailable, hasFeatureAccess } from "./check";
+export type { AccessStatus, PremiumFeature, SubscriptionTier } from "./types";

--- a/lib/subscription/types.ts
+++ b/lib/subscription/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Subscription Types
+ *
+ * Type definitions for the freemium gate and subscription system.
+ * Re-uses SubscriptionTier from the database types for consistency.
+ */
+
+import type { SubscriptionTier } from "@/lib/supabase/types";
+
+export type { SubscriptionTier };
+
+/** Features that can be gated behind a subscription */
+export type PremiumFeature =
+  | "final_four"
+  | "pdf_report"
+  | "detailed_confidence";
+
+/** Result of checking a user's access level */
+export interface AccessStatus {
+  /** The user's subscription tier */
+  tier: SubscriptionTier;
+  /** Whether the subscription is currently active (not expired) */
+  subscriptionActive: boolean;
+  /** Whether features are unlocked via 3-friend referral (permanent) */
+  referralUnlocked: boolean;
+  /** Whether the user has premium access (subscription OR referral) */
+  isPremium: boolean;
+}


### PR DESCRIPTION
## Summary

- Add `PAYWALL_ENABLED` env flag (default: `false` for workshop mode) that controls freemium gating
- Implement subscription tier system (`free` / `madness_plus` / `madness_family`) with `isFeatureAvailable()` and `hasFeatureAccess()` utilities
- Integrate with existing referral `features_unlocked` — referral unlock OR active subscription grants premium access
- Add `UpgradeCta` and `PremiumBadge` components with dual styling (Tailwind + inline)
- Enhance `BlurOverlay` to optionally show upgrade CTA with referral count
- Add `GET /api/subscription` endpoint for client-side access status checks
- 30 new tests across 5 test files (all 619 tests passing)

## Files Created

- `lib/subscription/` — types, constants, check logic, barrel export
- `components/subscription/` — UpgradeCta, PremiumBadge, barrel export
- `app/api/subscription/route.ts` — subscription status API
- `__tests__/subscription/` — check and constants tests
- `__tests__/components/subscription/` — component tests

## Files Modified

- `components/leaderboard/blur-overlay.tsx` — added optional UpgradeCta integration
- `components/leaderboard/types.ts` — extended BlurOverlayProps

## Test Plan

- [x] `PAYWALL_ENABLED=false` (default) -> all features accessible (workshop mode)
- [x] `PAYWALL_ENABLED=true` + free tier -> premium features gated
- [x] `PAYWALL_ENABLED=true` + referral_unlocked -> all features visible
- [x] `PAYWALL_ENABLED=true` + active madness_plus subscription -> all features visible
- [x] Expired subscription treated as free tier
- [x] BlurOverlay renders with pulse animation on lock icons
- [x] UpgradeCta shows referral count and subscribe button
- [x] PremiumBadge displays correctly for each tier
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes (no new errors in source files)
- [x] `npm test` passes (619/619)

Closes #34