### PR TITLE
refactor(engine): deduplicate computeConfidenceTier into shared import

### DIFF
--- a/__tests__/engine/confidence.test.ts
+++ b/__tests__/engine/confidence.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   getConfidenceTier,
+  getConfidenceTierBySignals,
   getAllConfidenceTiers,
   getConfidenceLabel,
 } from "@/lib/engine/confidence";
@@ -41,6 +42,41 @@ describe("getConfidenceTier", () => {
     expect(getConfidenceTier(1199)).toBe("medium");
     expect(getConfidenceTier(900)).toBe("medium");
     expect(getConfidenceTier(899)).toBe("low");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* getConfidenceTierBySignals                                          */
+/* ------------------------------------------------------------------ */
+
+describe("getConfidenceTierBySignals", () => {
+  it("returns 'very_high' for totalSignals >= 30", () => {
+    expect(getConfidenceTierBySignals(30)).toBe("very_high");
+    expect(getConfidenceTierBySignals(50)).toBe("very_high");
+  });
+
+  it("returns 'high' for 14 <= totalSignals < 30", () => {
+    expect(getConfidenceTierBySignals(14)).toBe("high");
+    expect(getConfidenceTierBySignals(29)).toBe("high");
+  });
+
+  it("returns 'medium' for 7 <= totalSignals < 14", () => {
+    expect(getConfidenceTierBySignals(7)).toBe("medium");
+    expect(getConfidenceTierBySignals(13)).toBe("medium");
+  });
+
+  it("returns 'low' for totalSignals < 7", () => {
+    expect(getConfidenceTierBySignals(6)).toBe("low");
+    expect(getConfidenceTierBySignals(0)).toBe("low");
+  });
+
+  it("handles edge cases at tier boundaries", () => {
+    expect(getConfidenceTierBySignals(30)).toBe("very_high");
+    expect(getConfidenceTierBySignals(29)).toBe("high");
+    expect(getConfidenceTierBySignals(14)).toBe("high");
+    expect(getConfidenceTierBySignals(13)).toBe("medium");
+    expect(getConfidenceTierBySignals(7)).toBe("medium");
+    expect(getConfidenceTierBySignals(6)).toBe("low");
   });
 });
 

--- a/app/(app)/dashboard/dashboard-leaderboard.tsx
+++ b/app/(app)/dashboard/dashboard-leaderboard.tsx
@@ -3,61 +3,29 @@
 /**
  * Dashboard Leaderboard Wrapper
  *
- * Client component that receives server-fetched data and renders
- * the Leaderboard component. This separation keeps data fetching
- * in the server component while allowing client interactivity
- * (FDA disclaimer acknowledgment, etc.).
+ * Client component that receives server-computed ranked allergens
+ * and renders the Leaderboard component. Confidence tiers are
+ * computed server-side via the engine module and passed as props.
  */
 
 import { Leaderboard } from "@/components/leaderboard";
 import type { RankedAllergen } from "@/components/leaderboard/types";
-import type { ConfidenceTier } from "@/lib/engine/types";
-
-/** Shape of an Elo row from the server component's Supabase query */
-interface EloRow {
-  allergen_id: string;
-  elo_score: number;
-  positive_signals: number;
-  negative_signals: number;
-  allergens: {
-    common_name: string;
-    category: string;
-  };
-}
 
 interface DashboardLeaderboardProps {
-  eloRows: EloRow[];
+  allergens: RankedAllergen[];
   isPremium: boolean;
   isEnvironmentalForecast: boolean;
   fdaAcknowledged: boolean;
   userId: string;
 }
 
-function computeConfidenceTier(totalSignals: number): ConfidenceTier {
-  if (totalSignals >= 30) return "very_high";
-  if (totalSignals >= 14) return "high";
-  if (totalSignals >= 7) return "medium";
-  return "low";
-}
-
 export function DashboardLeaderboard({
-  eloRows,
+  allergens,
   isPremium,
   isEnvironmentalForecast,
   fdaAcknowledged,
   userId,
 }: DashboardLeaderboardProps) {
-  const allergens: RankedAllergen[] = eloRows.map((row, index) => ({
-    allergen_id: row.allergen_id,
-    common_name: row.allergens.common_name,
-    category: row.allergens.category as RankedAllergen["category"],
-    elo_score: row.elo_score,
-    confidence_tier: computeConfidenceTier(
-      row.positive_signals + row.negative_signals
-    ),
-    rank: index + 1,
-  }));
-
   return (
     <Leaderboard
       allergens={allergens}

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { getConfidenceTierBySignals } from "@/lib/engine";
+import type { RankedAllergen } from "@/components/leaderboard/types";
 import { SignOutButton } from "./sign-out-button";
 import { DashboardLeaderboard } from "./dashboard-leaderboard";
 
@@ -37,6 +39,7 @@ export default async function DashboardPage() {
     .single();
 
   const profile = profileData as { fda_acknowledged: boolean } | null;
+  const fdaAcknowledged = profile?.fda_acknowledged ?? false;
 
   // Fetch subscription tier
   const { data: subscriptionData } = await supabase
@@ -69,6 +72,18 @@ export default async function DashboardPage() {
     .order("elo_score", { ascending: false });
 
   const eloRows = (rawEloRows ?? []) as unknown as EloRowWithAllergen[];
+
+  // Map to ranked allergens with confidence tiers (server-side computation)
+  const allergens: RankedAllergen[] = eloRows.map((row, index) => ({
+    allergen_id: row.allergen_id,
+    common_name: row.allergens.common_name,
+    category: row.allergens.category as RankedAllergen["category"],
+    elo_score: row.elo_score,
+    confidence_tier: getConfidenceTierBySignals(
+      row.positive_signals + row.negative_signals
+    ),
+    rank: index + 1,
+  }));
 
   // Determine if we should show Environmental Forecast mode.
   // Forecast mode activates when the user's most recent check-in has severity = 0,
@@ -151,10 +166,10 @@ export default async function DashboardPage() {
       </div>
 
       <DashboardLeaderboard
-        eloRows={eloRows}
+        allergens={allergens}
         isPremium={isPremium}
         isEnvironmentalForecast={isEnvironmentalForecast}
-        fdaAcknowledged={profile?.fda_acknowledged ?? false}
+        fdaAcknowledged={fdaAcknowledged}
         userId={user.id}
       />
     </div>

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import type { ConfidenceTier } from "@/lib/engine/types";
+import { getConfidenceTierBySignals } from "@/lib/engine";
 import type { RankedAllergen } from "@/components/leaderboard/types";
 
 /**
@@ -108,7 +108,7 @@ export async function GET() {
     common_name: row.allergens.common_name,
     category: row.allergens.category as RankedAllergen["category"],
     elo_score: row.elo_score,
-    confidence_tier: computeConfidenceTier(
+    confidence_tier: getConfidenceTierBySignals(
       row.positive_signals + row.negative_signals
     ),
     rank: index + 1,
@@ -122,13 +122,3 @@ export async function GET() {
   });
 }
 
-/**
- * Compute confidence tier based on total signal count.
- * More signals = higher confidence in the ranking.
- */
-function computeConfidenceTier(totalSignals: number): ConfidenceTier {
-  if (totalSignals >= 30) return "very_high";
-  if (totalSignals >= 14) return "high";
-  if (totalSignals >= 7) return "medium";
-  return "low";
-}

--- a/app/api/report/pdf/route.ts
+++ b/app/api/report/pdf/route.ts
@@ -14,7 +14,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { generateReportPdf } from "@/lib/pdf";
 import type { PdfAllergenEntry } from "@/lib/pdf";
-import type { ConfidenceTier } from "@/lib/engine/types";
+import { getConfidenceTierBySignals } from "@/lib/engine";
 
 /** Shape returned by the Supabase join query */
 interface EloRowWithAllergen {
@@ -26,16 +26,6 @@ interface EloRowWithAllergen {
     common_name: string;
     category: string;
   };
-}
-
-/**
- * Compute confidence tier based on total signal count.
- */
-function computeConfidenceTier(totalSignals: number): ConfidenceTier {
-  if (totalSignals >= 30) return "very_high";
-  if (totalSignals >= 14) return "high";
-  if (totalSignals >= 7) return "medium";
-  return "low";
 }
 
 export async function GET() {
@@ -111,7 +101,7 @@ export async function GET() {
     common_name: row.allergens.common_name,
     category: row.allergens.category as PdfAllergenEntry["category"],
     elo_score: row.elo_score,
-    confidence_tier: computeConfidenceTier(
+    confidence_tier: getConfidenceTierBySignals(
       row.positive_signals + row.negative_signals
     ),
   }));

--- a/lib/engine/confidence.ts
+++ b/lib/engine/confidence.ts
@@ -48,6 +48,38 @@ export function getConfidenceTier(eloScore: number): ConfidenceTier {
   return DEFAULT_TIER;
 }
 
+/* ------------------------------------------------------------------ */
+/* Signal-count thresholds                                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Signal-count tier boundaries.
+ * Used when a pre-computed Elo score is unavailable and only the raw
+ * positive + negative signal count is known (e.g. leaderboard API,
+ * PDF report generation).
+ * Order matters — checked from highest to lowest.
+ */
+const SIGNAL_TIER_THRESHOLDS: { min: number; tier: ConfidenceTier }[] = [
+  { min: 30, tier: "very_high" },
+  { min: 14, tier: "high" },
+  { min: 7, tier: "medium" },
+];
+
+/**
+ * Map a total signal count to a confidence tier.
+ *
+ * @param totalSignals — sum of positive + negative signals
+ * @returns confidence tier
+ */
+export function getConfidenceTierBySignals(
+  totalSignals: number,
+): ConfidenceTier {
+  for (const { min, tier } of SIGNAL_TIER_THRESHOLDS) {
+    if (totalSignals >= min) return tier;
+  }
+  return DEFAULT_TIER;
+}
+
 /**
  * Map multiple allergens' Elo scores to confidence tiers.
  *

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -64,6 +64,7 @@ export {
 // Confidence tiers
 export {
   getConfidenceTier,
+  getConfidenceTierBySignals,
   getAllConfidenceTiers,
   getConfidenceLabel,
 } from "./confidence";


### PR DESCRIPTION
## Summary

- Extracts signal-count-based confidence tier logic into `getConfidenceTierBySignals()` in `lib/engine/confidence.ts`, exported via the engine barrel
- Removes 3 duplicate `computeConfidenceTier()` implementations from `app/api/leaderboard/route.ts`, `app/api/report/pdf/route.ts`, and `app/(app)/dashboard/dashboard-leaderboard.tsx`
- Moves confidence tier computation for the dashboard from the client component to the server component (`page.tsx`), passing pre-mapped `RankedAllergen[]` as props — respecting the engine's server-side-only constraint

## Test plan

- [x] New unit tests for `getConfidenceTierBySignals` boundary values (30/14/7 thresholds)
- [x] All 756 existing tests pass (74 test files)
- [x] Lint clean, typecheck clean, production build succeeds
- [ ] Verify leaderboard renders correctly in PR preview
- [ ] Verify PDF report download still works

Closes #54