### PR TITLE
feat(apis): add AbortController timeout to external API fetch calls

### DIFF
--- a/__tests__/api/fetch-with-timeout.test.ts
+++ b/__tests__/api/fetch-with-timeout.test.ts
@@ -1,0 +1,101 @@
+/**
+ * fetchWithTimeout Utility Tests
+ *
+ * Validates that the shared fetch wrapper correctly applies
+ * AbortSignal.timeout and passes through options to fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchWithTimeout, API_TIMEOUT_MS } from "@/lib/apis/fetch-with-timeout";
+
+/* ------------------------------------------------------------------ */
+/* Mock fetch                                                          */
+/* ------------------------------------------------------------------ */
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+/* ------------------------------------------------------------------ */
+/* Mock AbortSignal.timeout                                            */
+/* ------------------------------------------------------------------ */
+
+const mockSignal = { aborted: false } as AbortSignal;
+const mockTimeout = vi.fn().mockReturnValue(mockSignal);
+vi.stubGlobal("AbortSignal", { timeout: mockTimeout });
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("fetchWithTimeout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTimeout.mockReturnValue(mockSignal);
+  });
+
+  it("exports API_TIMEOUT_MS as 5000", () => {
+    expect(API_TIMEOUT_MS).toBe(5_000);
+  });
+
+  it("calls fetch with AbortSignal.timeout using default timeout", async () => {
+    mockFetch.mockResolvedValue(new Response("ok", { status: 200 }));
+
+    await fetchWithTimeout("https://example.com/api");
+
+    expect(mockTimeout).toHaveBeenCalledWith(5_000);
+    expect(mockFetch).toHaveBeenCalledWith("https://example.com/api", {
+      signal: mockSignal,
+    });
+  });
+
+  it("accepts a custom timeout value", async () => {
+    mockFetch.mockResolvedValue(new Response("ok", { status: 200 }));
+
+    await fetchWithTimeout("https://example.com/api", {}, 3_000);
+
+    expect(mockTimeout).toHaveBeenCalledWith(3_000);
+  });
+
+  it("passes through request options (headers, method, etc.)", async () => {
+    mockFetch.mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const options = {
+      method: "POST",
+      headers: { Authorization: "Bearer test-key" },
+    };
+
+    await fetchWithTimeout("https://example.com/api", options);
+
+    expect(mockFetch).toHaveBeenCalledWith("https://example.com/api", {
+      ...options,
+      signal: mockSignal,
+    });
+  });
+
+  it("returns the fetch Response on success", async () => {
+    const mockResponse = new Response(JSON.stringify({ data: "test" }), {
+      status: 200,
+    });
+    mockFetch.mockResolvedValue(mockResponse);
+
+    const result = await fetchWithTimeout("https://example.com/api");
+    expect(result).toBe(mockResponse);
+  });
+
+  it("propagates fetch rejection (e.g. timeout AbortError)", async () => {
+    const abortError = new DOMException("signal timed out", "TimeoutError");
+    mockFetch.mockRejectedValue(abortError);
+
+    await expect(
+      fetchWithTimeout("https://example.com/api"),
+    ).rejects.toThrow("signal timed out");
+  });
+
+  it("propagates network errors", async () => {
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+
+    await expect(
+      fetchWithTimeout("https://example.com/api"),
+    ).rejects.toThrow("Network failure");
+  });
+});

--- a/lib/apis/aqi.ts
+++ b/lib/apis/aqi.ts
@@ -10,6 +10,8 @@
  * Reference: https://aqicn.org/json-api/doc/
  */
 
+import { fetchWithTimeout } from "./fetch-with-timeout";
+
 /* ------------------------------------------------------------------ */
 /* Types                                                               */
 /* ------------------------------------------------------------------ */
