### PR TITLE
refactor(apis): remove unused GeocodingError export

### DIFF
--- a/lib/apis/geocoding.ts
+++ b/lib/apis/geocoding.ts
@@ -23,11 +23,6 @@ export interface GeocodingResult {
   is_continental_us: boolean;
 }
 
-export interface GeocodingError {
-  error: string;
-  status: string;
-}
-
 /* ------------------------------------------------------------------ */
 /* Continental US bounds                                                */
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- Removes the unused `GeocodingError` interface export from `lib/apis/geocoding.ts`
- Confirmed no other file imports this interface — pure dead code removal

Closes #43

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (751 tests)
- [x] `npm run build` succeeds
- [x] Grep confirms no remaining references to `GeocodingError`