### PR TITLE
fix(engine): add null-coalescing defaults for rain/thunderstorm in MC runner

### DIFF
--- a/lib/engine/monte-carlo.ts
+++ b/lib/engine/monte-carlo.ts
@@ -271,8 +271,9 @@ export function runMonteCarloForAllergen(
   const wind = env.weather.wind_mph ?? MC_WEATHER_DEFAULTS.wind_mph;
   const humidity =
     env.weather.humidity_pct ?? MC_WEATHER_DEFAULTS.humidity_pct;
-  const rain = env.weather.rain_last_12h;
-  const thunderstorm = env.weather.thunderstorm_6h;
+  const rain = env.weather.rain_last_12h ?? MC_WEATHER_DEFAULTS.rain;
+  const thunderstorm =
+    env.weather.thunderstorm_6h ?? MC_WEATHER_DEFAULTS.thunderstorm;
 
   // Get pollen concentration for this allergen's category
   const upi = getPollenUpi(env.pollen, allergen.category);


### PR DESCRIPTION
## Summary

- Adds `?? MC_WEATHER_DEFAULTS.rain` and `?? MC_WEATHER_DEFAULTS.thunderstorm` fallbacks to `rain_last_12h` and `thunderstorm_6h` in `runMonteCarloForAllergen()`, matching the existing pattern used by `wind_mph` and `humidity_pct`.

Closes #50

## Test plan

- [x] All 626 existing tests pass
- [x] Lint and typecheck clean
- [ ] PR preview deploys successfully