@@ -81,7 +83,7 @@ export async function getAqiData(
   try {
     const url = `https://api.waqi.info/feed/geo:${lat};${lng}/?token=${apiToken}`;
 
-    const response = await fetch(url);
+    const response = await fetchWithTimeout(url);
     if (!response.ok) return AQI_DEFAULTS;
 
     const data = await response.json();

--- a/lib/apis/batchdata.ts
+++ b/lib/apis/batchdata.ts
@@ -11,6 +11,7 @@
  */
 
 import fixtureData from "@/lib/data/batchdata-fixtures.json";
+import { fetchWithTimeout } from "./fetch-with-timeout";
 
 /* ------------------------------------------------------------------ */
 /* Types                                                               */
@@ -81,7 +82,7 @@ async function fetchFromApi(address: string): Promise<PropertyData | null> {
     );
     url.searchParams.set("address", address);
 
-    const response = await fetch(url.toString(), {
+    const response = await fetchWithTimeout(url.toString(), {
       headers: {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",

--- a/lib/apis/census.ts
+++ b/lib/apis/census.ts
@@ -10,6 +10,8 @@
  * Reference: https://api.census.gov/data/2022/acs/acs5
  */
 
+import { fetchWithTimeout } from "./fetch-with-timeout";
+
 /* ------------------------------------------------------------------ */
 /* Types                                                               */
 /* ------------------------------------------------------------------ */
@@ -74,7 +76,7 @@ async function latLngToFips(
     url.searchParams.set("format", "json");
     url.searchParams.set("showall", "false");
 
-    const response = await fetch(url.toString());
+    const response = await fetchWithTimeout(url.toString());
     if (!response.ok) return null;
 
     const data = await response.json();
@@ -131,7 +133,7 @@ export async function getBlockGroupIncome(
       `&in=state:${fips.state}%20county:${fips.county}%20tract:${fips.tract}` +
       keyParam;
 
-    const response = await fetch(url);
+    const response = await fetchWithTimeout(url);
     if (!response.ok) return null;
 
     const data = await response.json();

--- a/lib/apis/fetch-with-timeout.ts
+++ b/lib/apis/fetch-with-timeout.ts
@@ -1,0 +1,45 @@
+/**
+ * Fetch with AbortController Timeout
+ *
+ * Wraps the native `fetch()` with an `AbortSignal.timeout()` to prevent
+ * indefinite hangs when external APIs are slow or unresponsive.
+ *
+ * Server-side only — used by all external API clients in `lib/apis/`.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static
+ */
+
+/* ------------------------------------------------------------------ */
+/* Constants                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Default timeout for external API calls (milliseconds) */
+export const API_TIMEOUT_MS = 5_000;
+
+/* ------------------------------------------------------------------ */
+/* Wrapper                                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Fetch a URL with an automatic timeout via AbortSignal.
+ *
+ * Behaves identically to `fetch()` but aborts the request if it exceeds
+ * `timeoutMs` milliseconds. The caller's existing error handling will
+ * catch the resulting `AbortError` / `TimeoutError`.
+ *
+ * @param url       — the URL to fetch
+ * @param options   — standard `RequestInit` options (headers, method, etc.)
+ * @param timeoutMs — timeout in milliseconds (defaults to `API_TIMEOUT_MS`)
+ * @returns the `Response` from fetch
+ * @throws `TimeoutError` (or `AbortError`) when the request exceeds the timeout
+ */
+export function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs: number = API_TIMEOUT_MS,
+): Promise<Response> {
+  return fetch(url, {
+    ...options,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+}

--- a/lib/apis/geocoding.ts
+++ b/lib/apis/geocoding.ts
@@ -7,6 +7,8 @@
  * Reference: https://developers.google.com/maps/documentation/geocoding
  */
 
+import { fetchWithTimeout } from "./fetch-with-timeout";
+
 /* ------------------------------------------------------------------ */
 /* Types                                                               */
 /* ------------------------------------------------------------------ */
@@ -74,7 +76,12 @@ export async function geocodeAddress(
   // Bias toward US results
   url.searchParams.set("components", "country:US");
 
-  const response = await fetch(url.toString());
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(url.toString());
+  } catch {
+    throw new Error("Geocoding API timeout");
+  }
   if (!response.ok) {
     throw new Error(`Geocoding API HTTP error: ${response.status}`);
   }

--- a/lib/apis/pollen.ts
+++ b/lib/apis/pollen.ts
@@ -10,6 +10,8 @@
  * Reference: https://developers.google.com/maps/documentation/pollen
  */
 
+import { fetchWithTimeout } from "./fetch-with-timeout";
+
 /* ------------------------------------------------------------------ */
 /* Types                                                               */
 /* ------------------------------------------------------------------ */
@@ -137,7 +139,7 @@ export async function getPollenData(
     url.searchParams.set("days", "1");
     url.searchParams.set("plantsDescription", "true");
 
-    const response = await fetch(url.toString());
+    const response = await fetchWithTimeout(url.toString());
     if (!response.ok) return POLLEN_DEFAULTS;
 
     const data = await response.json();

--- a/lib/apis/weather.ts
+++ b/lib/apis/weather.ts
@@ -10,6 +10,8 @@
  * Reference: https://openweathermap.org/current
  */
 
+import { fetchWithTimeout } from "./fetch-with-timeout";
+
 /* ------------------------------------------------------------------ */
 /* Types                                                               */
 /* ------------------------------------------------------------------ */
@@ -110,7 +112,7 @@ export async function getWeatherData(
     url.searchParams.set("appid", apiKey);
     // Units: standard (Kelvin) — we convert manually for precision
 
-    const response = await fetch(url.toString());
+    const response = await fetchWithTimeout(url.toString());
     if (!response.ok) return WEATHER_DEFAULTS;
 
     const data = await response.json();


### PR DESCRIPTION
## Summary
- Creates a shared `fetchWithTimeout()` wrapper in `lib/apis/fetch-with-timeout.ts` that applies `AbortSignal.timeout()` to all external API calls
- Updates all 6 API clients (geocoding, batchdata, census, pollen, weather, aqi) to use the wrapper with a 5-second default timeout
- Preserves existing fallback behavior: clients that return defaults on error continue to do so on timeout; geocoding throws a descriptive "Geocoding API timeout" error

## Changes
| File | Change |
|------|--------|
| `lib/apis/fetch-with-timeout.ts` | New shared utility with `fetchWithTimeout()` and `API_TIMEOUT_MS` constant |
| `lib/apis/geocoding.ts` | Uses `fetchWithTimeout`, wraps fetch in try/catch to throw timeout error |
| `lib/apis/batchdata.ts` | Uses `fetchWithTimeout` (existing catch returns null) |
| `lib/apis/census.ts` | Uses `fetchWithTimeout` in both FCC and Census API calls (existing catches return null) |
| `lib/apis/pollen.ts` | Uses `fetchWithTimeout` (existing catch returns defaults) |
| `lib/apis/weather.ts` | Uses `fetchWithTimeout` (existing catch returns defaults) |
| `lib/apis/aqi.ts` | Uses `fetchWithTimeout` (existing catch returns defaults) |
| `__tests__/api/fetch-with-timeout.test.ts` | 7 tests covering signal creation, option passthrough, error propagation |

## Test plan
- [x] All 626 existing tests pass
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] New fetchWithTimeout tests verify signal wiring and error propagation
- [x] Existing API client tests still pass (mocked fetch is unaffected by the wrapper)

Closes #42