### PR TITLE
feat(pfas): add food cross-reactivity panel (#31)

### DIFF
--- a/__tests__/components/pfas/pfas-panel.test.tsx
+++ b/__tests__/components/pfas/pfas-panel.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * PFAS Panel Component Tests
+ *
+ * Validates the food cross-reactivity panel:
+ * - Renders for premium users with cross-reactive data
+ * - Blurs food lists for free-tier users
+ * - Shows FDA disclaimer
+ * - Shows upgrade CTA for free users
+ * - Hidden when no cross-reactive data exists
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PfasPanel } from "@/components/pfas/pfas-panel";
+import type { PfasCrossReactivity } from "@/lib/pfas/types";
+
+/* ------------------------------------------------------------------ */
+/* Test data                                                           */
+/* ------------------------------------------------------------------ */
+
+const mockEntries: PfasCrossReactivity[] = [
+  {
+    allergen_id: "birch",
+    common_name: "Birch",
+    category: "tree",
+    cross_reactive_foods: ["apple", "pear", "cherry", "celery"],
+    pfas_severity: "moderate",
+  },
+  {
+    allergen_id: "ragweed",
+    common_name: "Ragweed",
+    category: "weed",
+    cross_reactive_foods: ["banana", "melon", "watermelon"],
+    pfas_severity: "moderate",
+  },
+];
+
+describe("PfasPanel", () => {
+  describe("premium user", () => {
+    it("renders the PFAS panel section", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      expect(screen.getByTestId("pfas-panel")).toBeDefined();
+    });
+
+    it("shows the section heading", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      expect(
+        screen.getByText("Food Cross-Reactivity (PFAS)"),
+      ).toBeDefined();
+    });
+
+    it("renders allergen cards for each entry", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      const cards = screen.getAllByTestId("pfas-allergen-card");
+      expect(cards).toHaveLength(2);
+    });
+
+    it("shows allergen names on cards", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      expect(screen.getByText("Birch")).toBeDefined();
+      expect(screen.getByText("Ragweed")).toBeDefined();
+    });
+
+    it("shows cross-reactive food tags for premium users", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      const foodTags = screen.getAllByTestId("pfas-food-tag");
+      // birch: 4 foods + ragweed: 3 foods = 7 total
+      expect(foodTags).toHaveLength(7);
+      expect(screen.getByText("apple")).toBeDefined();
+      expect(screen.getByText("banana")).toBeDefined();
+    });
+
+    it("shows severity badges", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      const badges = screen.getAllByTestId("pfas-severity-badge");
+      expect(badges).toHaveLength(2);
+      expect(screen.getAllByText("Moderate")).toHaveLength(2);
+    });
+
+    it("shows FDA disclaimer", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      expect(screen.getByTestId("fda-disclaimer")).toBeDefined();
+    });
+
+    it("does not show upgrade CTA for premium users", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      expect(screen.queryByTestId("pfas-upgrade-cta")).toBeNull();
+    });
+
+    it("does not show blur overlay for premium users", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={true} />);
+      expect(screen.queryByTestId("blur-overlay")).toBeNull();
+    });
+  });
+
+  describe("free-tier user", () => {
+    it("renders the PFAS panel section", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={false} />);
+      expect(screen.getByTestId("pfas-panel")).toBeDefined();
+    });
+
+    it("shows allergen names (visible even for free tier)", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={false} />);
+      expect(screen.getByText("Birch")).toBeDefined();
+      expect(screen.getByText("Ragweed")).toBeDefined();
+    });
+
+    it("blurs food lists for free-tier users", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={false} />);
+      const blurOverlays = screen.getAllByTestId("blur-overlay");
+      expect(blurOverlays.length).toBeGreaterThan(0);
+    });
+
+    it("shows upgrade CTA for free users", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={false} />);
+      expect(screen.getByTestId("pfas-upgrade-cta")).toBeDefined();
+    });
+
+    it("shows FDA disclaimer for free users too", () => {
+      render(<PfasPanel entries={mockEntries} isPremium={false} />);
+      expect(screen.getByTestId("fda-disclaimer")).toBeDefined();
+    });
+  });
+
+  describe("no data", () => {
+    it("returns null when entries array is empty", () => {
+      const { container } = render(
+        <PfasPanel entries={[]} isPremium={true} />,
+      );
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("does not render PFAS panel when no entries", () => {
+      render(<PfasPanel entries={[]} isPremium={false} />);
+      expect(screen.queryByTestId("pfas-panel")).toBeNull();
+    });
+  });
+
+  describe("severity badges", () => {
+    it("renders mild_oas severity correctly", () => {
+      const mildEntry: PfasCrossReactivity[] = [
+        {
+          allergen_id: "oak",
+          common_name: "Oak",
+          category: "tree",
+          cross_reactive_foods: ["apple", "cherry"],
+          pfas_severity: "mild_oas",
+        },
+      ];
+      render(<PfasPanel entries={mildEntry} isPremium={true} />);
+      expect(screen.getByText("Mild OAS")).toBeDefined();
+    });
+  });
+});

