### PR TITLE
fix(schema): widen CCRS CHECK constraint from 0-3 to 0-100

### DIFF
--- a/scripts/deploy-schema.sql
+++ b/scripts/deploy-schema.sql
@@ -41,8 +41,8 @@ CREATE TABLE user_profiles (
                           'wood_frame','brick_old','brick_modern',
                           'concrete_highrise','modern_sealed','other')),
 
-  -- Cockroach Climate Risk Score 0-3 (derived from home_state at onboarding)
-  ccrs                  SMALLINT DEFAULT 1 CHECK (ccrs BETWEEN 0 AND 3),
+  -- Cockroach Climate Risk Score 0-100 (derived from home_state at onboarding)
+  ccrs                  SMALLINT DEFAULT 0 CHECK (ccrs BETWEEN 0 AND 100),
 
   -- Indoor allergen context
   has_pets              BOOLEAN DEFAULT FALSE,
@@ -213,7 +213,7 @@ CREATE TABLE user_locations (
   state           TEXT,
   country_code    TEXT DEFAULT 'US',
   region          TEXT,
-  ccrs            SMALLINT DEFAULT 1 CHECK (ccrs BETWEEN 0 AND 3),
+  ccrs            SMALLINT DEFAULT 0 CHECK (ccrs BETWEEN 0 AND 100),
 
   -- Indoor profile at this location
   year_built      INT,

--- a/supabase/migrations/20260331150000_fix_ccrs_constraint.sql
+++ b/supabase/migrations/20260331150000_fix_ccrs_constraint.sql
@@ -1,0 +1,9 @@
+-- Fix CCRS constraint: allow 0-100 scale (was 0-3)
+-- The onboarding code and engine use 0-100 for graduated multipliers
+-- Ticket: #99
+
+ALTER TABLE user_profiles DROP CONSTRAINT IF EXISTS user_profiles_ccrs_check;
+ALTER TABLE user_profiles ADD CONSTRAINT user_profiles_ccrs_check CHECK (ccrs BETWEEN 0 AND 100);
+
+ALTER TABLE user_locations DROP CONSTRAINT IF EXISTS user_locations_ccrs_check;
+ALTER TABLE user_locations ADD CONSTRAINT user_locations_ccrs_check CHECK (ccrs BETWEEN 0 AND 100);


### PR DESCRIPTION
## Summary
- Widened CCRS CHECK constraint from `0-3` to `0-100` on both `user_profiles` and `user_locations` tables in `scripts/deploy-schema.sql`
- Created Supabase migration `20260331150000_fix_ccrs_constraint.sql` to ALTER the constraint on the live database
- The base migration already had no CHECK constraint on CCRS, so no changes needed there

## Root Cause
The deployed schema constrained CCRS to `BETWEEN 0 AND 3` but the onboarding code and engine compute CCRS on a 0-100 scale for graduated multipliers. This caused `user_profiles_ccrs_check` violations blocking new user registration.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — all 740 tests pass
- [x] `npm run build` — production build succeeds
- [ ] After merge, run migration on Supabase to fix live DB
- [ ] Verify new user onboarding completes without constraint violation

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)