### PR TITLE
fix(referral): use crypto.getRandomValues() for referral code generation

### DIFF
--- a/lib/referral/code.ts
+++ b/lib/referral/code.ts
@@ -9,15 +9,21 @@
 import { REFERRAL_CODE_LENGTH, REFERRAL_CODE_CHARS } from "./constants";
 
 /**
- * Generate a random referral code.
+ * Generate a random referral code using cryptographically secure randomness.
+ *
+ * Uses crypto.getRandomValues() for better randomness and reduced collision
+ * risk at scale. Referral codes are not security tokens, but crypto-grade
+ * randomness is a low-cost quality improvement.
  *
  * @returns An 8-character alphanumeric code (e.g., "X7KP3RVN")
  */
 export function generateReferralCode(): string {
+  const randomBytes = new Uint8Array(REFERRAL_CODE_LENGTH);
+  crypto.getRandomValues(randomBytes);
+
   let code = "";
   for (let i = 0; i < REFERRAL_CODE_LENGTH; i++) {
-    const randomIndex = Math.floor(Math.random() * REFERRAL_CODE_CHARS.length);
-    code += REFERRAL_CODE_CHARS[randomIndex];
+    code += REFERRAL_CODE_CHARS[randomBytes[i] % REFERRAL_CODE_CHARS.length];
   }
   return code;
 }


### PR DESCRIPTION
## Summary

- Replace `Math.random()` with `crypto.getRandomValues()` in `generateReferralCode()` for better randomness and reduced collision risk at scale
- No change to code length (8) or character set — existing codes remain valid
- Quality improvement, not a security fix (referral codes are short-lived invite codes, not tokens)

Closes #68

## Changes

- `lib/referral/code.ts`: Use `crypto.getRandomValues(new Uint8Array(length))` and map bytes to the character set via modulo

## Test plan

- [x] All 15 existing referral code tests pass
- [x] All 684 project tests pass
- [x] Lint and typecheck clean
- [x] Code length and character set unchanged
- [x] No functional regression

Generated with [Claude Code](https://claude.ai/code)