--- a/__tests__/pfas/get-pfas-data.test.ts
+++ b/__tests__/pfas/get-pfas-data.test.ts
@@ -1,0 +1,87 @@
+/**
+ * PFAS Data Retrieval Tests
+ *
+ * Validates that getPfasData correctly extracts cross-reactive food
+ * data from the allergen seed data based on provided allergen IDs.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getPfasData } from "@/lib/pfas/get-pfas-data";
+
+describe("getPfasData", () => {
+  it("returns cross-reactive foods for birch (top allergen with PFAS data)", () => {
+    const result = getPfasData(["birch"]);
+    expect(result.hasData).toBe(true);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].allergen_id).toBe("birch");
+    expect(result.entries[0].common_name).toBe("Birch");
+    expect(result.entries[0].pfas_severity).toBe("moderate");
+    expect(result.entries[0].cross_reactive_foods).toContain("apple");
+    expect(result.entries[0].cross_reactive_foods).toContain("celery");
+  });
+
+  it("returns data for multiple allergens with PFAS cross-reactivity", () => {
+    const result = getPfasData(["birch", "ragweed", "oak"]);
+    expect(result.hasData).toBe(true);
+    expect(result.entries).toHaveLength(3);
+    const ids = result.entries.map((e) => e.allergen_id);
+    expect(ids).toContain("birch");
+    expect(ids).toContain("ragweed");
+    expect(ids).toContain("oak");
+  });
+
+  it("excludes allergens with pfas_severity = none", () => {
+    // cedar-juniper has cross_reactive_foods: [] and pfas_severity: "none"
+    const result = getPfasData(["cedar-juniper"]);
+    expect(result.hasData).toBe(false);
+    expect(result.entries).toHaveLength(0);
+  });
+
+  it("excludes allergens with empty cross_reactive_foods", () => {
+    const result = getPfasData(["cedar-juniper"]);
+    expect(result.entries).toHaveLength(0);
+  });
+
+  it("returns empty result for allergen IDs not in seed data", () => {
+    const result = getPfasData(["nonexistent-allergen"]);
+    expect(result.hasData).toBe(false);
+    expect(result.entries).toHaveLength(0);
+  });
+
+  it("returns empty result for empty input array", () => {
+    const result = getPfasData([]);
+    expect(result.hasData).toBe(false);
+    expect(result.entries).toHaveLength(0);
+  });
+
+  it("food list matches allergen seed data (not hardcoded)", () => {
+    // Ragweed has specific cross-reactive foods in seed data
+    const result = getPfasData(["ragweed"]);
+    expect(result.entries[0].cross_reactive_foods).toContain("banana");
+    expect(result.entries[0].cross_reactive_foods).toContain("melon");
+    expect(result.entries[0].cross_reactive_foods).toContain("watermelon");
+  });
+
+  it("includes category from seed data", () => {
+    const result = getPfasData(["birch"]);
+    expect(result.entries[0].category).toBe("tree");
+  });
+
+  it("handles mixed allergens — some with PFAS, some without", () => {
+    // birch has PFAS, cedar-juniper does not
+    const result = getPfasData(["birch", "cedar-juniper"]);
+    expect(result.hasData).toBe(true);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].allergen_id).toBe("birch");
+  });
+
+  it("filters to only requested allergen IDs (top 5 scenario)", () => {
+    // Only request a subset of allergens
+    const result = getPfasData(["oak"]);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].allergen_id).toBe("oak");
+    // Should not include birch even though it has PFAS data
+    const ids = result.entries.map((e) => e.allergen_id);
+    expect(ids).not.toContain("birch");
+  });
+});

--- a/app/api/pfas/route.ts
+++ b/app/api/pfas/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { isFeatureAvailable } from "@/lib/subscription/check";
+import { getPfasData } from "@/lib/pfas/get-pfas-data";
+
+/**
+ * GET /api/pfas
+ *
+ * Returns PFAS (Pollen-Food Allergy Syndrome) cross-reactivity data
+ * for the authenticated user's top 5 allergens.
+ *
+ * Security:
+ * - Requires authentication (RLS-enforced)
+ * - Full food lists only returned for Madness+ / referral-unlocked users
+ * - Free users receive allergen names + severity but food lists are empty
+ * - NEVER returns income_tier
+ */
+export async function GET() {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Check premium access for PFAS panel
+  const hasPfasAccess = await isFeatureAvailable(
+    supabase,
+    user.id,
+    "pfas_panel",
+  );
+
+  // Fetch user's top 5 allergens by Elo score
+  const { data: eloRows, error: eloError } = await supabase
+    .from("user_allergen_elo")
+    .select("allergen_id")
+    .eq("user_id", user.id)
+    .is("child_id", null)
+    .order("elo_score", { ascending: false })
+    .limit(5);
+
+  if (eloError) {
+    return NextResponse.json(
+      { error: "Failed to load allergen data" },
+      { status: 500 },
+    );
+  }
+
+  const topAllergenIds = (eloRows ?? []).map(
+    (row: { allergen_id: string }) => row.allergen_id,
+  );
+
+  if (topAllergenIds.length === 0) {
+    return NextResponse.json({
+      entries: [],
+      hasData: false,
+      isPremium: hasPfasAccess,
+    });
+  }
+
+  // Get PFAS data from seed
+  const pfasData = getPfasData(topAllergenIds);
+
+  // For free users: return allergen names and severity but strip food lists
+  if (!hasPfasAccess) {
+    return NextResponse.json({
+      entries: pfasData.entries.map((entry) => ({
+        ...entry,
+        cross_reactive_foods: [],
+      })),
+      hasData: pfasData.hasData,
+      isPremium: false,
+    });
+  }
+
+  return NextResponse.json({
+    ...pfasData,
+    isPremium: true,
+  });
+}

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -24,6 +24,8 @@ import type { ForecastData } from "./environmental-forecast";
 import { ConfidenceBadge } from "./confidence-badge";
 import { CategoryIcon } from "./category-icon";
 import { UpgradeCta } from "@/components/subscription/upgrade-cta";
