### PR TITLE
feat(ui): implement Champ Health branding and Tailwind design system

### DIFF
--- a/__tests__/components/subscription/blur-overlay.test.tsx
+++ b/__tests__/components/subscription/blur-overlay.test.tsx
@@ -57,6 +57,6 @@ describe("BlurOverlay", () => {
     const lockOverlay = screen.getByTestId("blur-lock-overlay");
     const lockIcon = lockOverlay.querySelector("span[aria-hidden='true']");
     expect(lockIcon).toBeTruthy();
-    expect(lockIcon?.getAttribute("style")).toContain("pulse");
+    expect(lockIcon?.className).toContain("animate-pulse");
   });
 });

--- a/__tests__/theme/colors.test.ts
+++ b/__tests__/theme/colors.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Design Token Tests
+ *
+ * Validates that the centralized brand color tokens:
+ * - Export all required color categories
+ * - Have valid hex format for BRAND_COLORS
+ * - Have valid RGB tuple format for PDF_COLORS
+ * - Meet WCAG 2.1 AA contrast requirements for key text/background pairs
+ */
+
+import { describe, it, expect } from "vitest";
+import { BRAND_COLORS, PDF_COLORS } from "@/lib/theme";
+
+/* ------------------------------------------------------------------ */
+/* Helper: relative luminance for WCAG contrast ratio                  */
+/* ------------------------------------------------------------------ */
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [
+    parseInt(h.substring(0, 2), 16),
+    parseInt(h.substring(2, 4), 16),
+    parseInt(h.substring(4, 6), 16),
+  ];
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  const [rs, gs, bs] = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+}
+
+function contrastRatio(hex1: string, hex2: string): number {
+  const [r1, g1, b1] = hexToRgb(hex1);
+  const [r2, g2, b2] = hexToRgb(hex2);
+  const l1 = relativeLuminance(r1, g1, b1);
+  const l2 = relativeLuminance(r2, g2, b2);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("BRAND_COLORS", () => {
+  it("exports all required color categories", () => {
+    expect(BRAND_COLORS.primary).toBeDefined();
+    expect(BRAND_COLORS.accent).toBeDefined();
+    expect(BRAND_COLORS.warning).toBeDefined();
+    expect(BRAND_COLORS.error).toBeDefined();
+    expect(BRAND_COLORS.premium).toBeDefined();
+    expect(BRAND_COLORS.surface).toBeDefined();
+    expect(BRAND_COLORS.text).toBeDefined();
+  });
+
+  it("all values are valid hex colors", () => {
+    const hexRegex = /^#[0-9a-fA-F]{6}$/;
+    for (const [key, value] of Object.entries(BRAND_COLORS)) {
+      expect(value, `${key} should be a valid hex color`).toMatch(hexRegex);
+    }
+  });
+
+  it("includes light and dark variants for primary colors", () => {
+    expect(BRAND_COLORS.primaryLight).toBeDefined();
+    expect(BRAND_COLORS.primaryDark).toBeDefined();
+    expect(BRAND_COLORS.accentLight).toBeDefined();
+    expect(BRAND_COLORS.accentDark).toBeDefined();
+    expect(BRAND_COLORS.warningLight).toBeDefined();
+    expect(BRAND_COLORS.warningDark).toBeDefined();
+    expect(BRAND_COLORS.errorLight).toBeDefined();
+    expect(BRAND_COLORS.errorDark).toBeDefined();
+    expect(BRAND_COLORS.premiumLight).toBeDefined();
+    expect(BRAND_COLORS.premiumDark).toBeDefined();
+  });
+
+  it("includes text hierarchy colors", () => {
+    expect(BRAND_COLORS.text).toBeDefined();
+    expect(BRAND_COLORS.textSecondary).toBeDefined();
+    expect(BRAND_COLORS.textMuted).toBeDefined();
+    expect(BRAND_COLORS.textFaint).toBeDefined();
+  });
+});
+
+describe("PDF_COLORS", () => {
+  it("exports all required PDF color tuples", () => {
+    expect(PDF_COLORS.primary).toBeDefined();
+    expect(PDF_COLORS.gold).toBeDefined();
+    expect(PDF_COLORS.text).toBeDefined();
+    expect(PDF_COLORS.textMuted).toBeDefined();
+    expect(PDF_COLORS.border).toBeDefined();
+    expect(PDF_COLORS.amberBg).toBeDefined();
+    expect(PDF_COLORS.amberText).toBeDefined();
+  });
+
+  it("all tuples are [R, G, B] with values 0-255", () => {
+    for (const [key, tuple] of Object.entries(PDF_COLORS)) {
+      expect(tuple, `${key} should be a 3-element array`).toHaveLength(3);
+      for (const val of tuple) {
+        expect(val, `${key} values should be 0-255`).toBeGreaterThanOrEqual(0);
+        expect(val, `${key} values should be 0-255`).toBeLessThanOrEqual(255);
+      }
+    }
+  });
+});
+
+describe("WCAG 2.1 AA Contrast Requirements", () => {
+  // WCAG AA requires 4.5:1 for normal text, 3:1 for large text
+
+  it("primary text on white meets 4.5:1 contrast", () => {
+    const ratio = contrastRatio(BRAND_COLORS.text, BRAND_COLORS.surface);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("secondary text on white meets 4.5:1 contrast", () => {
+    const ratio = contrastRatio(BRAND_COLORS.textSecondary, BRAND_COLORS.surface);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("muted text on white meets 3:1 contrast (large text threshold)", () => {
+    const ratio = contrastRatio(BRAND_COLORS.textMuted, BRAND_COLORS.surface);
+    expect(ratio).toBeGreaterThanOrEqual(3);
+  });
+
+  it("warning dark text on warning light bg meets 4.5:1 contrast", () => {
+    const ratio = contrastRatio(BRAND_COLORS.warningDark, BRAND_COLORS.warningLight);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("error dark text on error light bg meets 4.5:1 contrast", () => {
+    const ratio = contrastRatio(BRAND_COLORS.errorDark, BRAND_COLORS.errorLight);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("white text on primary bg meets 4.5:1 contrast", () => {
+    const ratio = contrastRatio("#ffffff", BRAND_COLORS.primary);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("white text on premium bg meets 4.5:1 contrast", () => {
+    const ratio = contrastRatio("#ffffff", BRAND_COLORS.premium);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,127 @@
+@import "tailwindcss";
+
+/*
+ * Champ Health / Allergy Madness Design System
+ *
+ * Brand tokens defined via Tailwind v4 @theme directive.
+ * All semantic colors are available as utility classes:
+ *   bg-brand-primary, text-brand-accent, border-brand-warning, etc.
+ *
+ * CSS custom properties are also set on :root for runtime access
+ * and PDF report usage.
+ */
+
+@theme {
+  /* ------------------------------------------------------------------ */
+  /* Brand Colors                                                        */
+  /* ------------------------------------------------------------------ */
+
+  /* Primary — Health-forward blue */
+  --color-brand-primary: #2563eb;
+  --color-brand-primary-light: #dbeafe;
+  --color-brand-primary-dark: #1d4ed8;
+
+  /* Accent — Wellness green */
+  --color-brand-accent: #16a34a;
+  --color-brand-accent-light: #dcfce7;
+  --color-brand-accent-dark: #15803d;
+
+  /* Warning — FDA disclaimer amber */
+  --color-brand-warning: #d97706;
+  --color-brand-warning-light: #fffbeb;
+  --color-brand-warning-dark: #92400e;
+
+  /* Error — Alert red */
+  --color-brand-error: #dc2626;
+  --color-brand-error-light: #fef2f2;
+  --color-brand-error-dark: #991b1b;
+
+  /* Premium — Madness+ purple */
+  --color-brand-premium: #9333ea;
+  --color-brand-premium-light: #faf5ff;
+  --color-brand-premium-dark: #581c87;
+
+  /* Surface / Neutral */
+  --color-brand-surface: #ffffff;
+  --color-brand-surface-muted: #f9fafb;
+  --color-brand-border: #e5e7eb;
+  --color-brand-border-light: #f3f4f6;
+
+  /* Text */
+  --color-brand-text: #111827;
+  --color-brand-text-secondary: #4b5563;
+  --color-brand-text-muted: #6b7280;
+  --color-brand-text-faint: #9ca3af;
+
+  /* ------------------------------------------------------------------ */
+  /* Typography                                                          */
+  /* ------------------------------------------------------------------ */
+
+  --font-family-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+
+  /* ------------------------------------------------------------------ */
+  /* Border Radius                                                       */
+  /* ------------------------------------------------------------------ */
+
+  --radius-card: 0.5rem;
+  --radius-button: 0.375rem;
+  --radius-pill: 9999px;
+  --radius-xl: 0.75rem;
+}
+
+/* ------------------------------------------------------------------ */
+/* CSS Custom Properties (for runtime/PDF access)                       */
+/* ------------------------------------------------------------------ */
+
+:root {
+  /* Primary */
+  --champ-primary: #2563eb;
+  --champ-primary-light: #dbeafe;
+  --champ-primary-dark: #1d4ed8;
+  --champ-primary-rgb: 37, 99, 235;
+
+  /* Accent */
+  --champ-accent: #16a34a;
+  --champ-accent-light: #dcfce7;
+  --champ-accent-dark: #15803d;
+  --champ-accent-rgb: 22, 163, 74;
+
+  /* Warning */
+  --champ-warning: #d97706;
+  --champ-warning-light: #fffbeb;
+  --champ-warning-dark: #92400e;
+  --champ-warning-rgb: 217, 119, 6;
+
+  /* Error */
+  --champ-error: #dc2626;
+  --champ-error-light: #fef2f2;
+  --champ-error-dark: #991b1b;
+  --champ-error-rgb: 220, 38, 38;
+
+  /* Premium */
+  --champ-premium: #9333ea;
+  --champ-premium-light: #faf5ff;
+  --champ-premium-dark: #581c87;
+  --champ-premium-rgb: 147, 51, 234;
+
+  /* Surface */
+  --champ-surface: #ffffff;
+  --champ-surface-muted: #f9fafb;
+  --champ-border: #e5e7eb;
+  --champ-border-light: #f3f4f6;
+
+  /* Text */
+  --champ-text: #111827;
+  --champ-text-secondary: #4b5563;
+  --champ-text-muted: #6b7280;
+  --champ-text-faint: #9ca3af;
+}
+
+/* ------------------------------------------------------------------ */
+/* Base styles                                                          */
+/* ------------------------------------------------------------------ */
+
 *,
 *::before,
 *::after {
@@ -7,37 +131,35 @@
 }
 
 body {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family: var(--font-family-sans);
   line-height: 1.6;
-  color: #1a1a1a;
+  color: var(--champ-text);
   max-width: 640px;
   margin: 0 auto;
   padding: 2rem 1rem;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-h1 {
-  font-size: 1.75rem;
-  margin-bottom: 0.5rem;
+/* ------------------------------------------------------------------ */
+/* Keyframes (used by components)                                       */
+/* ------------------------------------------------------------------ */
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-h2 {
-  font-size: 1.25rem;
-  margin-top: 1.5rem;
-  margin-bottom: 0.5rem;
-}
-
-ul {
-  padding-left: 1.5rem;
-}
-
-li {
-  margin-bottom: 0.25rem;
-}
-
-code {
-  background: #f0f0f0;
-  padding: 0.15rem 0.35rem;
-  border-radius: 3px;
-  font-size: 0.9em;
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,12 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Agile Flow",
-  description: "Workshop template for agentic development workflows",
+  title: "Allergy Madness — The Digital Allergy Test by Champ Health",
+  description:
+    "Discover your top allergen triggers with Allergy Madness, a free predictive allergy screening tool by Champ Health.",
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({

--- a/components/checkin/checkin-form.tsx
+++ b/components/checkin/checkin-form.tsx
@@ -40,7 +40,6 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
     setFormData((prev) => ({
       ...prev,
       severity,
-      // Clear symptoms if severity goes to 0
       symptoms: severity === 0 ? {} : prev.symptoms,
     }));
   }, []);
@@ -103,34 +102,12 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
     return (
       <div
         className="rounded-lg border border-green-200 bg-green-50 p-6 text-center"
-        style={{
-          borderRadius: "0.5rem",
-          border: "1px solid #bbf7d0",
-          backgroundColor: "#f0fdf4",
-          padding: "1.5rem",
-          textAlign: "center",
-        }}
         data-testid="checkin-complete"
       >
-        <p
-          className="text-lg font-semibold text-green-800"
-          style={{
-            fontSize: "1.125rem",
-            fontWeight: 600,
-            color: "#166534",
-            margin: "0 0 0.5rem 0",
-          }}
-        >
+        <p className="text-lg font-semibold text-green-800">
           {submitted ? "Check-in submitted!" : "Already checked in today"}
         </p>
-        <p
-          className="text-sm text-green-600"
-          style={{
-            fontSize: "0.875rem",
-            color: "#16a34a",
-            margin: 0,
-          }}
-        >
+        <p className="mt-2 text-sm text-green-600">
           {submitted
             ? "Your leaderboard is being updated."
             : "Come back tomorrow for your next check-in."}
@@ -143,7 +120,6 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
     <form
       onSubmit={handleSubmit}
       className="space-y-8"
-      style={{ display: "flex", flexDirection: "column", gap: "2rem" }}
       data-testid="checkin-form"
     >
       {/* Error message */}
@@ -151,14 +127,6 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
         <div
           role="alert"
           className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
-          style={{
-            borderRadius: "0.5rem",
-            border: "1px solid #fecaca",
-            backgroundColor: "#fef2f2",
-            padding: "0.75rem 1rem",
-            fontSize: "0.875rem",
-            color: "#b91c1c",
-          }}
           data-testid="checkin-error"
         >
           {error}
@@ -191,35 +159,14 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
         type="submit"
         disabled={isSubmitting}
         data-testid="checkin-submit"
-        className="w-full rounded-lg bg-blue-600 px-4 py-3 text-base font-semibold text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        style={{
-          width: "100%",
-          borderRadius: "0.5rem",
-          backgroundColor: isSubmitting ? "#93c5fd" : "#2563eb",
-          padding: "0.75rem 1rem",
-          fontSize: "1rem",
-          fontWeight: 600,
-          color: "#ffffff",
-          border: "none",
-          cursor: isSubmitting ? "not-allowed" : "pointer",
-          opacity: isSubmitting ? 0.5 : 1,
-          transition: "background-color 0.15s",
-        }}
+        className="w-full rounded-lg bg-blue-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isSubmitting ? "Submitting..." : formData.severity === 0 ? "Log Symptom-Free Day" : "Submit Check-in"}
       </button>
 
       {/* Severity 0 hint */}
       {formData.severity === 0 && (
-        <p
-          className="text-xs text-gray-500 text-center"
-          style={{
-            fontSize: "0.75rem",
-            color: "#6b7280",
-            textAlign: "center",
-            margin: 0,
-          }}
-        >
+        <p className="text-center text-xs text-gray-500">
           Logging a symptom-free day helps calibrate your Environmental Forecast.
         </p>
       )}

--- a/components/checkin/severity-slider.tsx
+++ b/components/checkin/severity-slider.tsx
@@ -16,30 +16,12 @@ interface SeveritySliderProps {
 
 export function SeveritySlider({ value, onChange }: SeveritySliderProps) {
   return (
-    <fieldset
-      style={{ border: "none", padding: 0, margin: 0 }}
-    >
-      <legend
-        className="text-base font-semibold text-gray-900 mb-3"
-        style={{
-          fontSize: "1rem",
-          fontWeight: 600,
-          color: "#111827",
-          marginBottom: "0.75rem",
-          padding: 0,
-        }}
-      >
+    <fieldset className="border-none p-0 m-0">
+      <legend className="mb-3 text-base font-semibold text-gray-900">
         How are your allergies today?
       </legend>
 
-      <div
-        className="grid grid-cols-2 gap-3"
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(2, 1fr)",
-          gap: "0.75rem",
-        }}
-      >
+      <div className="grid grid-cols-2 gap-3">
         {SEVERITY_LEVELS.map((level) => {
           const isSelected = value === level.value;
           return (
@@ -51,62 +33,23 @@ export function SeveritySlider({ value, onChange }: SeveritySliderProps) {
               aria-label={`${level.label}: ${level.description}`}
               data-testid={`severity-${level.value}`}
               onClick={() => onChange(level.value)}
-              className={`rounded-lg border-2 p-3 text-left transition-colors ${
+              className={`cursor-pointer rounded-lg border-2 p-3 text-left transition-colors ${
                 isSelected
                   ? "border-blue-600 bg-blue-50"
                   : "border-gray-200 bg-white hover:border-gray-300"
               }`}
-              style={{
-                borderRadius: "0.5rem",
-                border: isSelected
-                  ? "2px solid #2563eb"
-                  : "2px solid #e5e7eb",
-                backgroundColor: isSelected ? "#eff6ff" : "#ffffff",
-                padding: "0.75rem",
-                textAlign: "left",
-                cursor: "pointer",
-                transition: "border-color 0.15s, background-color 0.15s",
-              }}
             >
-              <div
-                className="flex items-center gap-2 mb-1"
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "0.5rem",
-                  marginBottom: "0.25rem",
-                }}
-              >
+              <div className="mb-1 flex items-center gap-2">
                 <span
                   className="inline-block h-3 w-3 rounded-full"
-                  style={{
-                    display: "inline-block",
-                    height: "0.75rem",
-                    width: "0.75rem",
-                    borderRadius: "9999px",
-                    backgroundColor: level.color,
-                  }}
+                  style={{ backgroundColor: level.color }}
                   aria-hidden="true"
                 />
-                <span
-                  className="text-sm font-semibold text-gray-900"
-                  style={{
-                    fontSize: "0.875rem",
-                    fontWeight: 600,
-                    color: "#111827",
-                  }}
-                >
+                <span className="text-sm font-semibold text-gray-900">
                   {level.label}
                 </span>
               </div>
-              <p
-                className="text-xs text-gray-500"
-                style={{
-                  fontSize: "0.75rem",
-                  color: "#6b7280",
-                  margin: 0,
-                }}
-              >
+              <p className="text-xs text-gray-500">
                 {level.description}
               </p>
             </button>

--- a/components/checkin/symptom-zones.tsx
+++ b/components/checkin/symptom-zones.tsx
@@ -45,26 +45,12 @@ export function SymptomZones({ symptoms, onChange }: SymptomZonesProps) {
   };
 
   return (
-    <fieldset
-      style={{ border: "none", padding: 0, margin: 0 }}
-    >
-      <legend
-        className="text-base font-semibold text-gray-900 mb-3"
-        style={{
-          fontSize: "1rem",
-          fontWeight: 600,
-          color: "#111827",
-          marginBottom: "0.75rem",
-          padding: 0,
-        }}
-      >
+    <fieldset className="border-none p-0 m-0">
+      <legend className="mb-3 text-base font-semibold text-gray-900">
         Which areas are affected?
       </legend>
 
-      <div
-        className="space-y-2"
-        style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
-      >
+      <div className="space-y-2">
         {SYMPTOM_ZONES.map((zone) => {
           const isExpanded = expandedZones.has(zone.id);
           const activeCount = getZoneSymptomCount(zone.id);
@@ -72,12 +58,7 @@ export function SymptomZones({ symptoms, onChange }: SymptomZonesProps) {
           return (
             <div
               key={zone.id}
-              className="rounded-lg border border-gray-200 overflow-hidden"
-              style={{
-                borderRadius: "0.5rem",
-                border: "1px solid #e5e7eb",
-                overflow: "hidden",
-              }}
+              className="overflow-hidden rounded-lg border border-gray-200"
               data-testid={`zone-${zone.id}`}
             >
               {/* Zone header — toggle expand */}
@@ -86,87 +67,32 @@ export function SymptomZones({ symptoms, onChange }: SymptomZonesProps) {
                 aria-expanded={isExpanded}
                 aria-controls={`zone-panel-${zone.id}`}
                 onClick={() => toggleZone(zone.id)}
-                className="flex w-full items-center justify-between px-4 py-3 bg-gray-50 hover:bg-gray-100 transition-colors"
-                style={{
-                  display: "flex",
-                  width: "100%",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  padding: "0.75rem 1rem",
-                  backgroundColor: "#f9fafb",
-                  border: "none",
-                  cursor: "pointer",
-                  transition: "background-color 0.15s",
-                }}
+                className="flex w-full cursor-pointer items-center justify-between border-none bg-gray-50 px-4 py-3 transition-colors hover:bg-gray-100"
               >
-                <div
-                  className="flex items-center gap-3"
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "0.75rem",
-                  }}
-                >
+                <div className="flex items-center gap-3">
                   <span
                     className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-blue-700"
-                    style={{
-                      display: "flex",
-                      height: "2rem",
-                      width: "2rem",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      borderRadius: "9999px",
-                      backgroundColor: "#dbeafe",
-                      fontSize: "0.875rem",
-                      fontWeight: 700,
-                      color: "#1d4ed8",
-                    }}
                     aria-hidden="true"
                   >
                     {zone.icon}
                   </span>
-                  <span
-                    className="text-sm font-medium text-gray-900"
-                    style={{
-                      fontSize: "0.875rem",
-                      fontWeight: 500,
-                      color: "#111827",
-                    }}
-                  >
+                  <span className="text-sm font-medium text-gray-900">
                     {zone.label}
                   </span>
                 </div>
 
-                <div
-                  className="flex items-center gap-2"
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "0.5rem",
-                  }}
-                >
+                <div className="flex items-center gap-2">
                   {activeCount > 0 && (
                     <span
                       className="rounded-full bg-blue-600 px-2 py-0.5 text-xs font-bold text-white"
-                      style={{
-                        borderRadius: "9999px",
-                        backgroundColor: "#2563eb",
-                        padding: "0.125rem 0.5rem",
-                        fontSize: "0.75rem",
-                        fontWeight: 700,
-                        color: "#ffffff",
-                      }}
                       aria-label={`${activeCount} symptom${activeCount !== 1 ? "s" : ""} selected`}
                     >
                       {activeCount}
                     </span>
                   )}
                   <span
-                    className="text-gray-400 text-sm"
+                    className="text-sm text-gray-400 transition-transform"
                     style={{
-                      color: "#9ca3af",
-                      fontSize: "0.875rem",
-                      transition: "transform 0.15s",
                       transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
                     }}
                     aria-hidden="true"
@@ -182,46 +108,23 @@ export function SymptomZones({ symptoms, onChange }: SymptomZonesProps) {
                   id={`zone-panel-${zone.id}`}
                   role="group"
                   aria-label={`${zone.label} symptoms`}
-                  className="px-4 py-3 space-y-2"
-                  style={{
-                    padding: "0.75rem 1rem",
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "0.5rem",
-                  }}
+                  className="space-y-2 px-4 py-3"
                 >
                   {zone.symptoms.map((symptom) => {
                     const isChecked = !!symptoms[symptom.key];
                     return (
                       <label
                         key={symptom.key}
-                        className="flex items-center gap-3 cursor-pointer"
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "0.75rem",
-                          cursor: "pointer",
-                        }}
+                        className="flex cursor-pointer items-center gap-3"
                       >
                         <input
                           type="checkbox"
                           checked={isChecked}
                           onChange={() => toggleSymptom(symptom.key)}
                           data-testid={`symptom-${symptom.key}`}
-                          className="h-5 w-5 rounded border-gray-300 text-blue-600"
-                          style={{
-                            height: "1.25rem",
-                            width: "1.25rem",
-                            accentColor: "#2563eb",
-                          }}
+                          className="h-5 w-5 rounded border-gray-300 accent-blue-600"
                         />
-                        <span
-                          className="text-sm text-gray-700"
-                          style={{
-                            fontSize: "0.875rem",
-                            color: "#374151",
-                          }}
-                        >
+                        <span className="text-sm text-gray-700">
                           {symptom.label}
                         </span>
                       </label>

--- a/components/checkin/timing-selector.tsx
+++ b/components/checkin/timing-selector.tsx
@@ -24,33 +24,14 @@ export function TimingSelector({
   onIndoorsChange,
 }: TimingSelectorProps) {
   return (
-    <div
-      className="space-y-6"
-      style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
-    >
+    <div className="space-y-6">
       {/* Peak time */}
-      <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
-        <legend
-          className="text-base font-semibold text-gray-900 mb-3"
-          style={{
-            fontSize: "1rem",
-            fontWeight: 600,
-            color: "#111827",
-            marginBottom: "0.75rem",
-            padding: 0,
-          }}
-        >
+      <fieldset className="border-none p-0 m-0">
+        <legend className="mb-3 text-base font-semibold text-gray-900">
           When are symptoms worst?
         </legend>
 
-        <div
-          className="grid grid-cols-2 gap-2"
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(2, 1fr)",
-            gap: "0.5rem",
-          }}
-        >
+        <div className="grid grid-cols-2 gap-2">
           {TIMING_OPTIONS.map((option) => {
             const isSelected = peakTime === option.value;
             return (
@@ -61,24 +42,11 @@ export function TimingSelector({
                 aria-checked={isSelected}
                 data-testid={`timing-${option.value}`}
                 onClick={() => onPeakTimeChange(option.value)}
-                className={`rounded-lg border-2 px-4 py-2 text-sm font-medium transition-colors ${
+                className={`cursor-pointer rounded-lg border-2 px-4 py-2 text-sm font-medium transition-colors ${
                   isSelected
                     ? "border-blue-600 bg-blue-50 text-blue-700"
                     : "border-gray-200 bg-white text-gray-700 hover:border-gray-300"
                 }`}
-                style={{
-                  borderRadius: "0.5rem",
-                  border: isSelected
-                    ? "2px solid #2563eb"
-                    : "2px solid #e5e7eb",
-                  backgroundColor: isSelected ? "#eff6ff" : "#ffffff",
-                  padding: "0.5rem 1rem",
-                  fontSize: "0.875rem",
-                  fontWeight: 500,
-                  color: isSelected ? "#1d4ed8" : "#374151",
-                  cursor: "pointer",
-                  transition: "border-color 0.15s, background-color 0.15s",
-                }}
               >
                 {option.label}
               </button>
@@ -88,28 +56,12 @@ export function TimingSelector({
       </fieldset>
 
       {/* Indoor / outdoor context */}
-      <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
-        <legend
-          className="text-base font-semibold text-gray-900 mb-3"
-          style={{
-            fontSize: "1rem",
-            fontWeight: 600,
-            color: "#111827",
-            marginBottom: "0.75rem",
-            padding: 0,
-          }}
-        >
+      <fieldset className="border-none p-0 m-0">
+        <legend className="mb-3 text-base font-semibold text-gray-900">
           Where did you spend most of your time?
         </legend>
 
-        <div
-          className="grid grid-cols-2 gap-2"
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(2, 1fr)",
-            gap: "0.5rem",
-          }}
-        >
+        <div className="grid grid-cols-2 gap-2">
           {[
             { value: true, label: "Mostly indoors" },
             { value: false, label: "Mostly outdoors" },
@@ -123,24 +75,11 @@ export function TimingSelector({
                 aria-checked={isSelected}
                 data-testid={`indoors-${option.value}`}
                 onClick={() => onIndoorsChange(option.value)}
-                className={`rounded-lg border-2 px-4 py-2 text-sm font-medium transition-colors ${
+                className={`cursor-pointer rounded-lg border-2 px-4 py-2 text-sm font-medium transition-colors ${
                   isSelected
                     ? "border-blue-600 bg-blue-50 text-blue-700"
                     : "border-gray-200 bg-white text-gray-700 hover:border-gray-300"
                 }`}
-                style={{
-                  borderRadius: "0.5rem",
-                  border: isSelected
-                    ? "2px solid #2563eb"
-                    : "2px solid #e5e7eb",
-                  backgroundColor: isSelected ? "#eff6ff" : "#ffffff",
-                  padding: "0.5rem 1rem",
-                  fontSize: "0.875rem",
-                  fontWeight: 500,
-                  color: isSelected ? "#1d4ed8" : "#374151",
-                  cursor: "pointer",
-                  transition: "border-color 0.15s, background-color 0.15s",
-                }}
               >
                 {option.label}
               </button>

--- a/components/leaderboard/blur-overlay.tsx
+++ b/components/leaderboard/blur-overlay.tsx
@@ -19,16 +19,10 @@ export function BlurOverlay({
     <div
       data-testid="blur-overlay"
       className="relative"
-      style={{ position: "relative" }}
     >
       {/* Blurred content */}
       <div
         className="pointer-events-none select-none blur-md"
-        style={{
-          filter: "blur(8px)",
-          pointerEvents: "none",
-          userSelect: "none",
-        }}
         aria-hidden="true"
       >
         {children}
@@ -38,43 +32,20 @@ export function BlurOverlay({
       <div
         data-testid="blur-lock-overlay"
         className="absolute inset-0 flex flex-col items-center justify-center"
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
       >
         <span
-          className="mb-2 text-3xl"
-          style={{
-            fontSize: "1.875rem",
-            marginBottom: "0.5rem",
-            animation: "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite",
-          }}
+          className="mb-2 animate-pulse text-3xl"
           aria-hidden="true"
         >
           &#x1F512;
         </span>
         {!showUpgradeCta && (
-          <p
-            className="text-sm font-medium text-gray-600"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#4b5563",
-            }}
-          >
+          <p className="text-sm font-medium text-gray-600">
             Upgrade to Madness+ to reveal
           </p>
         )}
         {showUpgradeCta && (
-          <div style={{ marginTop: "0.5rem" }}>
+          <div className="mt-2">
             <UpgradeCta
               feature={featureLabel}
               referralsNeeded={referralsNeeded}

--- a/components/leaderboard/category-icon.tsx
+++ b/components/leaderboard/category-icon.tsx
@@ -30,7 +30,6 @@ export function CategoryIcon({ category }: CategoryIconProps) {
       data-testid="category-icon"
       data-category={category}
       className="text-lg"
-      style={{ fontSize: "1.125rem" }}
     >
       {config.icon}
     </span>

--- a/components/leaderboard/confidence-badge.tsx
+++ b/components/leaderboard/confidence-badge.tsx
@@ -13,30 +13,22 @@ interface ConfidenceBadgeProps {
 
 const TIER_CONFIG: Record<
   ConfidenceTier,
-  { label: string; bgColor: string; textColor: string; tailwind: string }
+  { label: string; tailwind: string }
 > = {
   low: {
     label: "Low",
-    bgColor: "#dbeafe",
-    textColor: "#1e40af",
     tailwind: "bg-blue-100 text-blue-800",
   },
   medium: {
     label: "Medium",
-    bgColor: "#fef9c3",
-    textColor: "#854d0e",
     tailwind: "bg-yellow-100 text-yellow-800",
   },
   high: {
     label: "High",
-    bgColor: "#fed7aa",
-    textColor: "#9a3412",
     tailwind: "bg-orange-100 text-orange-800",
   },
   very_high: {
     label: "Very High",
-    bgColor: "#fecaca",
-    textColor: "#991b1b",
     tailwind: "bg-red-100 text-red-800",
   },
 };
@@ -49,16 +41,6 @@ export function ConfidenceBadge({ tier }: ConfidenceBadgeProps) {
       data-testid="confidence-badge"
       data-tier={tier}
       className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${config.tailwind}`}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        borderRadius: "9999px",
-        padding: "0.125rem 0.5rem",
-        fontSize: "0.75rem",
-        fontWeight: 500,
-        backgroundColor: config.bgColor,
-        color: config.textColor,
-      }}
     >
       {config.label}
     </span>

--- a/components/leaderboard/environmental-forecast.tsx
+++ b/components/leaderboard/environmental-forecast.tsx
@@ -98,25 +98,8 @@ function DataCard({
   children: React.ReactNode;
 }) {
   return (
-    <div
-      className="rounded-lg border border-gray-200 bg-white p-4"
-      style={{
-        borderRadius: "0.5rem",
-        border: "1px solid #e5e7eb",
-        backgroundColor: "#ffffff",
-        padding: "1rem",
-      }}
-    >
-      <h3
-        className="mb-3 text-sm font-semibold text-gray-700"
-        style={{
-          fontSize: "0.875rem",
-          fontWeight: 600,
-          color: "#374151",
-          marginBottom: "0.75rem",
-          margin: "0 0 0.75rem 0",
-        }}
-      >
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-gray-700">
         {title}
       </h3>
       {children}
@@ -134,28 +117,13 @@ function DataRow({
   color?: string;
 }) {
   return (
-    <div
-      className="flex items-center justify-between py-1"
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        padding: "0.25rem 0",
-      }}
-    >
-      <span
-        className="text-sm text-gray-600"
-        style={{ fontSize: "0.875rem", color: "#4b5563" }}
-      >
+    <div className="flex items-center justify-between py-1">
+      <span className="text-sm text-gray-600">
         {label}
       </span>
       <span
         className="text-sm font-medium"
-        style={{
-          fontSize: "0.875rem",
-          fontWeight: 500,
-          color: color ?? "#111827",
-        }}
+        style={{ color: color ?? "#111827" }}
       >
         {value}
       </span>
@@ -168,17 +136,11 @@ function LoadingSkeleton() {
     <div
       data-testid="forecast-loading"
       className="space-y-4"
-      style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
     >
       {[1, 2, 3].map((i) => (
         <div
           key={i}
           className="h-24 animate-pulse rounded-lg bg-gray-100"
-          style={{
-            height: "6rem",
-            borderRadius: "0.5rem",
-            backgroundColor: "#f3f4f6",
-          }}
         />
       ))}
     </div>
@@ -190,18 +152,8 @@ function NoDataMessage() {
     <div
       data-testid="forecast-no-data"
       className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center"
-      style={{
-        borderRadius: "0.5rem",
-        border: "1px solid #e5e7eb",
-        backgroundColor: "#f9fafb",
-        padding: "1.5rem",
-        textAlign: "center",
-      }}
     >
-      <p
-        className="text-sm text-gray-600"
-        style={{ fontSize: "0.875rem", color: "#4b5563", margin: 0 }}
-      >
+      <p className="text-sm text-gray-600">
         Environmental data is not available. Please ensure your home location is
         set in your profile to receive local forecasts.
       </p>
@@ -229,49 +181,18 @@ export function EnvironmentalForecast({
     <div
       data-testid="environmental-forecast"
       className="space-y-4"
-      style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
     >
       {/* Good news banner */}
-      <div
-        className="rounded-xl border border-green-200 bg-green-50 p-5"
-        style={{
-          borderRadius: "0.75rem",
-          border: "1px solid #bbf7d0",
-          backgroundColor: "#f0fdf4",
-          padding: "1.25rem",
-        }}
-      >
-        <div
-          className="flex items-center gap-3"
-          style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}
-        >
-          <span
-            className="text-2xl"
-            style={{ fontSize: "1.5rem" }}
-            aria-hidden="true"
-          >
+      <div className="rounded-xl border border-green-200 bg-green-50 p-5">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl" aria-hidden="true">
             &#x2600;
           </span>
           <div>
-            <h2
-              className="text-base font-bold text-green-800"
-              style={{
-                fontSize: "1rem",
-                fontWeight: 700,
-                color: "#166534",
-                margin: 0,
-              }}
-            >
+            <h2 className="text-base font-bold text-green-800">
               No Symptoms Today
             </h2>
-            <p
-              className="mt-1 text-sm text-green-700"
-              style={{
-                fontSize: "0.875rem",
-                color: "#15803d",
-                margin: "0.25rem 0 0 0",
-              }}
-            >
+            <p className="mt-1 text-sm text-green-700">
               Great news! Here is what is currently in the air around you.
             </p>
           </div>
@@ -308,23 +229,8 @@ export function EnvironmentalForecast({
               color={upiColor(data.pollen.upi_weed)}
             />
             {data.pollen.species.length > 0 && (
-              <div
-                className="mt-2 border-t border-gray-100 pt-2"
-                style={{
-                  marginTop: "0.5rem",
-                  borderTop: "1px solid #f3f4f6",
-                  paddingTop: "0.5rem",
-                }}
-              >
-                <p
-                  className="mb-1 text-xs font-medium text-gray-500"
-                  style={{
-                    fontSize: "0.75rem",
-                    fontWeight: 500,
-                    color: "#6b7280",
-                    margin: "0 0 0.25rem 0",
-                  }}
-                >
+              <div className="mt-2 border-t border-gray-100 pt-2">
+                <p className="mb-1 text-xs font-medium text-gray-500">
                   Active Species
                 </p>
                 {data.pollen.species
@@ -346,32 +252,16 @@ export function EnvironmentalForecast({
           <DataCard title="Air Quality">
             {data.aqi.aqi !== null ? (
               <>
-                <div
-                  className="mb-2 flex items-baseline gap-2"
-                  style={{
-                    display: "flex",
-                    alignItems: "baseline",
-                    gap: "0.5rem",
-                    marginBottom: "0.5rem",
-                  }}
-                >
+                <div className="mb-2 flex items-baseline gap-2">
                   <span
                     className="text-2xl font-bold"
-                    style={{
-                      fontSize: "1.5rem",
-                      fontWeight: 700,
-                      color: aqiColor(data.aqi.aqi),
-                    }}
+                    style={{ color: aqiColor(data.aqi.aqi) }}
                   >
                     {data.aqi.aqi}
                   </span>
                   <span
                     className="text-sm font-medium"
-                    style={{
-                      fontSize: "0.875rem",
-                      fontWeight: 500,
-                      color: aqiColor(data.aqi.aqi),
-                    }}
+                    style={{ color: aqiColor(data.aqi.aqi) }}
                   >
                     {aqiLabel(data.aqi.aqi)}
                   </span>
@@ -395,24 +285,13 @@ export function EnvironmentalForecast({
                   />
                 )}
                 {data.aqi.station && (
-                  <p
-                    className="mt-2 text-xs text-gray-400"
-                    style={{
-                      fontSize: "0.75rem",
-                      color: "#9ca3af",
-                      marginTop: "0.5rem",
-                      margin: "0.5rem 0 0 0",
-                    }}
-                  >
+                  <p className="mt-2 text-xs text-gray-400">
                     Station: {data.aqi.station}
                   </p>
                 )}
               </>
             ) : (
-              <p
-                className="text-sm text-gray-500"
-                style={{ fontSize: "0.875rem", color: "#6b7280", margin: 0 }}
-              >
+              <p className="text-sm text-gray-500">
                 AQI data unavailable for your location.
               </p>
             )}
@@ -446,10 +325,7 @@ export function EnvironmentalForecast({
                 )}
               </>
             ) : (
-              <p
-                className="text-sm text-gray-500"
-                style={{ fontSize: "0.875rem", color: "#6b7280", margin: 0 }}
-              >
+              <p className="text-sm text-gray-500">
                 Weather data unavailable for your location.
               </p>
             )}
@@ -459,12 +335,6 @@ export function EnvironmentalForecast({
           {data.region && (
             <p
               className="text-center text-xs text-gray-400"
-              style={{
-                fontSize: "0.75rem",
-                color: "#9ca3af",
-                textAlign: "center",
-                margin: 0,
-              }}
               data-testid="forecast-region"
             >
               Region: {data.region}

--- a/components/leaderboard/final-four.tsx
+++ b/components/leaderboard/final-four.tsx
@@ -16,39 +16,12 @@ function FinalFourCard({ allergen }: { allergen: RankedAllergen }) {
     <div
       data-testid="final-four-card"
       className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
-      style={{
-        borderRadius: "0.5rem",
-        border: "1px solid #e5e7eb",
-        backgroundColor: "#ffffff",
-        padding: "1rem",
-        boxShadow: "0 1px 2px 0 rgba(0,0,0,.05)",
-      }}
     >
       {/* Rank badge */}
-      <div
-        className="mb-2 flex items-center justify-between"
-        style={{
-          marginBottom: "0.5rem",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
+      <div className="mb-2 flex items-center justify-between">
         <span
           data-testid="final-four-rank"
           className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-600"
-          style={{
-            display: "flex",
-            height: "1.5rem",
-            width: "1.5rem",
-            alignItems: "center",
-            justifyContent: "center",
-            borderRadius: "9999px",
-            backgroundColor: "#f3f4f6",
-            fontSize: "0.75rem",
-            fontWeight: 700,
-            color: "#4b5563",
-          }}
         >
           #{allergen.rank}
         </span>
@@ -56,36 +29,18 @@ function FinalFourCard({ allergen }: { allergen: RankedAllergen }) {
       </div>
 
       {/* Allergen info */}
-      <div
-        className="flex items-center gap-2"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "0.5rem",
-        }}
-      >
+      <div className="flex items-center gap-2">
         <CategoryIcon category={allergen.category} />
         <div>
           <p
             data-testid="final-four-name"
             className="text-sm font-semibold text-gray-900"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 600,
-              color: "#111827",
-              margin: 0,
-            }}
           >
             {allergen.common_name}
           </p>
           <p
             data-testid="final-four-elo"
             className="text-xs text-gray-500"
-            style={{
-              fontSize: "0.75rem",
-              color: "#6b7280",
-              margin: 0,
-            }}
           >
             Elo {allergen.elo_score}
           </p>
@@ -102,11 +57,6 @@ export function FinalFour({ allergens, isBlurred }: FinalFourProps) {
     <div
       data-testid="final-four-grid"
       className="grid grid-cols-1 gap-3 sm:grid-cols-3"
-      style={{
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
-        gap: "0.75rem",
-      }}
     >
       {allergens.map((allergen) => (
         <FinalFourCard key={allergen.allergen_id} allergen={allergen} />

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -102,21 +102,8 @@ export function Leaderboard({
       <div
         data-testid="leaderboard"
         className="mx-auto max-w-2xl space-y-6 px-4 py-6"
-        style={{
-          maxWidth: "42rem",
-          margin: "0 auto",
-          padding: "1.5rem 1rem",
-        }}
       >
-        <h1
-          className="text-2xl font-bold text-gray-900"
-          style={{
-            fontSize: "1.5rem",
-            fontWeight: 700,
-            color: "#111827",
-            margin: 0,
-          }}
-        >
+        <h1 className="text-2xl font-bold text-gray-900">
           Environmental Forecast
         </h1>
         <EnvironmentalForecast data={forecastData} loading={forecastLoading} />
@@ -131,21 +118,8 @@ export function Leaderboard({
     <div
       data-testid="leaderboard"
       className="mx-auto max-w-2xl space-y-6 px-4 py-6"
-      style={{
-        maxWidth: "42rem",
-        margin: "0 auto",
-        padding: "1.5rem 1rem",
-      }}
     >
-      <h1
-        className="text-2xl font-bold text-gray-900"
-        style={{
-          fontSize: "1.5rem",
-          fontWeight: 700,
-          color: "#111827",
-          margin: "0 0 1.5rem 0",
-        }}
-      >
+      <h1 className="text-2xl font-bold text-gray-900">
         Your Allergen Leaderboard
       </h1>
 
@@ -154,23 +128,15 @@ export function Leaderboard({
 
       {/* Trigger Champion */}
       {champion && (
-        <div style={{ marginTop: "1.5rem" }}>
+        <div className="mt-6">
           <TriggerChampionCard allergen={champion} />
         </div>
       )}
 
       {/* Final Four (#2-#4) */}
       {finalFour.length > 0 && (
-        <div style={{ marginTop: "1.5rem" }}>
-          <h2
-            className="mb-3 text-lg font-semibold text-gray-800"
-            style={{
-              fontSize: "1.125rem",
-              fontWeight: 600,
-              color: "#1f2937",
-              marginBottom: "0.75rem",
-            }}
-          >
+        <div className="mt-6">
+          <h2 className="mb-3 text-lg font-semibold text-gray-800">
             Final Four
           </h2>
           <FinalFour allergens={finalFour} isBlurred={!isPremium} />
@@ -179,75 +145,26 @@ export function Leaderboard({
 
       {/* Full Ranked List (beyond top 4) */}
       {allergens.length > 4 && (
-        <div style={{ marginTop: "1.5rem" }}>
-          <h2
-            className="mb-3 text-lg font-semibold text-gray-800"
-            style={{
-              fontSize: "1.125rem",
-              fontWeight: 600,
-              color: "#1f2937",
-              marginBottom: "0.75rem",
-            }}
-          >
+        <div className="mt-6">
+          <h2 className="mb-3 text-lg font-semibold text-gray-800">
             Full Rankings
           </h2>
           <div
             data-testid="full-rankings"
             className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white"
-            style={{
-              borderRadius: "0.5rem",
-              border: "1px solid #e5e7eb",
-              backgroundColor: "#ffffff",
-              overflow: "hidden",
-            }}
           >
             {allergens.slice(4).map((allergen) => (
               <div
                 key={allergen.allergen_id}
                 data-testid="ranked-allergen-row"
                 className="flex items-center justify-between px-4 py-3"
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  padding: "0.75rem 1rem",
-                  borderBottom: "1px solid #f3f4f6",
-                }}
               >
-                <div
-                  className="flex items-center gap-3"
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "0.75rem",
-                  }}
-                >
-                  <span
-                    className="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-500"
-                    style={{
-                      display: "flex",
-                      height: "1.75rem",
-                      width: "1.75rem",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      borderRadius: "9999px",
-                      backgroundColor: "#f3f4f6",
-                      fontSize: "0.75rem",
-                      fontWeight: 700,
-                      color: "#6b7280",
-                    }}
-                  >
+                <div className="flex items-center gap-3">
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-500">
                     #{allergen.rank}
                   </span>
                   <CategoryIcon category={allergen.category} />
-                  <span
-                    className="text-sm font-medium text-gray-900"
-                    style={{
-                      fontSize: "0.875rem",
-                      fontWeight: 500,
-                      color: "#111827",
-                    }}
-                  >
+                  <span className="text-sm font-medium text-gray-900">
                     {allergen.common_name}
                   </span>
                 </div>
@@ -255,16 +172,8 @@ export function Leaderboard({
                   <div
                     data-testid="ranking-score-details"
                     className="flex items-center gap-2"
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "0.5rem",
-                    }}
                   >
-                    <span
-                      className="text-xs text-gray-500"
-                      style={{ fontSize: "0.75rem", color: "#6b7280" }}
-                    >
+                    <span className="text-xs text-gray-500">
                       {allergen.elo_score}
                     </span>
                     <ConfidenceBadge tier={allergen.confidence_tier} />
@@ -273,26 +182,14 @@ export function Leaderboard({
                   <div
                     data-testid="ranking-score-locked"
                     className="flex items-center gap-1.5"
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "0.375rem",
-                    }}
                   >
                     <span
                       aria-hidden="true"
-                      style={{ fontSize: "0.875rem" }}
+                      className="text-sm"
                     >
                       &#x1F512;
                     </span>
-                    <span
-                      className="text-xs font-medium text-purple-600"
-                      style={{
-                        fontSize: "0.75rem",
-                        fontWeight: 500,
-                        color: "#9333ea",
-                      }}
-                    >
+                    <span className="text-xs font-medium text-purple-600">
                       Upgrade
                     </span>
                   </div>
@@ -305,7 +202,7 @@ export function Leaderboard({
           {!isPremium && (
             <div
               data-testid="rankings-upgrade-cta"
-              style={{ marginTop: "1rem" }}
+              className="mt-4"
             >
               <UpgradeCta feature="full ranking details" />
             </div>
@@ -315,7 +212,7 @@ export function Leaderboard({
 
       {/* PFAS Cross-Reactivity Panel */}
       {pfasEntries.length > 0 && (
-        <div style={{ marginTop: "1.5rem" }}>
+        <div className="mt-6">
           <PfasPanel entries={pfasEntries} isPremium={isPremium} />
         </div>
       )}

--- a/components/leaderboard/trigger-champion-card.tsx
+++ b/components/leaderboard/trigger-champion-card.tsx
@@ -14,89 +14,33 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
     <div
       data-testid="trigger-champion-card"
       className="rounded-xl border-2 border-amber-400 bg-gradient-to-br from-amber-50 to-orange-50 p-6 shadow-lg"
-      style={{
-        borderRadius: "0.75rem",
-        border: "2px solid #fbbf24",
-        background: "linear-gradient(to bottom right, #fffbeb, #fff7ed)",
-        padding: "1.5rem",
-        boxShadow:
-          "0 10px 15px -3px rgba(0,0,0,.1), 0 4px 6px -4px rgba(0,0,0,.1)",
-      }}
     >
       {/* Crown / header */}
-      <div
-        className="mb-3 flex items-center gap-2"
-        style={{
-          marginBottom: "0.75rem",
-          display: "flex",
-          alignItems: "center",
-          gap: "0.5rem",
-        }}
-      >
-        <span
-          className="text-2xl"
-          style={{ fontSize: "1.5rem" }}
-          aria-hidden="true"
-        >
+      <div className="mb-3 flex items-center gap-2">
+        <span className="text-2xl" aria-hidden="true">
           &#x1F451;
         </span>
-        <h2
-          className="text-sm font-bold uppercase tracking-wider text-amber-700"
-          style={{
-            fontSize: "0.75rem",
-            fontWeight: 700,
-            textTransform: "uppercase",
-            letterSpacing: "0.05em",
-            color: "#b45309",
-            margin: 0,
-          }}
-        >
+        <h2 className="text-sm font-bold uppercase tracking-wider text-amber-700">
           Trigger Champion
         </h2>
       </div>
 
       {/* Allergen name + category */}
-      <div
-        className="mb-3 flex items-center gap-3"
-        style={{
-          marginBottom: "0.75rem",
-          display: "flex",
-          alignItems: "center",
-          gap: "0.75rem",
-        }}
-      >
+      <div className="mb-3 flex items-center gap-3">
         <CategoryIcon category={allergen.category} />
         <h3
           data-testid="champion-name"
           className="text-2xl font-bold text-gray-900"
-          style={{
-            fontSize: "1.5rem",
-            fontWeight: 700,
-            color: "#111827",
-            margin: 0,
-          }}
         >
           {allergen.common_name}
         </h3>
       </div>
 
       {/* Elo score + confidence */}
-      <div
-        className="flex items-center gap-3"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "0.75rem",
-        }}
-      >
+      <div className="flex items-center gap-3">
         <span
           data-testid="champion-elo"
           className="text-lg font-semibold text-gray-700"
-          style={{
-            fontSize: "1.125rem",
-            fontWeight: 600,
-            color: "#374151",
-          }}
         >
           Elo {allergen.elo_score}
         </span>

--- a/components/onboarding/onboarding-wizard.tsx
+++ b/components/onboarding/onboarding-wizard.tsx
@@ -80,58 +80,27 @@ export function OnboardingWizard() {
   // Processing screen has its own layout
   if (currentStep === "processing") {
     return (
-      <div
-        className="mx-auto max-w-md px-4 py-16"
-        style={{
-          maxWidth: "28rem",
-          margin: "0 auto",
-          padding: "4rem 1rem",
-        }}
-      >
+      <div className="mx-auto max-w-md px-4 py-16">
         <ProcessingScreen formData={formData} />
       </div>
     );
   }
 
   return (
-    <div
-      className="mx-auto max-w-md px-4 py-8"
-      style={{
-        maxWidth: "28rem",
-        margin: "0 auto",
-        padding: "2rem 1rem",
-      }}
-    >
+    <div className="mx-auto max-w-md px-4 py-8">
       {/* Step indicator */}
       <nav
         aria-label="Onboarding progress"
         className="mb-8"
-        style={{ marginBottom: "2rem" }}
       >
-        <ol
-          className="flex items-center justify-between"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            listStyle: "none",
-            padding: 0,
-            margin: 0,
-          }}
-        >
+        <ol className="flex list-none items-center justify-between p-0 m-0">
           {STEPS.filter((s) => s !== "processing").map((step, i) => {
             const isActive = i === stepIndex;
             const isCompleted = i < stepIndex;
             return (
               <li
                 key={step}
-                className="flex flex-col items-center"
-                style={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  flex: 1,
-                }}
+                className="flex flex-1 flex-col items-center"
               >
                 <div
                   className={`flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold ${
@@ -141,26 +110,6 @@ export function OnboardingWizard() {
                         ? "bg-blue-100 text-blue-600"
                         : "bg-gray-200 text-gray-500"
                   }`}
-                  style={{
-                    display: "flex",
-                    height: "2rem",
-                    width: "2rem",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    borderRadius: "9999px",
-                    fontSize: "0.75rem",
-                    fontWeight: 700,
-                    backgroundColor: isActive
-                      ? "#2563eb"
-                      : isCompleted
-                        ? "#dbeafe"
-                        : "#e5e7eb",
-                    color: isActive
-                      ? "#ffffff"
-                      : isCompleted
-                        ? "#2563eb"
-                        : "#6b7280",
-                  }}
                   aria-current={isActive ? "step" : undefined}
                 >
                   {isCompleted ? "\u2713" : i + 1}
@@ -171,12 +120,6 @@ export function OnboardingWizard() {
                       ? "font-medium text-blue-600"
                       : "text-gray-500"
                   }`}
-                  style={{
-                    marginTop: "0.25rem",
-                    fontSize: "0.75rem",
-                    fontWeight: isActive ? 500 : 400,
-                    color: isActive ? "#2563eb" : "#6b7280",
-                  }}
                 >
                   {STEP_LABELS[step]}
                 </span>

--- a/components/onboarding/processing-screen.tsx
+++ b/components/onboarding/processing-screen.tsx
@@ -95,43 +95,12 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
 
   if (error) {
     return (
-      <div
-        className="space-y-4 text-center"
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "1rem",
-          textAlign: "center",
-        }}
-      >
-        <div
-          className="rounded-md border border-red-200 bg-red-50 p-4"
-          style={{
-            borderRadius: "0.375rem",
-            border: "1px solid #fecaca",
-            backgroundColor: "#fef2f2",
-            padding: "1rem",
-          }}
-        >
-          <p
-            className="text-sm font-medium text-red-800"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#991b1b",
-              margin: 0,
-            }}
-          >
+      <div className="space-y-4 text-center">
+        <div className="rounded-md border border-red-200 bg-red-50 p-4">
+          <p className="text-sm font-medium text-red-800">
             Something went wrong
           </p>
-          <p
-            className="mt-1 text-sm text-red-600"
-            style={{
-              fontSize: "0.875rem",
-              color: "#dc2626",
-              marginTop: "0.25rem",
-            }}
-          >
+          <p className="mt-1 text-sm text-red-600">
             {error}
           </p>
         </div>
@@ -144,16 +113,6 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
             submitOnboarding();
           }}
           className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white"
-          style={{
-            borderRadius: "0.375rem",
-            backgroundColor: "#2563eb",
-            padding: "0.5rem 1rem",
-            fontSize: "0.875rem",
-            fontWeight: 500,
-            color: "#ffffff",
-            border: "none",
-            cursor: "pointer",
-          }}
         >
           Try again
         </button>
@@ -167,53 +126,21 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
   return (
     <div
       className="space-y-8 text-center"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "2rem",
-        textAlign: "center",
-      }}
       data-testid="processing-screen"
     >
       <div>
-        <h2
-          className="text-xl font-bold text-gray-900"
-          style={{
-            fontSize: "1.25rem",
-            fontWeight: 700,
-            color: "#111827",
-            margin: 0,
-          }}
-        >
+        <h2 className="text-xl font-bold text-gray-900">
           Building your prediction
         </h2>
-        <p
-          className="mt-2 text-sm text-gray-500"
-          style={{
-            fontSize: "0.875rem",
-            color: "#6b7280",
-            marginTop: "0.5rem",
-          }}
-        >
+        <p className="mt-2 text-sm text-gray-500">
           Analyzing your data against regional allergen profiles...
         </p>
       </div>
 
       {/* Spinner */}
-      <div
-        className="flex justify-center"
-        style={{ display: "flex", justifyContent: "center" }}
-      >
+      <div className="flex justify-center">
         <div
           className="h-12 w-12 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600"
-          style={{
-            height: "3rem",
-            width: "3rem",
-            borderRadius: "9999px",
-            border: "4px solid #e5e7eb",
-            borderTopColor: "#2563eb",
-            animation: "spin 1s linear infinite",
-          }}
           role="status"
           aria-label="Processing"
         />
@@ -221,13 +148,7 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
 
       {/* Current message */}
       <p
-        className="text-sm font-medium text-gray-700"
-        style={{
-          fontSize: "0.875rem",
-          fontWeight: 500,
-          color: "#374151",
-          minHeight: "1.25rem",
-        }}
+        className="min-h-5 text-sm font-medium text-gray-700"
         data-testid="processing-message"
         aria-live="polite"
       >
@@ -235,29 +156,11 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
       </p>
 
       {/* Progress bar */}
-      <div
-        className="mx-auto w-full max-w-xs"
-        style={{ maxWidth: "20rem", margin: "0 auto", width: "100%" }}
-      >
-        <div
-          className="h-2 w-full rounded-full bg-gray-200"
-          style={{
-            height: "0.5rem",
-            width: "100%",
-            borderRadius: "9999px",
-            backgroundColor: "#e5e7eb",
-            overflow: "hidden",
-          }}
-        >
+      <div className="mx-auto w-full max-w-xs">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
           <div
             className="h-full rounded-full bg-blue-600 transition-all duration-500"
-            style={{
-              height: "100%",
-              borderRadius: "9999px",
-              backgroundColor: "#2563eb",
-              width: `${progress}%`,
-              transition: "width 0.5s ease",
-            }}
+            style={{ width: `${progress}%` }}
             role="progressbar"
             aria-valuenow={progress}
             aria-valuemin={0}

--- a/components/onboarding/step-address.tsx
+++ b/components/onboarding/step-address.tsx
@@ -30,30 +30,12 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
 
   return (
     <form onSubmit={handleSubmit}>
-      <div
-        className="space-y-6"
-        style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
-      >
+      <div className="space-y-6">
         <div>
-          <h2
-            className="text-xl font-bold text-gray-900"
-            style={{
-              fontSize: "1.25rem",
-              fontWeight: 700,
-              color: "#111827",
-              margin: 0,
-            }}
-          >
+          <h2 className="text-xl font-bold text-gray-900">
             Where do you live?
           </h2>
-          <p
-            className="mt-2 text-sm text-gray-600"
-            style={{
-              fontSize: "0.875rem",
-              color: "#4b5563",
-              marginTop: "0.5rem",
-            }}
-          >
+          <p className="mt-2 text-sm text-gray-600">
             Your address helps us identify regional allergens and auto-populate
             your home profile. We use it to predict which allergens are most
             likely to affect you.
@@ -64,13 +46,6 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
           <label
             htmlFor="address"
             className="block text-sm font-medium text-gray-700"
-            style={{
-              display: "block",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              marginBottom: "0.25rem",
-            }}
           >
             Home address
           </label>
@@ -86,25 +61,10 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
             autoFocus
             autoComplete="street-address"
             className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-            style={{
-              display: "block",
-              width: "100%",
-              borderRadius: "0.375rem",
-              border: "1px solid #d1d5db",
-              padding: "0.5rem 0.75rem",
-              fontSize: "0.875rem",
-              marginTop: "0.25rem",
-              boxSizing: "border-box",
-            }}
           />
           {error && (
             <p
               className="mt-1 text-sm text-red-600"
-              style={{
-                fontSize: "0.875rem",
-                color: "#dc2626",
-                marginTop: "0.25rem",
-              }}
               role="alert"
             >
               {error}
@@ -112,13 +72,7 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
           )}
         </div>
 
-        <p
-          className="text-xs text-gray-500"
-          style={{
-            fontSize: "0.75rem",
-            color: "#6b7280",
-          }}
-        >
+        <p className="text-xs text-gray-500">
           Your address is geocoded server-side. It is never shared or sold. We
           use it to look up property age, type, and regional pollen data.
         </p>
@@ -126,17 +80,6 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
         <button
           type="submit"
           className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-          style={{
-            width: "100%",
-            borderRadius: "0.375rem",
-            backgroundColor: "#2563eb",
-            padding: "0.5rem 1rem",
-            fontSize: "0.875rem",
-            fontWeight: 500,
-            color: "#ffffff",
-            border: "none",
-            cursor: "pointer",
-          }}
         >
           Continue
         </button>

--- a/components/onboarding/step-confirmation.tsx
+++ b/components/onboarding/step-confirmation.tsx
@@ -32,53 +32,19 @@ export function StepConfirmation({
   onNext,
 }: StepProps) {
   return (
-    <div
-      className="space-y-6"
-      style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
-    >
+    <div className="space-y-6">
       <div>
-        <h2
-          className="text-xl font-bold text-gray-900"
-          style={{
-            fontSize: "1.25rem",
-            fontWeight: 700,
-            color: "#111827",
-            margin: 0,
-          }}
-        >
+        <h2 className="text-xl font-bold text-gray-900">
           Confirm your information
         </h2>
-        <p
-          className="mt-2 text-sm text-gray-600"
-          style={{
-            fontSize: "0.875rem",
-            color: "#4b5563",
-            marginTop: "0.5rem",
-          }}
-        >
+        <p className="mt-2 text-sm text-gray-600">
           Review the details below. You can go back to make changes.
         </p>
       </div>
 
       {/* Summary card */}
-      <div
-        className="rounded-md border border-gray-200 bg-gray-50 p-4"
-        style={{
-          borderRadius: "0.375rem",
-          border: "1px solid #e5e7eb",
-          backgroundColor: "#f9fafb",
-          padding: "1rem",
-        }}
-      >
-        <dl
-          className="space-y-3 text-sm"
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "0.75rem",
-            fontSize: "0.875rem",
-          }}
-        >
+      <div className="rounded-md border border-gray-200 bg-gray-50 p-4">
+        <dl className="space-y-3 text-sm">
           <SummaryRow label="Address" value={formData.address} />
           <SummaryRow
             label="Home type"
@@ -119,34 +85,17 @@ export function StepConfirmation({
         </dl>
       </div>
 
-      <p
-        className="text-xs text-gray-500"
-        style={{ fontSize: "0.75rem", color: "#6b7280" }}
-      >
+      <p className="text-xs text-gray-500">
         By continuing, we will analyze your regional allergen data and build your
         personalized prediction. This typically takes about 4 seconds.
       </p>
 
       {/* Navigation */}
-      <div
-        className="flex gap-3"
-        style={{ display: "flex", gap: "0.75rem" }}
-      >
+      <div className="flex gap-3">
         <button
           type="button"
           onClick={onBack}
-          className="flex-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-          style={{
-            flex: 1,
-            borderRadius: "0.375rem",
-            border: "1px solid #d1d5db",
-            padding: "0.5rem 1rem",
-            fontSize: "0.875rem",
-            fontWeight: 500,
-            color: "#374151",
-            backgroundColor: "#ffffff",
-            cursor: "pointer",
-          }}
+          className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
         >
           Back
         </button>
@@ -155,17 +104,6 @@ export function StepConfirmation({
           onClick={onNext}
           data-testid="submit-onboarding"
           className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-          style={{
-            flex: 1,
-            borderRadius: "0.375rem",
-            backgroundColor: "#2563eb",
-            padding: "0.5rem 1rem",
-            fontSize: "0.875rem",
-            fontWeight: 500,
-            color: "#ffffff",
-            border: "none",
-            cursor: "pointer",
-          }}
         >
           Build My Prediction
         </button>
@@ -180,25 +118,13 @@ export function StepConfirmation({
 
 function SummaryRow({ label, value }: { label: string; value: string }) {
   return (
-    <div
-      className="flex justify-between"
-      style={{
-        display: "flex",
-        justifyContent: "space-between",
-      }}
-    >
+    <div className="flex justify-between">
       {label && (
-        <dt
-          className="font-medium text-gray-500"
-          style={{ fontWeight: 500, color: "#6b7280" }}
-        >
+        <dt className="font-medium text-gray-500">
           {label}
         </dt>
       )}
-      <dd
-        className="text-gray-900"
-        style={{ color: "#111827", textAlign: "right" }}
-      >
+      <dd className="text-right text-gray-900">
         {value}
       </dd>
     </div>

--- a/components/onboarding/step-health-questions.tsx
+++ b/components/onboarding/step-health-questions.tsx
@@ -46,67 +46,23 @@ export function StepHealthQuestions({
 
   return (
     <form onSubmit={handleSubmit}>
-      <div
-        className="space-y-6"
-        style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
-      >
+      <div className="space-y-6">
         <div>
-          <h2
-            className="text-xl font-bold text-gray-900"
-            style={{
-              fontSize: "1.25rem",
-              fontWeight: 700,
-              color: "#111827",
-              margin: 0,
-            }}
-          >
+          <h2 className="text-xl font-bold text-gray-900">
             A few quick questions
           </h2>
-          <p
-            className="mt-2 text-sm text-gray-600"
-            style={{
-              fontSize: "0.875rem",
-              color: "#4b5563",
-              marginTop: "0.5rem",
-            }}
-          >
+          <p className="mt-2 text-sm text-gray-600">
             These help us fine-tune your allergen predictions.
           </p>
         </div>
 
         {/* Pets */}
-        <fieldset
-          style={{
-            border: "none",
-            padding: 0,
-            margin: 0,
-          }}
-        >
-          <legend
-            className="text-sm font-medium text-gray-700"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              marginBottom: "0.5rem",
-            }}
-          >
+        <fieldset className="border-none p-0 m-0">
+          <legend className="mb-2 text-sm font-medium text-gray-700">
             Do you have pets at home?
           </legend>
-          <div
-            className="flex gap-4"
-            style={{ display: "flex", gap: "1rem", marginTop: "0.25rem" }}
-          >
-            <label
-              className="flex items-center gap-2 text-sm"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                fontSize: "0.875rem",
-                cursor: "pointer",
-              }}
-            >
+          <div className="flex gap-4">
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="radio"
                 name="has_pets"
@@ -115,16 +71,7 @@ export function StepHealthQuestions({
               />
               Yes
             </label>
-            <label
-              className="flex items-center gap-2 text-sm"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                fontSize: "0.875rem",
-                cursor: "pointer",
-              }}
-            >
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="radio"
                 name="has_pets"
@@ -137,15 +84,7 @@ export function StepHealthQuestions({
             </label>
           </div>
           {formData.has_pets && (
-            <div
-              className="mt-3 flex flex-wrap gap-2"
-              style={{
-                display: "flex",
-                flexWrap: "wrap",
-                gap: "0.5rem",
-                marginTop: "0.75rem",
-              }}
-            >
+            <div className="mt-3 flex flex-wrap gap-2">
               {PET_OPTIONS.map((pet) => {
                 const selected = formData.pet_types.includes(pet);
                 return (
@@ -153,22 +92,11 @@ export function StepHealthQuestions({
                     key={pet}
                     type="button"
                     onClick={() => togglePetType(pet)}
-                    className={`rounded-full border px-3 py-1 text-sm ${
+                    className={`rounded-full border px-3 py-1 text-sm cursor-pointer ${
                       selected
                         ? "border-blue-500 bg-blue-50 text-blue-700"
                         : "border-gray-300 bg-white text-gray-700"
                     }`}
-                    style={{
-                      borderRadius: "9999px",
-                      border: selected
-                        ? "1px solid #3b82f6"
-                        : "1px solid #d1d5db",
-                      backgroundColor: selected ? "#eff6ff" : "#ffffff",
-                      color: selected ? "#1d4ed8" : "#374151",
-                      padding: "0.25rem 0.75rem",
-                      fontSize: "0.875rem",
-                      cursor: "pointer",
-                    }}
                     aria-pressed={selected}
                   >
                     {pet}
@@ -180,32 +108,12 @@ export function StepHealthQuestions({
         </fieldset>
 
         {/* Prior diagnosis */}
-        <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
-          <legend
-            className="text-sm font-medium text-gray-700"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              marginBottom: "0.5rem",
-            }}
-          >
+        <fieldset className="border-none p-0 m-0">
+          <legend className="mb-2 text-sm font-medium text-gray-700">
             Have you been diagnosed with allergies before?
           </legend>
-          <div
-            className="flex gap-4"
-            style={{ display: "flex", gap: "1rem", marginTop: "0.25rem" }}
-          >
-            <label
-              className="flex items-center gap-2 text-sm"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                fontSize: "0.875rem",
-                cursor: "pointer",
-              }}
-            >
+          <div className="flex gap-4">
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="radio"
                 name="prior_diagnosis"
@@ -216,16 +124,7 @@ export function StepHealthQuestions({
               />
               Yes
             </label>
-            <label
-              className="flex items-center gap-2 text-sm"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                fontSize: "0.875rem",
-                cursor: "pointer",
-              }}
-            >
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="radio"
                 name="prior_diagnosis"
@@ -244,13 +143,6 @@ export function StepHealthQuestions({
           <label
             htmlFor="seasonal_pattern"
             className="block text-sm font-medium text-gray-700"
-            style={{
-              display: "block",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              marginBottom: "0.25rem",
-            }}
           >
             When are your symptoms worst?
           </label>
@@ -262,18 +154,7 @@ export function StepHealthQuestions({
                 seasonal_pattern: e.target.value as SeasonalPattern,
               })
             }
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            style={{
-              display: "block",
-              width: "100%",
-              borderRadius: "0.375rem",
-              border: "1px solid #d1d5db",
-              padding: "0.5rem 0.75rem",
-              fontSize: "0.875rem",
-              marginTop: "0.25rem",
-              boxSizing: "border-box",
-              backgroundColor: "#ffffff",
-            }}
+            className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
           >
             {SEASONAL_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -284,37 +165,12 @@ export function StepHealthQuestions({
         </div>
 
         {/* Indoor risk factors */}
-        <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
-          <legend
-            className="text-sm font-medium text-gray-700"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              marginBottom: "0.5rem",
-            }}
-          >
+        <fieldset className="border-none p-0 m-0">
+          <legend className="mb-2 text-sm font-medium text-gray-700">
             Indoor risk factors (check any that apply)
           </legend>
-          <div
-            className="space-y-2"
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "0.5rem",
-              marginTop: "0.25rem",
-            }}
-          >
-            <label
-              className="flex items-center gap-2 text-sm"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                fontSize: "0.875rem",
-                cursor: "pointer",
-              }}
-            >
+          <div className="space-y-2">
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="checkbox"
                 checked={formData.has_mold_moisture}
@@ -324,16 +180,7 @@ export function StepHealthQuestions({
               />
               Mold or moisture issues
             </label>
-            <label
-              className="flex items-center gap-2 text-sm"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                fontSize: "0.875rem",
-                cursor: "pointer",
-              }}
-            >
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="checkbox"
                 checked={formData.cockroach_sighting}
@@ -343,16 +190,7 @@ export function StepHealthQuestions({
               />
               Cockroach sightings
             </label>
-            <label
-              className="flex items-center gap-2 text-sm"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                fontSize: "0.875rem",
-                cursor: "pointer",
-              }}
-            >
+            <label className="flex cursor-pointer items-center gap-2 text-sm">
               <input
                 type="checkbox"
                 checked={formData.smoking_in_home}
@@ -366,42 +204,17 @@ export function StepHealthQuestions({
         </fieldset>
 
         {/* Navigation */}
-        <div
-          className="flex gap-3"
-          style={{ display: "flex", gap: "0.75rem" }}
-        >
+        <div className="flex gap-3">
           <button
             type="button"
             onClick={onBack}
-            className="flex-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-            style={{
-              flex: 1,
-              borderRadius: "0.375rem",
-              border: "1px solid #d1d5db",
-              padding: "0.5rem 1rem",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              backgroundColor: "#ffffff",
-              cursor: "pointer",
-            }}
+            className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
             Back
           </button>
           <button
             type="submit"
             className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-            style={{
-              flex: 1,
-              borderRadius: "0.375rem",
-              backgroundColor: "#2563eb",
-              padding: "0.5rem 1rem",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#ffffff",
-              border: "none",
-              cursor: "pointer",
-            }}
           >
             Continue
           </button>

--- a/components/onboarding/step-home-details.tsx
+++ b/components/onboarding/step-home-details.tsx
@@ -33,30 +33,12 @@ export function StepHomeDetails({
 
   return (
     <form onSubmit={handleSubmit}>
-      <div
-        className="space-y-6"
-        style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}
-      >
+      <div className="space-y-6">
         <div>
-          <h2
-            className="text-xl font-bold text-gray-900"
-            style={{
-              fontSize: "1.25rem",
-              fontWeight: 700,
-              color: "#111827",
-              margin: 0,
-            }}
-          >
+          <h2 className="text-xl font-bold text-gray-900">
             About your home
           </h2>
-          <p
-            className="mt-2 text-sm text-gray-600"
-            style={{
-              fontSize: "0.875rem",
-              color: "#4b5563",
-              marginTop: "0.5rem",
-            }}
-          >
+          <p className="mt-2 text-sm text-gray-600">
             Home characteristics affect indoor allergen exposure. We
             auto-populate what we can — feel free to adjust.
           </p>
@@ -67,13 +49,6 @@ export function StepHomeDetails({
           <label
             htmlFor="home_type"
             className="block text-sm font-medium text-gray-700"
-            style={{
-              display: "block",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              marginBottom: "0.25rem",
-            }}
           >
             Home type
           </label>
@@ -85,18 +60,7 @@ export function StepHomeDetails({
                 home_type: (e.target.value || null) as HomeType | null,
               })
             }
-            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            style={{
-              display: "block",
-              width: "100%",
-              borderRadius: "0.375rem",
-              border: "1px solid #d1d5db",
-              padding: "0.5rem 0.75rem",
-              fontSize: "0.875rem",
-              marginTop: "0.25rem",
-              boxSizing: "border-box",
-              backgroundColor: "#ffffff",
-            }}
+            className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm"
           >
             <option value="">Select home type...</option>
             {HOME_TYPE_OPTIONS.map((opt) => (
@@ -112,13 +76,6 @@ export function StepHomeDetails({
           <label
             htmlFor="year_built"
             className="block text-sm font-medium text-gray-700"
-            style={{
-              display: "block",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              marginBottom: "0.25rem",
-            }}
           >
             Year built (approximate)
           </label>
@@ -135,16 +92,6 @@ export function StepHomeDetails({
             }
             placeholder="e.g. 1985"
             className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            style={{
-              display: "block",
-              width: "100%",
-              borderRadius: "0.375rem",
-              border: "1px solid #d1d5db",
-              padding: "0.5rem 0.75rem",
-              fontSize: "0.875rem",
-              marginTop: "0.25rem",
-              boxSizing: "border-box",
-            }}
           />
         </div>
 
@@ -153,13 +100,6 @@ export function StepHomeDetails({
           <label
             htmlFor="sqft"
             className="block text-sm font-medium text-gray-700"
-            style={{
-              display: "block",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              marginBottom: "0.25rem",
-            }}
           >
             Square footage (approximate)
           </label>
@@ -176,64 +116,26 @@ export function StepHomeDetails({
             }
             placeholder="e.g. 1500"
             className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
-            style={{
-              display: "block",
-              width: "100%",
-              borderRadius: "0.375rem",
-              border: "1px solid #d1d5db",
-              padding: "0.5rem 0.75rem",
-              fontSize: "0.875rem",
-              marginTop: "0.25rem",
-              boxSizing: "border-box",
-            }}
           />
         </div>
 
-        <p
-          className="text-xs text-gray-500"
-          style={{ fontSize: "0.75rem", color: "#6b7280" }}
-        >
+        <p className="text-xs text-gray-500">
           All fields are optional. Older homes and certain construction types may
           have higher indoor allergen risk.
         </p>
 
         {/* Navigation */}
-        <div
-          className="flex gap-3"
-          style={{ display: "flex", gap: "0.75rem" }}
-        >
+        <div className="flex gap-3">
           <button
             type="button"
             onClick={onBack}
-            className="flex-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-            style={{
-              flex: 1,
-              borderRadius: "0.375rem",
-              border: "1px solid #d1d5db",
-              padding: "0.5rem 1rem",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              backgroundColor: "#ffffff",
-              cursor: "pointer",
-            }}
+            className="flex-1 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
             Back
           </button>
           <button
             type="submit"
             className="flex-1 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-            style={{
-              flex: 1,
-              borderRadius: "0.375rem",
-              backgroundColor: "#2563eb",
-              padding: "0.5rem 1rem",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#ffffff",
-              border: "none",
-              cursor: "pointer",
-            }}
           >
             Continue
           </button>

--- a/components/pfas/pfas-panel.tsx
+++ b/components/pfas/pfas-panel.tsx
@@ -9,8 +9,6 @@
  *
  * Premium feature — gated behind Madness+ subscription.
  * Free-tier users see allergen names but food lists are blurred.
- *
- * Dual styling: Tailwind utility classes + inline styles.
  */
 
 import { FdaDisclaimer } from "@/components/shared/fda-disclaimer";
@@ -67,15 +65,6 @@ function SeverityBadge({ severity }: { severity: PfasSeverity }) {
       data-testid="pfas-severity-badge"
       className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
       style={{
-        display: "inline-flex",
-        alignItems: "center",
-        borderRadius: "9999px",
-        paddingLeft: "0.5rem",
-        paddingRight: "0.5rem",
-        paddingTop: "0.125rem",
-        paddingBottom: "0.125rem",
-        fontSize: "0.75rem",
-        fontWeight: 500,
         backgroundColor: colors.bg,
         color: colors.text,
         border: `1px solid ${colors.border}`,
@@ -90,20 +79,7 @@ function FoodTag({ food }: { food: string }) {
   return (
     <span
       data-testid="pfas-food-tag"
-      className="inline-block rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-800"
-      style={{
-        display: "inline-block",
-        borderRadius: "0.375rem",
-        backgroundColor: "#f0fdf4",
-        paddingLeft: "0.5rem",
-        paddingRight: "0.5rem",
-        paddingTop: "0.25rem",
-        paddingBottom: "0.25rem",
-        fontSize: "0.75rem",
-        fontWeight: 500,
-        color: "#166534",
-        border: "1px solid #bbf7d0",
-      }}
+      className="inline-block rounded-md border border-green-200 bg-green-50 px-2 py-1 text-xs font-medium text-green-800"
     >
       {food}
     </span>
@@ -118,14 +94,7 @@ function AllergenCrossReactivityCard({
   isPremium: boolean;
 }) {
   const foodContent = (
-    <div
-      className="flex flex-wrap gap-2"
-      style={{
-        display: "flex",
-        flexWrap: "wrap",
-        gap: "0.5rem",
-      }}
-    >
+    <div className="flex flex-wrap gap-2">
       {entry.cross_reactive_foods.map((food) => (
         <FoodTag key={food} food={food} />
       ))}
@@ -136,40 +105,12 @@ function AllergenCrossReactivityCard({
     <div
       data-testid="pfas-allergen-card"
       className="rounded-lg border border-gray-200 bg-white p-4"
-      style={{
-        borderRadius: "0.5rem",
-        border: "1px solid #e5e7eb",
-        backgroundColor: "#ffffff",
-        padding: "1rem",
-      }}
     >
       {/* Allergen header — always visible */}
-      <div
-        className="mb-3 flex items-center justify-between"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          marginBottom: "0.75rem",
-        }}
-      >
-        <div
-          className="flex items-center gap-2"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "0.5rem",
-          }}
-        >
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
           <CategoryIcon category={entry.category} />
-          <span
-            className="text-sm font-semibold text-gray-900"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 600,
-              color: "#111827",
-            }}
-          >
+          <span className="text-sm font-semibold text-gray-900">
             {entry.common_name}
           </span>
         </div>
@@ -178,15 +119,7 @@ function AllergenCrossReactivityCard({
 
       {/* Food list — blurred for free tier */}
       <div>
-        <p
-          className="mb-2 text-xs font-medium text-gray-500"
-          style={{
-            fontSize: "0.75rem",
-            fontWeight: 500,
-            color: "#6b7280",
-            marginBottom: "0.5rem",
-          }}
-        >
+        <p className="mb-2 text-xs font-medium text-gray-500">
           Cross-reactive foods
         </p>
         {isPremium ? (
@@ -211,33 +144,13 @@ export function PfasPanel({ entries, isPremium }: PfasPanelProps) {
       data-testid="pfas-panel"
       aria-label="Food cross-reactivity panel"
       className="space-y-4"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "1rem",
-      }}
     >
       {/* Section header */}
       <div>
-        <h2
-          className="text-lg font-semibold text-gray-800"
-          style={{
-            fontSize: "1.125rem",
-            fontWeight: 600,
-            color: "#1f2937",
-            margin: 0,
-          }}
-        >
+        <h2 className="text-lg font-semibold text-gray-800">
           Food Cross-Reactivity (PFAS)
         </h2>
-        <p
-          className="mt-1 text-xs text-gray-500"
-          style={{
-            fontSize: "0.75rem",
-            color: "#6b7280",
-            marginTop: "0.25rem",
-          }}
-        >
+        <p className="mt-1 text-xs text-gray-500">
           Foods that may trigger oral symptoms due to pollen-food allergy
           syndrome
         </p>
@@ -259,7 +172,7 @@ export function PfasPanel({ entries, isPremium }: PfasPanelProps) {
       {!isPremium && (
         <div
           data-testid="pfas-upgrade-cta"
-          style={{ marginTop: "0.5rem" }}
+          className="mt-2"
         >
           <UpgradeCta feature="food cross-reactivity details" />
         </div>

--- a/components/referral/referral-progress.tsx
+++ b/components/referral/referral-progress.tsx
@@ -3,8 +3,6 @@
  *
  * Displays the user's referral progress toward the 3-friend unlock threshold.
  * Shows a visual progress bar and count (e.g., "2 of 3 friends invited").
- *
- * Uses dual styling (Tailwind + inline) per project convention.
  */
 
 import { REFERRAL_UNLOCK_THRESHOLD } from "@/lib/referral/constants";
@@ -31,32 +29,11 @@ export function ReferralProgress({
       <div
         data-testid="referral-progress"
         className={`rounded-lg border border-green-200 bg-green-50 p-4 ${className}`.trim()}
-        style={{
-          borderRadius: "0.5rem",
-          border: "1px solid #bbf7d0",
-          backgroundColor: "#f0fdf4",
-          padding: "1rem",
-        }}
       >
-        <p
-          className="text-sm font-semibold text-green-800"
-          style={{
-            fontSize: "0.875rem",
-            fontWeight: 600,
-            color: "#166534",
-            margin: 0,
-          }}
-        >
+        <p className="text-sm font-semibold text-green-800">
           All features unlocked!
         </p>
-        <p
-          className="mt-1 text-xs text-green-600"
-          style={{
-            fontSize: "0.75rem",
-            color: "#16a34a",
-            marginTop: "0.25rem",
-          }}
-        >
+        <p className="mt-1 text-xs text-green-600">
           Thank you for sharing Allergy Madness with {referralCount} friend
           {referralCount !== 1 ? "s" : ""}. Your premium features are permanently active.
         </p>
@@ -68,47 +45,18 @@ export function ReferralProgress({
     <div
       data-testid="referral-progress"
       className={`rounded-lg border border-gray-200 bg-white p-4 ${className}`.trim()}
-      style={{
-        borderRadius: "0.5rem",
-        border: "1px solid #e5e7eb",
-        backgroundColor: "#ffffff",
-        padding: "1rem",
-      }}
     >
-      <p
-        className="text-sm font-semibold text-gray-800"
-        style={{
-          fontSize: "0.875rem",
-          fontWeight: 600,
-          color: "#1f2937",
-          margin: 0,
-        }}
-      >
+      <p className="text-sm font-semibold text-gray-800">
         {progress} of {REFERRAL_UNLOCK_THRESHOLD} friends invited
       </p>
-      <p
-        className="mt-1 text-xs text-gray-500"
-        style={{
-          fontSize: "0.75rem",
-          color: "#6b7280",
-          marginTop: "0.25rem",
-        }}
-      >
+      <p className="mt-1 text-xs text-gray-500">
         Invite {REFERRAL_UNLOCK_THRESHOLD - progress} more friend
         {REFERRAL_UNLOCK_THRESHOLD - progress !== 1 ? "s" : ""} to unlock all features
       </p>
 
       {/* Progress bar */}
       <div
-        className="mt-3 h-2 w-full rounded-full bg-gray-100"
-        style={{
-          marginTop: "0.75rem",
-          height: "0.5rem",
-          width: "100%",
-          borderRadius: "9999px",
-          backgroundColor: "#f3f4f6",
-          overflow: "hidden",
-        }}
+        className="mt-3 h-2 w-full overflow-hidden rounded-full bg-gray-100"
         role="progressbar"
         aria-valuenow={progress}
         aria-valuemin={0}
@@ -117,25 +65,12 @@ export function ReferralProgress({
       >
         <div
           className="h-full rounded-full bg-indigo-500 transition-all duration-300"
-          style={{
-            height: "100%",
-            borderRadius: "9999px",
-            backgroundColor: "#6366f1",
-            width: `${progressPercent}%`,
-            transition: "width 300ms ease",
-          }}
+          style={{ width: `${progressPercent}%` }}
         />
       </div>
 
       {/* Step indicators */}
-      <div
-        className="mt-2 flex justify-between"
-        style={{
-          marginTop: "0.5rem",
-          display: "flex",
-          justifyContent: "space-between",
-        }}
-      >
+      <div className="mt-2 flex justify-between">
         {Array.from({ length: REFERRAL_UNLOCK_THRESHOLD }, (_, i) => (
           <div
             key={i}
@@ -144,18 +79,6 @@ export function ReferralProgress({
                 ? "bg-indigo-500 text-white"
                 : "bg-gray-100 text-gray-400"
             }`}
-            style={{
-              display: "flex",
-              height: "1.5rem",
-              width: "1.5rem",
-              alignItems: "center",
-              justifyContent: "center",
-              borderRadius: "9999px",
-              fontSize: "0.75rem",
-              fontWeight: 500,
-              backgroundColor: i < progress ? "#6366f1" : "#f3f4f6",
-              color: i < progress ? "#ffffff" : "#9ca3af",
-            }}
           >
             {i < progress ? "\u2713" : i + 1}
           </div>

--- a/components/referral/referral-share.tsx
+++ b/components/referral/referral-share.tsx
@@ -10,8 +10,6 @@
  *
  * IMPORTANT: Uses window.location.origin — never hardcodes URLs.
  * IMPORTANT: Referral links contain NO health data.
- *
- * Uses dual styling (Tailwind + inline) per project convention.
  */
 
 import { useState, useCallback } from "react";
@@ -41,7 +39,6 @@ export function ReferralShare({
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Fallback for environments where clipboard API is unavailable
       const textArea = document.createElement("textarea");
       textArea.value = referralLink;
       textArea.style.position = "fixed";
@@ -75,85 +72,32 @@ export function ReferralShare({
     <div
       data-testid="referral-share"
       className={`rounded-lg border border-gray-200 bg-white p-4 ${className}`.trim()}
-      style={{
-        borderRadius: "0.5rem",
-        border: "1px solid #e5e7eb",
-        backgroundColor: "#ffffff",
-        padding: "1rem",
-      }}
     >
-      <p
-        className="text-sm font-semibold text-gray-800"
-        style={{
-          fontSize: "0.875rem",
-          fontWeight: 600,
-          color: "#1f2937",
-          margin: 0,
-        }}
-      >
+      <p className="text-sm font-semibold text-gray-800">
         Your Referral Link
       </p>
 
       {/* Link display */}
-      <div
-        className="mt-2 flex items-center gap-2 rounded-md border border-gray-100 bg-gray-50 px-3 py-2"
-        style={{
-          marginTop: "0.5rem",
-          display: "flex",
-          alignItems: "center",
-          gap: "0.5rem",
-          borderRadius: "0.375rem",
-          border: "1px solid #f3f4f6",
-          backgroundColor: "#f9fafb",
-          padding: "0.5rem 0.75rem",
-        }}
-      >
+      <div className="mt-2 flex items-center gap-2 rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
         <code
           data-testid="referral-link-display"
           className="flex-1 truncate text-xs text-gray-600"
-          style={{
-            flex: 1,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            fontSize: "0.75rem",
-            color: "#4b5563",
-          }}
         >
           {referralLink}
         </code>
       </div>
 
       {/* Action buttons */}
-      <div
-        className="mt-3 flex gap-2"
-        style={{
-          marginTop: "0.75rem",
-          display: "flex",
-          gap: "0.5rem",
-        }}
-      >
+      <div className="mt-3 flex gap-2">
         <button
           type="button"
           onClick={handleCopy}
           data-testid="referral-copy-btn"
-          className={`flex-1 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+          className={`flex-1 cursor-pointer rounded-md border-none px-4 py-2 text-sm font-medium text-white transition-colors ${
             copied
-              ? "bg-green-500 text-white"
-              : "bg-indigo-500 text-white hover:bg-indigo-600"
+              ? "bg-green-500"
+              : "bg-indigo-500 hover:bg-indigo-600"
           }`}
-          style={{
-            flex: 1,
-            borderRadius: "0.375rem",
-            padding: "0.5rem 1rem",
-            fontSize: "0.875rem",
-            fontWeight: 500,
-            backgroundColor: copied ? "#22c55e" : "#6366f1",
-            color: "#ffffff",
-            border: "none",
-            cursor: "pointer",
-            transition: "background-color 150ms ease",
-          }}
         >
           {copied ? "Copied!" : "Copy Link"}
         </button>
@@ -163,33 +107,14 @@ export function ReferralShare({
             type="button"
             onClick={handleShare}
             data-testid="referral-share-btn"
-            className="flex-1 rounded-md border border-indigo-500 bg-white px-4 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-50"
-            style={{
-              flex: 1,
-              borderRadius: "0.375rem",
-              border: "1px solid #6366f1",
-              backgroundColor: "#ffffff",
-              padding: "0.5rem 1rem",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#4f46e5",
-              cursor: "pointer",
-              transition: "background-color 150ms ease",
-            }}
+            className="flex-1 cursor-pointer rounded-md border border-indigo-500 bg-white px-4 py-2 text-sm font-medium text-indigo-600 transition-colors hover:bg-indigo-50"
           >
             Share
           </button>
         )}
       </div>
 
-      <p
-        className="mt-2 text-xs text-gray-400"
-        style={{
-          marginTop: "0.5rem",
-          fontSize: "0.75rem",
-          color: "#9ca3af",
-        }}
-      >
+      <p className="mt-2 text-xs text-gray-400">
         Share this link with friends. When 3 sign up, all features unlock permanently.
       </p>
     </div>

--- a/components/report/download-button.tsx
+++ b/components/report/download-button.tsx
@@ -3,8 +3,6 @@
  *
  * Client component that triggers PDF report generation and download.
  * Calls the /api/report/pdf endpoint and triggers a browser download.
- *
- * Dual styling: Tailwind utility classes + inline styles.
  */
 
 "use client";
@@ -61,24 +59,7 @@ export function DownloadReportButton({
         onClick={handleDownload}
         disabled={isLoading}
         data-testid="download-report-button"
-        className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: "0.5rem",
-          borderRadius: "0.5rem",
-          backgroundColor: isLoading ? "#93c5fd" : "#2563eb",
-          paddingLeft: "1rem",
-          paddingRight: "1rem",
-          paddingTop: "0.5rem",
-          paddingBottom: "0.5rem",
-          fontSize: "0.875rem",
-          fontWeight: 500,
-          color: "#ffffff",
-          border: "none",
-          cursor: isLoading ? "not-allowed" : "pointer",
-          opacity: isLoading ? 0.5 : 1,
-        }}
+        className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {/* Download icon (inline SVG to avoid dependency) */}
         <svg
@@ -88,7 +69,7 @@ export function DownloadReportButton({
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
           aria-hidden="true"
-          style={{ width: "1rem", height: "1rem" }}
+          className="h-4 w-4"
         >
           <path
             d="M2 10v3a1 1 0 001 1h10a1 1 0 001-1v-3M8 2v8m0 0l3-3m-3 3L5 7"
@@ -106,11 +87,6 @@ export function DownloadReportButton({
           role="alert"
           data-testid="download-report-error"
           className="mt-2 text-sm text-red-600"
-          style={{
-            marginTop: "0.5rem",
-            fontSize: "0.875rem",
-            color: "#dc2626",
-          }}
         >
           {error}
         </p>

--- a/components/scout/scan-form.tsx
+++ b/components/scout/scan-form.tsx
@@ -25,15 +25,11 @@ export function ScanForm() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  /**
-   * Convert a File to base64 string (without the data URI prefix).
-   */
   const fileToBase64 = useCallback((file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => {
         const result = reader.result as string;
-        // Return the full data URI — the API will strip the prefix
         resolve(result);
       };
       reader.onerror = () => reject(new Error("Failed to read file"));
@@ -41,21 +37,16 @@ export function ScanForm() {
     });
   }, []);
 
-  /**
-   * Handle file selection (from camera or gallery).
-   */
   const handleFileChange = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
       if (!file) return;
 
-      // Validate file type
       if (!file.type.startsWith("image/")) {
         setError("Please select an image file");
         return;
       }
 
-      // Validate file size (4MB max)
       if (file.size > 4 * 1024 * 1024) {
         setError("Image must be under 4MB");
         return;
@@ -66,11 +57,9 @@ export function ScanForm() {
       setIsScanning(true);
 
       try {
-        // Create preview
         const base64 = await fileToBase64(file);
         setPreviewUrl(base64);
 
-        // Send to API
         const response = await fetch("/api/trigger-scout/scan", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -94,16 +83,10 @@ export function ScanForm() {
     [fileToBase64],
   );
 
-  /**
-   * Trigger the file input (camera or gallery).
-   */
   const handleCapture = useCallback(() => {
     fileInputRef.current?.click();
   }, []);
 
-  /**
-   * Reset state for a new scan.
-   */
   const handleReset = useCallback(() => {
     setError(null);
     setResults(null);
@@ -123,32 +106,18 @@ export function ScanForm() {
         capture="environment"
         onChange={handleFileChange}
         className="hidden"
-        style={{ display: "none" }}
         aria-label="Upload plant photo"
         data-testid="scout-file-input"
       />
 
       {/* Image preview */}
       {previewUrl && (
-        <div
-          className="mb-4 overflow-hidden rounded-lg border border-gray-200"
-          style={{
-            marginBottom: "1rem",
-            overflow: "hidden",
-            borderRadius: "0.5rem",
-            border: "1px solid #e5e7eb",
-          }}
-        >
+        <div className="mb-4 overflow-hidden rounded-lg border border-gray-200">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={previewUrl}
             alt="Plant photo preview"
             className="h-48 w-full object-cover"
-            style={{
-              width: "100%",
-              height: "12rem",
-              objectFit: "cover",
-            }}
             data-testid="scout-preview"
           />
         </div>
@@ -160,19 +129,7 @@ export function ScanForm() {
           type="button"
           onClick={handleCapture}
           disabled={isScanning}
-          className="w-full rounded-lg bg-green-600 px-4 py-3 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50"
-          style={{
-            width: "100%",
-            borderRadius: "0.5rem",
-            backgroundColor: isScanning ? "#9ca3af" : "#16a34a",
-            padding: "0.75rem 1rem",
-            fontSize: "0.875rem",
-            fontWeight: 600,
-            color: "#ffffff",
-            border: "none",
-            cursor: isScanning ? "wait" : "pointer",
-            opacity: isScanning ? 0.5 : 1,
-          }}
+          className="w-full cursor-pointer rounded-lg border-none bg-green-600 px-4 py-3 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50"
           data-testid="scout-capture-btn"
         >
           {isScanning ? "Scanning..." : "Take Photo or Upload"}
@@ -183,12 +140,6 @@ export function ScanForm() {
       {isScanning && (
         <p
           className="mt-3 text-center text-sm text-gray-500"
-          style={{
-            marginTop: "0.75rem",
-            textAlign: "center",
-            fontSize: "0.875rem",
-            color: "#6b7280",
-          }}
           data-testid="scout-scanning"
         >
           Analyzing plant image with AI...
@@ -199,19 +150,9 @@ export function ScanForm() {
       {error && (
         <div
           className="mt-3 rounded-md border border-red-200 bg-red-50 px-4 py-3"
-          style={{
-            marginTop: "0.75rem",
-            borderRadius: "0.375rem",
-            border: "1px solid #fecaca",
-            backgroundColor: "#fef2f2",
-            padding: "0.75rem 1rem",
-          }}
           data-testid="scout-error"
         >
-          <p
-            className="text-sm text-red-700"
-            style={{ fontSize: "0.875rem", color: "#b91c1c", margin: 0 }}
-          >
+          <p className="text-sm text-red-700">
             {error}
           </p>
         </div>
@@ -221,23 +162,11 @@ export function ScanForm() {
       {results && (
         <div
           className="mt-4"
-          style={{ marginTop: "1rem" }}
           data-testid="scout-results"
         >
           {results.matches.length === 0 ? (
-            <div
-              className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3"
-              style={{
-                borderRadius: "0.375rem",
-                border: "1px solid #e5e7eb",
-                backgroundColor: "#f9fafb",
-                padding: "0.75rem 1rem",
-              }}
-            >
-              <p
-                className="text-sm text-gray-600"
-                style={{ fontSize: "0.875rem", color: "#4b5563", margin: 0 }}
-              >
+            <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3">
+              <p className="text-sm text-gray-600">
                 No allergen-producing plants identified in this photo.
                 Try taking a closer photo of the plant.
               </p>
@@ -245,31 +174,13 @@ export function ScanForm() {
           ) : (
             <>
               {/* Summary */}
-              <div
-                className="mb-3"
-                style={{ marginBottom: "0.75rem" }}
-              >
-                <p
-                  className="text-sm font-medium text-gray-700"
-                  style={{
-                    fontSize: "0.875rem",
-                    fontWeight: 500,
-                    color: "#374151",
-                    margin: "0 0 0.25rem 0",
-                  }}
-                >
+              <div className="mb-3">
+                <p className="text-sm font-medium text-gray-700">
                   {results.matches.length} plant
                   {results.matches.length === 1 ? "" : "s"} identified
                 </p>
                 {results.active_count > 0 && (
-                  <p
-                    className="text-xs text-green-700"
-                    style={{
-                      fontSize: "0.75rem",
-                      color: "#15803d",
-                      margin: 0,
-                    }}
-                  >
+                  <p className="text-xs text-green-700">
                     {results.active_count} active — {results.proximity_multiplier}x
                     proximity multiplier applied
                   </p>
@@ -277,10 +188,7 @@ export function ScanForm() {
               </div>
 
               {/* Match cards */}
-              <div
-                className="space-y-2"
-                style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
-              >
+              <div className="space-y-2">
                 {results.matches.map((match) => (
                   <MatchCard key={match.allergen_id} match={match} />
                 ))}
@@ -292,19 +200,7 @@ export function ScanForm() {
           <button
             type="button"
             onClick={handleReset}
-            className="mt-4 w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-            style={{
-              marginTop: "1rem",
-              width: "100%",
-              borderRadius: "0.5rem",
-              border: "1px solid #d1d5db",
-              backgroundColor: "#ffffff",
-              padding: "0.5rem 1rem",
-              fontSize: "0.875rem",
-              fontWeight: 500,
-              color: "#374151",
-              cursor: "pointer",
-            }}
+            className="mt-4 w-full cursor-pointer rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
             data-testid="scout-reset-btn"
           >
             Scan Another Plant
@@ -329,42 +225,14 @@ function MatchCard({ match }: { match: ScanMatchResult }) {
           ? "border-green-200 bg-green-50"
           : "border-amber-200 bg-amber-50"
       }`}
-      style={{
-        borderRadius: "0.375rem",
-        border: `1px solid ${isActive ? "#bbf7d0" : "#fde68a"}`,
-        backgroundColor: isActive ? "#f0fdf4" : "#fffbeb",
-        padding: "0.75rem 1rem",
-      }}
       data-testid={`scout-match-${match.allergen_id}`}
     >
-      <div
-        className="flex items-center justify-between"
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
+      <div className="flex items-center justify-between">
         <div>
-          <p
-            className="text-sm font-semibold text-gray-900"
-            style={{
-              fontSize: "0.875rem",
-              fontWeight: 600,
-              color: "#111827",
-              margin: 0,
-            }}
-          >
+          <p className="text-sm font-semibold text-gray-900">
             {match.common_name}
           </p>
-          <p
-            className="text-xs text-gray-500"
-            style={{
-              fontSize: "0.75rem",
-              color: "#6b7280",
-              margin: "0.125rem 0 0 0",
-            }}
-          >
+          <p className="mt-0.5 text-xs text-gray-500">
             {match.category} &middot; {Math.round(match.confidence * 100)}%
             confidence
           </p>
@@ -375,14 +243,6 @@ function MatchCard({ match }: { match: ScanMatchResult }) {
               ? "bg-green-100 text-green-700"
               : "bg-amber-100 text-amber-700"
           }`}
-          style={{
-            borderRadius: "9999px",
-            padding: "0.25rem 0.5rem",
-            fontSize: "0.75rem",
-            fontWeight: 500,
-            backgroundColor: isActive ? "#dcfce7" : "#fef3c7",
-            color: isActive ? "#15803d" : "#b45309",
-          }}
           data-testid={`scout-badge-${match.allergen_id}`}
         >
           {isActive ? "Active" : "Dormant"}

--- a/components/shared/disclaimer-modal.tsx
+++ b/components/shared/disclaimer-modal.tsx
@@ -6,18 +6,6 @@
  * One-time gate shown before first leaderboard view.
  * Once the user clicks "I Understand", fda_acknowledged is set to true
  * in Supabase and the modal never appears again.
- *
- * This component:
- * - Renders a full-screen overlay with the FDA disclaimer
- * - Blocks interaction with the page behind it
- * - Cannot be dismissed without clicking "I Understand"
- * - Calls onAcknowledge callback after Supabase update succeeds
- *
- * Usage:
- *   <DisclaimerModal
- *     userId={user.id}
- *     onAcknowledge={() => setAcknowledged(true)}
- *   />
  */
 
 import { useState } from "react";
@@ -49,7 +37,6 @@ export function DisclaimerModal({
       const supabase = createClient();
       const { error: updateError } = await supabase
         .from("user_profiles")
-        // Supabase generic inference needs explicit cast for new columns
         .update({ fda_acknowledged: true } as never)
         .eq("id", userId);
 
@@ -73,85 +60,28 @@ export function DisclaimerModal({
       aria-labelledby="fda-modal-title"
       data-testid="disclaimer-modal"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        zIndex: 50,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "rgba(0, 0, 0, 0.5)",
-      }}
     >
-      <div
-        className="mx-4 max-w-md rounded-lg bg-white p-6 shadow-xl"
-        style={{
-          maxWidth: "28rem",
-          margin: "0 1rem",
-          backgroundColor: "#ffffff",
-          borderRadius: "0.5rem",
-          padding: "1.5rem",
-          boxShadow:
-            "0 20px 25px -5px rgba(0,0,0,.1), 0 8px 10px -6px rgba(0,0,0,.1)",
-        }}
-      >
+      <div className="mx-4 max-w-md rounded-lg bg-white p-6 shadow-xl">
         {/* Warning icon */}
-        <div
-          className="mb-4 flex items-center gap-2"
-          style={{
-            marginBottom: "1rem",
-            display: "flex",
-            alignItems: "center",
-            gap: "0.5rem",
-          }}
-        >
-          <span
-            className="text-2xl"
-            style={{ fontSize: "1.5rem" }}
-            aria-hidden="true"
-          >
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-2xl" aria-hidden="true">
             &#9888;
           </span>
           <h2
             id="fda-modal-title"
             className="text-lg font-bold text-gray-900"
-            style={{
-              fontSize: "1.125rem",
-              fontWeight: 700,
-              color: "#111827",
-              margin: 0,
-            }}
           >
             Important Health Disclaimer
           </h2>
         </div>
 
         {/* Disclaimer label */}
-        <p
-          className="mb-3 text-base font-semibold text-amber-800"
-          style={{
-            fontSize: "1rem",
-            fontWeight: 600,
-            color: "#92400e",
-            marginBottom: "0.75rem",
-          }}
-        >
+        <p className="mb-3 text-base font-semibold text-amber-800">
           {FDA_DISCLAIMER_LABEL}
         </p>
 
         {/* Full disclaimer text */}
-        <p
-          className="mb-6 text-sm leading-relaxed text-gray-600"
-          style={{
-            fontSize: "0.875rem",
-            lineHeight: 1.625,
-            color: "#4b5563",
-            marginBottom: "1.5rem",
-          }}
-        >
+        <p className="mb-6 text-sm leading-relaxed text-gray-600">
           {FDA_DISCLAIMER_FULL_TEXT}
         </p>
 
@@ -160,11 +90,6 @@ export function DisclaimerModal({
           <p
             data-testid="disclaimer-error"
             className="mb-3 text-sm text-red-600"
-            style={{
-              fontSize: "0.875rem",
-              color: "#dc2626",
-              marginBottom: "0.75rem",
-            }}
           >
             {error}
           </p>
@@ -175,19 +100,7 @@ export function DisclaimerModal({
           onClick={handleAcknowledge}
           disabled={loading}
           data-testid="acknowledge-button"
-          className="w-full rounded-md bg-amber-600 px-4 py-3 text-sm font-semibold text-white hover:bg-amber-700 disabled:opacity-50"
-          style={{
-            width: "100%",
-            borderRadius: "0.375rem",
-            backgroundColor: loading ? "#d97706" : "#d97706",
-            padding: "0.75rem 1rem",
-            fontSize: "0.875rem",
-            fontWeight: 600,
-            color: "#ffffff",
-            border: "none",
-            cursor: loading ? "not-allowed" : "pointer",
-            opacity: loading ? 0.5 : 1,
-          }}
+          className="w-full rounded-md bg-amber-600 px-4 py-3 text-sm font-semibold text-white hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {loading ? "Saving..." : "I Understand"}
         </button>

--- a/components/shared/fda-disclaimer.tsx
+++ b/components/shared/fda-disclaimer.tsx
@@ -55,12 +55,6 @@ export function FdaDisclaimer({
         aria-label="FDA disclaimer"
         data-testid="fda-disclaimer"
         className={`text-xs font-medium text-amber-700 ${className}`.trim()}
-        style={{
-          fontSize: "0.75rem",
-          fontWeight: 500,
-          color: "#b45309",
-          margin: 0,
-        }}
       >
         {FDA_DISCLAIMER_LABEL}
       </p>
@@ -73,32 +67,11 @@ export function FdaDisclaimer({
       aria-label="FDA disclaimer"
       data-testid="fda-disclaimer"
       className={`rounded-md border border-amber-200 bg-amber-50 px-4 py-3 ${className}`.trim()}
-      style={{
-        borderRadius: "0.375rem",
-        border: "1px solid #fde68a",
-        backgroundColor: "#fffbeb",
-        padding: "0.75rem 1rem",
-      }}
     >
-      <p
-        className="text-sm font-semibold text-amber-800"
-        style={{
-          fontSize: "0.875rem",
-          fontWeight: 600,
-          color: "#92400e",
-          margin: 0,
-        }}
-      >
+      <p className="text-sm font-semibold text-amber-800">
         {FDA_DISCLAIMER_LABEL}
       </p>
-      <p
-        className="mt-1 text-xs text-amber-700"
-        style={{
-          fontSize: "0.75rem",
-          color: "#b45309",
-          marginTop: "0.25rem",
-        }}
-      >
+      <p className="mt-1 text-xs text-amber-700">
         {FDA_DISCLAIMER_FULL_TEXT}
       </p>
     </div>

--- a/components/subscription/premium-badge.tsx
+++ b/components/subscription/premium-badge.tsx
@@ -3,8 +3,6 @@
  *
  * Small badge indicating a feature requires premium access.
  * Shown next to gated features in the UI.
- *
- * Dual styling: Tailwind utility classes + inline styles.
  */
 
 import type { SubscriptionTier } from "@/lib/subscription/types";
@@ -27,20 +25,6 @@ export function PremiumBadge({
       <span
         data-testid="premium-badge"
         className="inline-flex items-center gap-1 rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700"
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: "0.25rem",
-          borderRadius: "9999px",
-          backgroundColor: "#f3e8ff",
-          paddingLeft: "0.5rem",
-          paddingRight: "0.5rem",
-          paddingTop: "0.125rem",
-          paddingBottom: "0.125rem",
-          fontSize: "0.75rem",
-          fontWeight: 500,
-          color: "#7c3aed",
-        }}
       >
         {!compact && <span aria-hidden="true">&#x2B50;</span>}
         Madness+
@@ -52,20 +36,6 @@ export function PremiumBadge({
     <span
       data-testid="premium-badge-locked"
       className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500"
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: "0.25rem",
-        borderRadius: "9999px",
-        backgroundColor: "#f3f4f6",
-        paddingLeft: "0.5rem",
-        paddingRight: "0.5rem",
-        paddingTop: "0.125rem",
-        paddingBottom: "0.125rem",
-        fontSize: "0.75rem",
-        fontWeight: 500,
-        color: "#6b7280",
-      }}
     >
       {!compact && <span aria-hidden="true">&#x1F512;</span>}
       Premium

--- a/components/subscription/upgrade-cta.tsx
+++ b/components/subscription/upgrade-cta.tsx
@@ -3,8 +3,6 @@
  *
  * Prompts free-tier users to upgrade to Madness+ or unlock via referrals.
  * Shown alongside the blur overlay on gated content.
- *
- * Dual styling: Tailwind utility classes + inline styles.
  */
 
 "use client";
@@ -24,37 +22,11 @@ export function UpgradeCta({
     <div
       data-testid="upgrade-cta"
       className="mx-auto max-w-md rounded-xl border border-purple-200 bg-gradient-to-br from-purple-50 to-white p-6 text-center shadow-md"
-      style={{
-        maxWidth: "28rem",
-        margin: "0 auto",
-        borderRadius: "0.75rem",
-        border: "1px solid #e9d5ff",
-        background: "linear-gradient(to bottom right, #faf5ff, #ffffff)",
-        padding: "1.5rem",
-        textAlign: "center",
-        boxShadow:
-          "0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1)",
-      }}
     >
-      <h3
-        className="mb-2 text-lg font-bold text-purple-900"
-        style={{
-          fontSize: "1.125rem",
-          fontWeight: 700,
-          color: "#581c87",
-          marginBottom: "0.5rem",
-        }}
-      >
+      <h3 className="mb-2 text-lg font-bold text-purple-900">
         Unlock {feature}
       </h3>
-      <p
-        className="mb-4 text-sm text-gray-600"
-        style={{
-          fontSize: "0.875rem",
-          color: "#4b5563",
-          marginBottom: "1rem",
-        }}
-      >
+      <p className="mb-4 text-sm text-gray-600">
         Get the full picture of your allergen triggers with Madness+.
       </p>
 
@@ -62,23 +34,7 @@ export function UpgradeCta({
       <button
         type="button"
         data-testid="upgrade-cta-subscribe"
-        className="mb-3 w-full rounded-lg bg-purple-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-700"
-        style={{
-          width: "100%",
-          borderRadius: "0.5rem",
-          backgroundColor: "#9333ea",
-          paddingLeft: "1rem",
-          paddingRight: "1rem",
-          paddingTop: "0.625rem",
-          paddingBottom: "0.625rem",
-          fontSize: "0.875rem",
-          fontWeight: 600,
-          color: "#ffffff",
-          border: "none",
-          cursor: "pointer",
-          marginBottom: "0.75rem",
-          boxShadow: "0 1px 2px 0 rgba(0,0,0,.05)",
-        }}
+        className="mb-3 w-full cursor-pointer rounded-lg border-none bg-purple-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-purple-700"
         onClick={() => {
           // Placeholder — will connect to RevenueCat paywall
         }}
@@ -91,10 +47,6 @@ export function UpgradeCta({
         <p
           data-testid="upgrade-cta-referral"
           className="text-xs text-gray-500"
-          style={{
-            fontSize: "0.75rem",
-            color: "#6b7280",
-          }}
         >
           Or invite {referralsNeeded} friend{referralsNeeded !== 1 ? "s" : ""}{" "}
           to unlock for free

--- a/lib/pdf/report.ts
+++ b/lib/pdf/report.ts
@@ -18,6 +18,7 @@ import {
   FDA_DISCLAIMER_LABEL,
   FDA_DISCLAIMER_FULL_TEXT,
 } from "@/components/shared/fda-disclaimer";
+import { PDF_COLORS } from "@/lib/theme";
 import type { PdfReportInput, PdfAllergenEntry } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -31,14 +32,14 @@ const MARGIN_RIGHT = 20;
 const CONTENT_WIDTH = PAGE_WIDTH - MARGIN_LEFT - MARGIN_RIGHT;
 const FOOTER_Y = PAGE_HEIGHT - 25;
 
-const COLOR_PRIMARY = [59, 130, 246] as const; // Blue-500
-const COLOR_GOLD = [234, 179, 8] as const; // Amber/Gold for champion
-const COLOR_TEXT = [31, 41, 55] as const; // Gray-800
-const COLOR_MUTED = [107, 114, 128] as const; // Gray-500
-const COLOR_BORDER = [209, 213, 219] as const; // Gray-300
-const COLOR_BG_LIGHT = [249, 250, 251] as const; // Gray-50
-const COLOR_AMBER_BG = [255, 251, 235] as const; // Amber-50
-const COLOR_AMBER_TEXT = [146, 64, 14] as const; // Amber-800
+const COLOR_PRIMARY = PDF_COLORS.primary;
+const COLOR_GOLD = PDF_COLORS.gold;
+const COLOR_TEXT = PDF_COLORS.textSecondary;
+const COLOR_MUTED = PDF_COLORS.textMuted;
+const COLOR_BORDER = PDF_COLORS.border;
+const COLOR_BG_LIGHT = PDF_COLORS.bgLight;
+const COLOR_AMBER_BG = PDF_COLORS.amberBg;
+const COLOR_AMBER_TEXT = PDF_COLORS.amberText;
 
 const TIER_LABELS: Record<string, string> = {
   very_high: "Very High",

--- a/lib/theme/colors.ts
+++ b/lib/theme/colors.ts
@@ -1,0 +1,87 @@
+/**
+ * Champ Health Brand Color Tokens
+ *
+ * Server-side color constants for PDF reports and non-CSS contexts.
+ * These values MUST stay in sync with the CSS custom properties
+ * defined in app/globals.css.
+ *
+ * For UI components, use Tailwind utility classes instead:
+ *   bg-brand-primary, text-brand-accent, border-brand-warning, etc.
+ *
+ * For PDF generation (jsPDF), use the RGB tuples exported here.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Hex values (for any server-side string context)                     */
+/* ------------------------------------------------------------------ */
+
+export const BRAND_COLORS = {
+  /** Health-forward blue — primary actions, links, active states */
+  primary: "#2563eb",
+  primaryLight: "#dbeafe",
+  primaryDark: "#1d4ed8",
+
+  /** Wellness green — success states, positive indicators */
+  accent: "#16a34a",
+  accentLight: "#dcfce7",
+  accentDark: "#15803d",
+
+  /** FDA disclaimer amber — warnings, regulatory notices */
+  warning: "#d97706",
+  warningLight: "#fffbeb",
+  warningDark: "#92400e",
+
+  /** Alert red — errors, destructive actions */
+  error: "#dc2626",
+  errorLight: "#fef2f2",
+  errorDark: "#991b1b",
+
+  /** Madness+ purple — premium features, upgrade prompts */
+  premium: "#9333ea",
+  premiumLight: "#faf5ff",
+  premiumDark: "#581c87",
+
+  /** Surface — backgrounds */
+  surface: "#ffffff",
+  surfaceMuted: "#f9fafb",
+
+  /** Borders */
+  border: "#e5e7eb",
+  borderLight: "#f3f4f6",
+
+  /** Text hierarchy */
+  text: "#111827",
+  textSecondary: "#4b5563",
+  textMuted: "#6b7280",
+  textFaint: "#9ca3af",
+
+  /** Champion gold — trigger champion card */
+  gold: "#eab308",
+  goldLight: "#fffbeb",
+  goldDark: "#b45309",
+  goldBorder: "#fbbf24",
+} as const;
+
+/* ------------------------------------------------------------------ */
+/* RGB tuples for jsPDF (0-255)                                        */
+/* ------------------------------------------------------------------ */
+
+export const PDF_COLORS = {
+  primary: [37, 99, 235] as const,
+  gold: [234, 179, 8] as const,
+  text: [17, 24, 39] as const,
+  textSecondary: [31, 41, 55] as const,
+  textMuted: [107, 114, 128] as const,
+  border: [209, 213, 219] as const,
+  bgLight: [249, 250, 251] as const,
+  amberBg: [255, 251, 235] as const,
+  amberText: [146, 64, 14] as const,
+  white: [255, 255, 255] as const,
+} as const;
+
+/* ------------------------------------------------------------------ */
+/* Type exports                                                        */
+/* ------------------------------------------------------------------ */
+
+export type BrandColor = keyof typeof BRAND_COLORS;
+export type PdfColor = keyof typeof PDF_COLORS;

--- a/lib/theme/index.ts
+++ b/lib/theme/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Champ Health Design System — Theme Barrel Export
+ *
+ * Central export point for all design tokens.
+ * Import from `@/lib/theme` for server-side color access.
+ * For UI components, prefer Tailwind utility classes.
+ */
+
+export { BRAND_COLORS, PDF_COLORS } from "./colors";
+export type { BrandColor, PdfColor } from "./colors";

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,16 +17,33 @@
         "react-dom": "^19"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.2",
         "@testing-library/react": "^16",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4",
+        "autoprefixer": "^10.4.27",
         "eslint": "^9",
         "eslint-config-next": "^15",
         "jsdom": "^26",
+        "postcss": "^8.5.8",
+        "tailwindcss": "^4.2.2",
         "typescript": "^5",
         "vitest": "^3"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3782,6 +3799,289 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
+      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.2"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -5285,6 +5585,43 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.27",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
+      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-lite": "^1.0.30001774",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5918,8 +6255,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6000,7 +6337,6 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
       "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.0"
@@ -7071,6 +7407,20 @@
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "license": "MIT"
     },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7336,8 +7686,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -8084,6 +8433,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8294,6 +8653,279 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/loader-runner": {
@@ -8602,6 +9234,34 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-exports-info": {
@@ -9058,9 +9718,10 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9077,13 +9738,20 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -10213,12 +10881,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tapable": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -10800,35 +11474,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.11",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -20,14 +20,18 @@
     "react-dom": "^19"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/react": "^16",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",
+    "autoprefixer": "^10.4.27",
     "eslint": "^9",
     "eslint-config-next": "^15",
     "jsdom": "^26",
+    "postcss": "^8.5.8",
+    "tailwindcss": "^4.2.2",
     "typescript": "^5",
     "vitest": "^3"
   }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#2563EB"/>
+  <text x="16" y="23" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="18" fill="white">A</text>
+</svg>


### PR DESCRIPTION
## Summary

- Install and configure **Tailwind CSS v4** with `@tailwindcss/postcss` and define brand color tokens via the `@theme` directive in `globals.css`
- Create centralized **design tokens** in `lib/theme/` (`BRAND_COLORS` hex map + `PDF_COLORS` RGB tuples) for server-side usage (PDF reports)
- Remove **inline style fallbacks** from all 26 components, replacing the dual-styling workaround with pure Tailwind classes
- Update **PDF report** (`lib/pdf/report.ts`) to import shared `PDF_COLORS` from `lib/theme`
- Add **Champ Health favicon** (`public/favicon.svg`) and update `app/layout.tsx` metadata
- Add **design token tests** with WCAG 2.1 AA contrast ratio validation (13 new tests, 697 total passing)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 697/697 tests pass (including 13 new design token tests)
- [x] `npm run build` succeeds
- [ ] Visual spot-check in browser: colors render correctly via Tailwind classes
- [ ] PDF download produces correctly colored report

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)