### PR TITLE
feat(leaderboard): blur gate for ranks #5+ on free tier

### DIFF
--- a/__tests__/components/leaderboard/leaderboard.test.tsx
+++ b/__tests__/components/leaderboard/leaderboard.test.tsx
@@ -81,6 +81,14 @@ const mockAllergens: RankedAllergen[] = [
     confidence_tier: "medium",
     rank: 5,
   },
+  {
+    allergen_id: "cat_dander",
+    common_name: "Cat Dander",
+    category: "indoor",
+    elo_score: 1300,
+    confidence_tier: "low",
+    rank: 6,
+  },
 ];
 
 const defaultProps = {
@@ -119,7 +127,7 @@ describe("Leaderboard", () => {
       render(<Leaderboard {...defaultProps} />);
       expect(screen.getByText("Full Rankings")).toBeDefined();
       const rows = screen.getAllByTestId("ranked-allergen-row");
-      expect(rows.length).toBe(1); // Only #5 (Dust Mites)
+      expect(rows.length).toBe(2); // #5 (Dust Mites) and #6 (Cat Dander)
     });
 
     it("shows Dust Mites in full rankings", () => {
@@ -203,6 +211,61 @@ describe("Leaderboard", () => {
       render(<Leaderboard {...defaultProps} fdaAcknowledged={true} />);
       expect(screen.queryByTestId("disclaimer-modal")).toBeNull();
       expect(screen.getByTestId("leaderboard")).toBeDefined();
+    });
+  });
+
+  describe("free-tier user (ranks #5+ score gating)", () => {
+    it("shows allergen names for ranks #5+ but hides scores", () => {
+      render(<Leaderboard {...defaultProps} isPremium={false} />);
+      // Allergen names are visible
+      expect(screen.getByText("Dust Mites")).toBeDefined();
+      expect(screen.getByText("Cat Dander")).toBeDefined();
+      // Scores are hidden — lock icons shown instead
+      const lockedElements = screen.getAllByTestId("ranking-score-locked");
+      expect(lockedElements.length).toBe(2);
+      // Score values should NOT appear
+      expect(screen.queryByText("1350")).toBeNull();
+      expect(screen.queryByText("1300")).toBeNull();
+    });
+
+    it("shows 'Upgrade' text where scores would be for free users", () => {
+      render(<Leaderboard {...defaultProps} isPremium={false} />);
+      const upgradeTexts = screen.getAllByText("Upgrade");
+      // Each ranked row (#5, #6) shows "Upgrade"
+      expect(upgradeTexts.length).toBe(2);
+    });
+
+    it("shows upgrade CTA below full rankings for free users", () => {
+      render(<Leaderboard {...defaultProps} isPremium={false} />);
+      expect(screen.getByTestId("rankings-upgrade-cta")).toBeDefined();
+      expect(screen.getByTestId("upgrade-cta")).toBeDefined();
+    });
+
+    it("does not show score details for free users", () => {
+      render(<Leaderboard {...defaultProps} isPremium={false} />);
+      expect(screen.queryByTestId("ranking-score-details")).toBeNull();
+    });
+  });
+
+  describe("premium user (full rankings visible)", () => {
+    it("shows full scores and confidence for ranks #5+", () => {
+      render(<Leaderboard {...defaultProps} isPremium={true} />);
+      // Scores are visible
+      expect(screen.getByText("1350")).toBeDefined();
+      expect(screen.getByText("1300")).toBeDefined();
+      // Score detail elements present
+      const scoreDetails = screen.getAllByTestId("ranking-score-details");
+      expect(scoreDetails.length).toBe(2);
+    });
+
+    it("does not show lock icons for premium users", () => {
+      render(<Leaderboard {...defaultProps} isPremium={true} />);
+      expect(screen.queryByTestId("ranking-score-locked")).toBeNull();
+    });
+
+    it("does not show rankings upgrade CTA for premium users", () => {
+      render(<Leaderboard {...defaultProps} isPremium={true} />);
+      expect(screen.queryByTestId("rankings-upgrade-cta")).toBeNull();
     });
   });
 

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -23,6 +23,7 @@ import { EnvironmentalForecast } from "./environmental-forecast";
 import type { ForecastData } from "./environmental-forecast";
 import { ConfidenceBadge } from "./confidence-badge";
 import { CategoryIcon } from "./category-icon";
+import { UpgradeCta } from "@/components/subscription/upgrade-cta";
 import type { RankedAllergen } from "./types";
 
 export interface LeaderboardClientProps {
@@ -245,25 +246,65 @@ export function Leaderboard({
                     {allergen.common_name}
                   </span>
                 </div>
-                <div
-                  className="flex items-center gap-2"
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "0.5rem",
-                  }}
-                >
-                  <span
-                    className="text-xs text-gray-500"
-                    style={{ fontSize: "0.75rem", color: "#6b7280" }}
+                {isPremium ? (
+                  <div
+                    data-testid="ranking-score-details"
+                    className="flex items-center gap-2"
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.5rem",
+                    }}
                   >
-                    {allergen.elo_score}
-                  </span>
-                  <ConfidenceBadge tier={allergen.confidence_tier} />
-                </div>
+                    <span
+                      className="text-xs text-gray-500"
+                      style={{ fontSize: "0.75rem", color: "#6b7280" }}
+                    >
+                      {allergen.elo_score}
+                    </span>
+                    <ConfidenceBadge tier={allergen.confidence_tier} />
+                  </div>
+                ) : (
+                  <div
+                    data-testid="ranking-score-locked"
+                    className="flex items-center gap-1.5"
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.375rem",
+                    }}
+                  >
+                    <span
+                      aria-hidden="true"
+                      style={{ fontSize: "0.875rem" }}
+                    >
+                      &#x1F512;
+                    </span>
+                    <span
+                      className="text-xs font-medium text-purple-600"
+                      style={{
+                        fontSize: "0.75rem",
+                        fontWeight: 500,
+                        color: "#9333ea",
+                      }}
+                    >
+                      Upgrade
+                    </span>
+                  </div>
+                )}
               </div>
             ))}
           </div>