+import { PfasPanel } from "@/components/pfas/pfas-panel";
+import type { PfasCrossReactivity } from "@/lib/pfas/types";
 import type { RankedAllergen } from "./types";
 
 export interface LeaderboardClientProps {
@@ -37,6 +39,8 @@ export interface LeaderboardClientProps {
   fdaAcknowledged: boolean;
   /** Authenticated user ID */
   userId: string;
+  /** PFAS cross-reactivity entries for top allergens (optional) */
+  pfasEntries?: PfasCrossReactivity[];
 }
 
 export function Leaderboard({
@@ -45,6 +49,7 @@ export function Leaderboard({
   isEnvironmentalForecast,
   fdaAcknowledged,
   userId,
+  pfasEntries = [],
 }: LeaderboardClientProps) {
   const [acknowledged, setAcknowledged] = useState(fdaAcknowledged);
   const [forecastData, setForecastData] = useState<ForecastData | null>(null);
@@ -305,6 +310,13 @@ export function Leaderboard({
               <UpgradeCta feature="full ranking details" />
             </div>
           )}
+        </div>
+      )}
+
+      {/* PFAS Cross-Reactivity Panel */}
+      {pfasEntries.length > 0 && (
+        <div style={{ marginTop: "1.5rem" }}>
+          <PfasPanel entries={pfasEntries} isPremium={isPremium} />
         </div>
       )}
     </div>

--- a/components/pfas/index.ts
+++ b/components/pfas/index.ts
@@ -1,0 +1,8 @@
+/**
+ * PFAS Components
+ *
+ * Re-exports for the food cross-reactivity panel.
+ */
+
+export { PfasPanel } from "./pfas-panel";
+export type { PfasPanelProps } from "./pfas-panel";

--- a/components/pfas/pfas-panel.tsx
+++ b/components/pfas/pfas-panel.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+/**
+ * PFAS Panel
+ *
+ * Displays food cross-reactivity information for allergens in the
+ * user's top 5. Shows which foods may trigger oral allergy symptoms
+ * based on pollen-food allergy syndrome (PFAS) data.
+ *
+ * Premium feature — gated behind Madness+ subscription.
+ * Free-tier users see allergen names but food lists are blurred.
+ *
+ * Dual styling: Tailwind utility classes + inline styles.
+ */
+
+import { FdaDisclaimer } from "@/components/shared/fda-disclaimer";
+import { BlurOverlay } from "@/components/leaderboard/blur-overlay";
+import { CategoryIcon } from "@/components/leaderboard/category-icon";
+import { UpgradeCta } from "@/components/subscription/upgrade-cta";
+import type { PfasCrossReactivity } from "@/lib/pfas/types";
+import type { PfasSeverity } from "@/lib/supabase/types";
+
+export interface PfasPanelProps {
+  /** Cross-reactivity entries for top allergens */
+  entries: PfasCrossReactivity[];
+  /** Whether the user has premium access */
+  isPremium: boolean;
+}
+
+const SEVERITY_LABELS: Record<PfasSeverity, string> = {
+  mild_oas: "Mild OAS",
+  moderate: "Moderate",
+  systemic_risk: "Systemic Risk",
+  none: "None",
+};
+
+const SEVERITY_COLORS: Record<
+  PfasSeverity,
+  { bg: string; text: string; border: string }
+> = {
+  mild_oas: {
+    bg: "#fef9c3",
+    text: "#854d0e",
+    border: "#fde68a",
+  },
+  moderate: {
+    bg: "#ffedd5",
+    text: "#9a3412",
+    border: "#fed7aa",
+  },
+  systemic_risk: {
+    bg: "#fee2e2",
+    text: "#991b1b",
+    border: "#fecaca",
+  },
+  none: {
+    bg: "#f3f4f6",
+    text: "#374151",
+    border: "#e5e7eb",
+  },
+};
+
+function SeverityBadge({ severity }: { severity: PfasSeverity }) {
+  const colors = SEVERITY_COLORS[severity];
+  return (
+    <span
+      data-testid="pfas-severity-badge"
+      className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        borderRadius: "9999px",
+        paddingLeft: "0.5rem",
+        paddingRight: "0.5rem",
+        paddingTop: "0.125rem",
+        paddingBottom: "0.125rem",
+        fontSize: "0.75rem",
+        fontWeight: 500,
+        backgroundColor: colors.bg,
+        color: colors.text,
+        border: `1px solid ${colors.border}`,
+      }}
+    >
+      {SEVERITY_LABELS[severity]}
+    </span>
+  );
+}
+
+function FoodTag({ food }: { food: string }) {
+  return (
+    <span
+      data-testid="pfas-food-tag"
+      className="inline-block rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-800"
+      style={{
+        display: "inline-block",
+        borderRadius: "0.375rem",
+        backgroundColor: "#f0fdf4",
+        paddingLeft: "0.5rem",
+        paddingRight: "0.5rem",
+        paddingTop: "0.25rem",
+        paddingBottom: "0.25rem",
+        fontSize: "0.75rem",
+        fontWeight: 500,
+        color: "#166534",
+        border: "1px solid #bbf7d0",
+      }}
+    >
+      {food}
+    </span>
+  );
+}
+
+function AllergenCrossReactivityCard({
+  entry,
+  isPremium,
+}: {
+  entry: PfasCrossReactivity;
+  isPremium: boolean;
+}) {
+  const foodContent = (
+    <div
+      className="flex flex-wrap gap-2"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "0.5rem",
+      }}
+    >
+      {entry.cross_reactive_foods.map((food) => (
+        <FoodTag key={food} food={food} />
+      ))}
+    </div>
+  );
+
+  return (
+    <div
+      data-testid="pfas-allergen-card"
+      className="rounded-lg border border-gray-200 bg-white p-4"
+      style={{
+        borderRadius: "0.5rem",
+        border: "1px solid #e5e7eb",
+        backgroundColor: "#ffffff",
+        padding: "1rem",
+      }}
+    >
+      {/* Allergen header — always visible */}
+      <div
+        className="mb-3 flex items-center justify-between"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "0.75rem",
+        }}
+      >
+        <div
+          className="flex items-center gap-2"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "0.5rem",
+          }}
+        >
+          <CategoryIcon category={entry.category} />
+          <span
+            className="text-sm font-semibold text-gray-900"
+            style={{
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              color: "#111827",
+            }}
+          >
+            {entry.common_name}
+          </span>
+        </div>
+        <SeverityBadge severity={entry.pfas_severity} />
+      </div>
+
+      {/* Food list — blurred for free tier */}
+      <div>
+        <p
+          className="mb-2 text-xs font-medium text-gray-500"
+          style={{
+            fontSize: "0.75rem",
+            fontWeight: 500,
+            color: "#6b7280",
+            marginBottom: "0.5rem",
+          }}
+        >
+          Cross-reactive foods
+        </p>
+        {isPremium ? (
+          foodContent
+        ) : (
+          <BlurOverlay featureLabel="food cross-reactivity details">
+            {foodContent}
+          </BlurOverlay>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function PfasPanel({ entries, isPremium }: PfasPanelProps) {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      data-testid="pfas-panel"
+      aria-label="Food cross-reactivity panel"
+      className="space-y-4"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+      }}
+    >
+      {/* Section header */}
+      <div>
+        <h2
+          className="text-lg font-semibold text-gray-800"
+          style={{
+            fontSize: "1.125rem",
+            fontWeight: 600,
+            color: "#1f2937",
+            margin: 0,
+          }}
+        >
+          Food Cross-Reactivity (PFAS)
+        </h2>
+        <p
+          className="mt-1 text-xs text-gray-500"
+          style={{
+            fontSize: "0.75rem",
+            color: "#6b7280",
+            marginTop: "0.25rem",
+          }}
+        >
+          Foods that may trigger oral symptoms due to pollen-food allergy
+          syndrome
+        </p>
+      </div>
+
+      {/* FDA Disclaimer — required on health-adjacent content */}
+      <FdaDisclaimer variant="compact" />
+
+      {/* Cross-reactivity cards */}
+      {entries.map((entry) => (
+        <AllergenCrossReactivityCard
+          key={entry.allergen_id}
+          entry={entry}
+          isPremium={isPremium}
+        />
+      ))}
+
+      {/* Upgrade CTA for free users */}
+      {!isPremium && (
+        <div
+          data-testid="pfas-upgrade-cta"
+          style={{ marginTop: "0.5rem" }}
+        >
+          <UpgradeCta feature="food cross-reactivity details" />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/lib/pfas/get-pfas-data.ts
+++ b/lib/pfas/get-pfas-data.ts
@@ -1,0 +1,56 @@
+/**
+ * PFAS Data Retrieval
+ *
+ * Extracts cross-reactive food data from the allergen seed data
+ * for a user's top-ranked allergens. Data is NOT hardcoded — it
+ * comes from the allergen seed JSON (cross_reactive_foods field).
+ *
+ * Server-side only — do not import from client components.
+ */
+
+import allergensSeed from "@/lib/data/allergens-seed.json";
+import type { PfasCrossReactivity, PfasPanelData } from "./types";
+import type { AllergenCategory, PfasSeverity } from "@/lib/supabase/types";
+
+interface SeedAllergen {
+  id: string;
+  common_name: string;
+  category: string;
+  cross_reactive_foods: string[];
+  pfas_severity: string;
+}
+
+/**
+ * Get PFAS cross-reactivity data for a set of allergen IDs.
+ *
+ * Filters allergen seed data to only include allergens that:
+ * 1. Are in the provided list (typically top 5 from leaderboard)
+ * 2. Have non-empty cross_reactive_foods arrays
+ * 3. Have a pfas_severity other than "none"
+ *
+ * @param allergenIds - Allergen IDs to check (typically top 5)
+ * @returns PfasPanelData with matching entries
+ */
+export function getPfasData(allergenIds: string[]): PfasPanelData {
+  const idSet = new Set(allergenIds);
+
+  const entries: PfasCrossReactivity[] = (allergensSeed as SeedAllergen[])
+    .filter(
+      (a) =>
+        idSet.has(a.id) &&
+        a.cross_reactive_foods.length > 0 &&
+        a.pfas_severity !== "none",
+    )
+    .map((a) => ({
+      allergen_id: a.id,
+      common_name: a.common_name,
+      category: a.category as AllergenCategory,
+      cross_reactive_foods: a.cross_reactive_foods,
+      pfas_severity: a.pfas_severity as PfasSeverity,
+    }));
+
+  return {
+    entries,
+    hasData: entries.length > 0,
+  };
+}

--- a/lib/pfas/index.ts
+++ b/lib/pfas/index.ts
@@ -1,0 +1,8 @@
+/**
+ * PFAS (Pollen-Food Allergy Syndrome) Module
+ *
+ * Barrel export for PFAS business logic and types.
+ */
+
+export { getPfasData } from "./get-pfas-data";
+export type { PfasCrossReactivity, PfasPanelData } from "./types";

--- a/lib/pfas/types.ts
+++ b/lib/pfas/types.ts
@@ -1,0 +1,31 @@
+/**
+ * PFAS (Pollen-Food Allergy Syndrome) Types
+ *
+ * Type definitions for the food cross-reactivity panel.
+ * PFAS maps pollen allergens to cross-reactive foods that can
+ * cause oral allergy symptoms in sensitized individuals.
+ */
+
+import type { PfasSeverity, AllergenCategory } from "@/lib/supabase/types";
+
+/** A single allergen's cross-reactivity data */
+export interface PfasCrossReactivity {
+  /** Allergen ID from seed data */
+  allergen_id: string;
+  /** Human-readable allergen name */
+  common_name: string;
+  /** Allergen category (tree, weed, grass, etc.) */
+  category: AllergenCategory;
+  /** Foods that cross-react with this allergen */
+  cross_reactive_foods: string[];
+  /** Severity of PFAS reactions */
+  pfas_severity: PfasSeverity;
+}
+
+/** Grouped PFAS data for display, organized by allergen */
+export interface PfasPanelData {
+  /** Allergens from the user's top 5 that have cross-reactive foods */
+  entries: PfasCrossReactivity[];
+  /** Whether any cross-reactive data exists for this user's top allergens */
+  hasData: boolean;
+}

--- a/lib/subscription/constants.ts
+++ b/lib/subscription/constants.ts
@@ -24,8 +24,8 @@ export const PAYWALL_ENABLED =
  */
 export const TIER_FEATURES: Record<SubscriptionTier, PremiumFeature[]> = {
   free: [],
-  madness_plus: ["final_four", "pdf_report", "detailed_confidence", "full_rankings"],
-  madness_family: ["final_four", "pdf_report", "detailed_confidence", "full_rankings"],
+  madness_plus: ["final_four", "pdf_report", "detailed_confidence", "full_rankings", "pfas_panel"],
+  madness_family: ["final_four", "pdf_report", "detailed_confidence", "full_rankings", "pfas_panel"],
 };
 
 /**

--- a/lib/subscription/types.ts
+++ b/lib/subscription/types.ts
@@ -14,7 +14,8 @@ export type PremiumFeature =
   | "final_four"
   | "pdf_report"
   | "detailed_confidence"
-  | "full_rankings";
+  | "full_rankings"
+  | "pfas_panel";
 
 /** Result of checking a user's access level */
 export interface AccessStatus {


### PR DESCRIPTION
## Summary

- Add PFAS (Pollen-Food Allergy Syndrome) panel that shows cross-reactive foods for the user's top allergens
- Gate PFAS panel as a Madness+ premium feature (`pfas_panel`) with blur overlay and upgrade CTA for free users
- Source cross-reactivity data from allergen seed JSON (`cross_reactive_foods` / `pfas_severity` fields) -- not hardcoded
- Include FDA disclaimer, severity badges (mild OAS / moderate / systemic risk), and food tags
- Add `/api/pfas` route that returns PFAS data for authenticated users (food lists stripped for free tier)
- Integrate PFAS panel into the leaderboard component below the full rankings section
- 27 new tests covering business logic, component rendering, premium gating, and edge cases

## Test plan

- [x] PFAS panel appears for Madness+ user with birch in top 5 (shows apple, pear, cherry, celery)
- [x] PFAS panel hidden for free-tier user (food lists blurred, upgrade CTA shown)
- [x] PFAS panel hidden when no top-5 allergen has cross-reactive foods
- [x] Food list matches allergen seed data (not hardcoded)
- [x] FDA disclaimer visible on PFAS panel
- [x] All 660 tests pass (including 27 new PFAS tests)
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)