+
+          {/* Upgrade CTA for free users */}
+          {!isPremium && (
+            <div
+              data-testid="rankings-upgrade-cta"
+              style={{ marginTop: "1rem" }}
+            >
+              <UpgradeCta feature="full ranking details" />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/lib/subscription/constants.ts
+++ b/lib/subscription/constants.ts
@@ -24,8 +24,8 @@ export const PAYWALL_ENABLED =
  */
 export const TIER_FEATURES: Record<SubscriptionTier, PremiumFeature[]> = {
   free: [],
-  madness_plus: ["final_four", "pdf_report", "detailed_confidence"],
-  madness_family: ["final_four", "pdf_report", "detailed_confidence"],
+  madness_plus: ["final_four", "pdf_report", "detailed_confidence", "full_rankings"],
+  madness_family: ["final_four", "pdf_report", "detailed_confidence", "full_rankings"],
 };
 
 /**

--- a/lib/subscription/types.ts
+++ b/lib/subscription/types.ts
@@ -13,7 +13,8 @@ export type { SubscriptionTier };
 export type PremiumFeature =
   | "final_four"
   | "pdf_report"
-  | "detailed_confidence";
+  | "detailed_confidence"
+  | "full_rankings";
 
 /** Result of checking a user's access level */
 export interface AccessStatus {


### PR DESCRIPTION
## Summary

- Free-tier users viewing ranks #5+ now see allergen names and rank numbers but **not** Elo scores or confidence tiers -- those are replaced with a lock icon and "Upgrade" text
- Premium users (or when `PAYWALL_ENABLED=false`) see full details for all ranks
- Adds an "Upgrade to see full ranking details" CTA below the full rankings list for free users
- Adds `full_rankings` to the `PremiumFeature` type and premium tier feature lists

## What changed

| File | Change |
|------|--------|
| `components/leaderboard/leaderboard.tsx` | Conditional render: scores visible for premium, lock+upgrade for free |
| `lib/subscription/types.ts` | Added `full_rankings` to `PremiumFeature` union |
| `lib/subscription/constants.ts` | Added `full_rankings` to `madness_plus` and `madness_family` tier features |
| `__tests__/components/leaderboard/leaderboard.test.tsx` | 7 new tests for free/premium score visibility, lock icons, upgrade CTA |

## What is NOT changed

- Trigger Champion (#1) -- fully visible to all users
- Final Four (#2-#4) blur behavior -- unchanged
- No server-side logic changes

## Test plan

- [x] Free user sees allergen names but not scores for ranks #5+
- [x] Free user sees lock icon + "Upgrade" text instead of scores
- [x] Free user sees upgrade CTA below rankings
- [x] Premium user sees full scores and confidence for all ranks
- [x] Premium user does not see lock icons or upgrade CTA
- [x] Existing Final Four blur tests still pass
- [x] All 633 tests pass, lint clean, typecheck clean

Closes #56