### PR TITLE
feat(ui): replace scaffold with branded landing page

### DIFF
--- a/__tests__/components/layout/nav-header.test.tsx
+++ b/__tests__/components/layout/nav-header.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// Mock next/navigation
+let mockPathname = "/dashboard";
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { NavHeader } from "@/components/layout/nav-header";
+
+describe("NavHeader", () => {
+  it("renders the app name as a link to dashboard", () => {
+    render(<NavHeader />);
+
+    const logoLink = screen.getByText("Allergy Madness");
+    expect(logoLink).toBeDefined();
+    expect(logoLink.closest("a")?.getAttribute("href")).toBe("/dashboard");
+  });
+
+  it("renders all navigation links", () => {
+    render(<NavHeader />);
+
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((l) => l.getAttribute("href"));
+
+    expect(hrefs).toContain("/dashboard");
+    expect(hrefs).toContain("/checkin");
+    expect(hrefs).toContain("/children");
+    expect(hrefs).toContain("/scout");
+  });
+
+  it("highlights the active link based on pathname", () => {
+    mockPathname = "/checkin";
+    render(<NavHeader />);
+
+    // The checkin links (desktop + mobile) should have the active style
+    const checkinLinks = screen.getAllByText("Check-in");
+    for (const link of checkinLinks) {
+      expect(link.className).toContain("text-brand-primary");
+    }
+  });
+
+  it("has a test ID for integration targeting", () => {
+    render(<NavHeader />);
+    expect(screen.getByTestId("nav-header")).toBeDefined();
+  });
+
+  it("toggles mobile menu on hamburger click", () => {
+    mockPathname = "/dashboard";
+    render(<NavHeader />);
+
+    const menuButton = screen.getByLabelText("Open menu");
+    fireEvent.click(menuButton);
+
+    // After opening, the button label should change
+    expect(screen.getByLabelText("Close menu")).toBeDefined();
+  });
+});

--- a/__tests__/landing-page.test.tsx
+++ b/__tests__/landing-page.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Track redirect calls
+const redirectMock = vi.fn();
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => {
+    redirectMock(...args);
+    // redirect throws in Next.js to halt rendering
+    throw new Error("NEXT_REDIRECT");
+  },
+}));
+
+// Mock next/link as a simple anchor
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Default: unauthenticated user
+let mockUser: { id: string; email: string } | null = null;
+let mockProfileData: { home_region: string | null } | null = null;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockImplementation(async () => ({
+    auth: {
+      getUser: async () => ({
+        data: { user: mockUser },
+      }),
+    },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: async () => ({
+            data: mockProfileData,
+          }),
+        }),
+      }),
+    }),
+  })),
+}));
+
+import HomePage from "@/app/page";
+
+describe("HomePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = null;
+    mockProfileData = null;
+  });
+
+  describe("Unauthenticated users", () => {
+    it("renders the branded landing page", async () => {
+      const Page = await HomePage();
+      render(Page);
+
+      expect(
+        screen.getByRole("heading", {
+          name: /predict your allergy triggers/i,
+        }),
+      ).toBeDefined();
+    });
+
+    it("shows Allergy Madness branding", async () => {
+      const Page = await HomePage();
+      render(Page);
+
+      expect(screen.getByText("Allergy Madness")).toBeDefined();
+    });
+
+    it('has a "Get Started Free" CTA linking to signup', async () => {
+      const Page = await HomePage();
+      render(Page);
+
+      const cta = screen.getAllByText(/get started/i);
+      expect(cta.length).toBeGreaterThan(0);
+
+      // At least one should link to /signup
+      const signupLinks = screen
+        .getAllByRole("link")
+        .filter(
+          (link) =>
+            link.getAttribute("href") === "/signup" &&
+            link.textContent?.match(/get started/i),
+        );
+      expect(signupLinks.length).toBeGreaterThan(0);
+    });
+
+    it('has a "Sign In" link to /login', async () => {
+      const Page = await HomePage();
+      render(Page);
+
+      const signInLinks = screen
+        .getAllByRole("link")
+        .filter((link) => link.getAttribute("href") === "/login");
+      expect(signInLinks.length).toBeGreaterThan(0);
+    });
+
+    it("displays the FDA disclaimer", async () => {
+      const Page = await HomePage();
+      render(Page);
+
+      expect(
+        screen.getByText(/predicted triggers/i),
+      ).toBeDefined();
+    });
+
+    it("shows the How It Works section", async () => {
+      const Page = await HomePage();
+      render(Page);
+
+      expect(
+        screen.getByRole("heading", { name: /how it works/i }),
+      ).toBeDefined();
+    });
+
+    it("shows the Features section", async () => {
+      const Page = await HomePage();
+      render(Page);
+
+      expect(
+        screen.getByRole("heading", { name: /features/i }),
+      ).toBeDefined();
+      expect(screen.getByText(/symptom check-in/i)).toBeDefined();
+      expect(screen.getByText(/trigger leaderboard/i)).toBeDefined();
+      expect(screen.getByText(/trigger scout/i)).toBeDefined();
+    });
+  });
+
+  describe("Authenticated users with completed profile", () => {
+    it("redirects to /dashboard", async () => {
+      mockUser = { id: "user-1", email: "test@example.com" };
+      mockProfileData = { home_region: "Southeast" };
+
+      await expect(HomePage()).rejects.toThrow("NEXT_REDIRECT");
+      expect(redirectMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  describe("Authenticated users without completed profile", () => {
+    it("redirects to /onboarding", async () => {
+      mockUser = { id: "user-2", email: "new@example.com" };
+      mockProfileData = { home_region: null };
+
+      await expect(HomePage()).rejects.toThrow("NEXT_REDIRECT");
+      expect(redirectMock).toHaveBeenCalledWith("/onboarding");
+    });
+  });
+});

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,0 +1,16 @@
+import { NavHeader } from "@/components/layout";
+
+/**
+ * Layout for authenticated app pages.
+ *
+ * Wraps all routes under `(app)/` with the navigation header.
+ * Individual pages handle their own auth checks and redirects.
+ */
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <NavHeader />
+      {children}
+    </>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -134,9 +134,6 @@ body {
   font-family: var(--font-family-sans);
   line-height: 1.6;
   color: var(--champ-text);
-  max-width: 640px;
-  margin: 0 auto;
-  padding: 2rem 1rem;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,31 +1,245 @@
-export default function Home() {
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import Link from "next/link";
+import {
+  FDA_DISCLAIMER_LABEL,
+  FDA_DISCLAIMER_FULL_TEXT,
+} from "@/components/shared/fda-disclaimer";
+
+/**
+ * Root Landing Page
+ *
+ * - Authenticated users with completed profile → redirect to /dashboard
+ * - Authenticated users without profile → redirect to /onboarding
+ * - Unauthenticated users → branded landing page
+ */
+export default async function HomePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    // Check if onboarding is complete
+    const { data: profileData } = await supabase
+      .from("user_profiles")
+      .select("home_region")
+      .eq("id", user.id)
+      .single();
+
+    const profile = profileData as { home_region: string | null } | null;
+    if (profile?.home_region) {
+      redirect("/dashboard");
+    } else {
+      redirect("/onboarding");
+    }
+  }
+
   return (
-    <main>
-      <h1>Allergy Madness</h1>
-      <p>
-        Your deployment pipeline is live. Configure your stack with{" "}
-        <code>/bootstrap-architecture</code>.
-      </p>
+    <div className="min-h-screen bg-brand-surface">
+      {/* Navigation */}
+      <header className="border-b border-brand-border bg-white">
+        <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4 sm:px-6">
+          <div className="flex items-center gap-2">
+            <span
+              className="text-xl font-bold text-brand-primary"
+              aria-label="Allergy Madness logo"
+            >
+              Allergy Madness
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link
+              href="/login"
+              className="rounded-button px-4 py-2 text-sm font-medium text-brand-text-secondary transition-colors hover:text-brand-primary"
+            >
+              Sign In
+            </Link>
+            <Link
+              href="/signup"
+              className="rounded-button bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-primary-dark"
+            >
+              Get Started
+            </Link>
+          </div>
+        </nav>
+      </header>
 
-      <h2>Endpoints</h2>
-      <ul>
-        <li>
-          <code>GET /api/health</code> — Health Check
-        </li>
-        <li>
-          <code>GET /api/error</code> — Trigger a test error (for Sentry)
-        </li>
-        <li>
-          <code>POST /api/error-events</code> — Error event receiver
-        </li>
-      </ul>
+      {/* Hero Section */}
+      <section className="bg-gradient-to-b from-brand-primary-light to-white px-4 py-16 sm:px-6 sm:py-24">
+        <div className="mx-auto max-w-3xl text-center">
+          <h1 className="text-3xl font-bold tracking-tight text-brand-text sm:text-5xl">
+            Predict Your Allergy Triggers
+          </h1>
+          <p className="mx-auto mt-4 max-w-xl text-lg text-brand-text-secondary sm:mt-6 sm:text-xl">
+            Track symptoms, discover patterns, and get personalized insights
+            about what may be causing your allergies — all from your phone.
+          </p>
+          <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4">
+            <Link
+              href="/signup"
+              className="w-full rounded-button bg-brand-primary px-8 py-3 text-center text-base font-semibold text-white shadow-sm transition-colors hover:bg-brand-primary-dark sm:w-auto"
+            >
+              Get Started Free
+            </Link>
+            <Link
+              href="/login"
+              className="w-full rounded-button border border-brand-border px-8 py-3 text-center text-base font-medium text-brand-text-secondary transition-colors hover:border-brand-primary hover:text-brand-primary sm:w-auto"
+            >
+              Sign In
+            </Link>
+          </div>
+          <p className="mt-3 text-sm text-brand-text-muted">
+            No credit card required. Free plan available.
+          </p>
+        </div>
+      </section>
 
-      <p>
-        <small>
-          This is the deploy-first starter. Your tech stack will be configured
-          during the bootstrap phase.
-        </small>
-      </p>
-    </main>
+      {/* How It Works */}
+      <section className="px-4 py-16 sm:px-6">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-center text-2xl font-bold text-brand-text sm:text-3xl">
+            How It Works
+          </h2>
+          <p className="mx-auto mt-2 max-w-lg text-center text-brand-text-secondary">
+            Three simple steps to start understanding your allergy triggers.
+          </p>
+          <div className="mt-12 grid gap-8 sm:grid-cols-3">
+            <StepCard
+              step="1"
+              title="Quick Onboarding"
+              description="Tell us your zip code and a few health details. We auto-detect your local environment."
+            />
+            <StepCard
+              step="2"
+              title="Daily Check-ins"
+              description="Log how you feel each day in under 30 seconds. Our engine tracks patterns over time."
+            />
+            <StepCard
+              step="3"
+              title="See Your Triggers"
+              description="View a ranked leaderboard of your predicted allergy triggers with confidence scores."
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="bg-brand-surface-muted px-4 py-16 sm:px-6">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="text-center text-2xl font-bold text-brand-text sm:text-3xl">
+            Features
+          </h2>
+          <div className="mt-12 grid gap-6 sm:grid-cols-2">
+            <FeatureCard
+              title="Symptom Check-in"
+              description="Log severity, body zones, and timing each day. Takes less than 30 seconds."
+            />
+            <FeatureCard
+              title="Trigger Leaderboard"
+              description="See your top allergens ranked by our Elo-based prediction engine."
+            />
+            <FeatureCard
+              title="Trigger Scout"
+              description="Snap a photo of food or products. Our AI identifies potential allergens."
+            />
+            <FeatureCard
+              title="Environmental Forecast"
+              description="Get pollen, air quality, and weather data tailored to your location."
+            />
+            <FeatureCard
+              title="Child Profiles"
+              description="Track allergy triggers for your kids alongside your own profile."
+            />
+            <FeatureCard
+              title="PDF Reports"
+              description="Download shareable reports to bring to your allergist appointments."
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="px-4 py-16 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-2xl font-bold text-brand-text sm:text-3xl">
+            Ready to Understand Your Allergies?
+          </h2>
+          <p className="mt-3 text-brand-text-secondary">
+            Join thousands of families using Allergy Madness to track and
+            predict allergy triggers.
+          </p>
+          <Link
+            href="/signup"
+            className="mt-8 inline-block rounded-button bg-brand-primary px-8 py-3 text-base font-semibold text-white shadow-sm transition-colors hover:bg-brand-primary-dark"
+          >
+            Get Started Free
+          </Link>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="border-t border-brand-border bg-white px-4 py-8 sm:px-6">
+        <div className="mx-auto max-w-5xl">
+          {/* FDA Disclaimer */}
+          <div className="rounded-card border border-amber-200 bg-amber-50 px-4 py-3">
+            <p className="text-sm font-semibold text-amber-800">
+              {FDA_DISCLAIMER_LABEL}
+            </p>
+            <p className="mt-1 text-xs text-amber-700">
+              {FDA_DISCLAIMER_FULL_TEXT}
+            </p>
+          </div>
+          <div className="mt-6 flex flex-col items-center gap-2 text-center">
+            <p className="text-sm font-medium text-brand-text-secondary">
+              Allergy Madness — The Digital Allergy Test by Champ Health
+            </p>
+            <p className="text-xs text-brand-text-muted">
+              &copy; {new Date().getFullYear()} Champ Health. All rights
+              reserved.
+            </p>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Sub-components (co-located, not exported)                           */
+/* ------------------------------------------------------------------ */
+
+function StepCard({
+  step,
+  title,
+  description,
+}: {
+  step: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col items-center text-center">
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary text-sm font-bold text-white">
+        {step}
+      </div>
+      <h3 className="mt-4 text-lg font-semibold text-brand-text">{title}</h3>
+      <p className="mt-2 text-sm text-brand-text-secondary">{description}</p>
+    </div>
+  );
+}
+
+function FeatureCard({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-card border border-brand-border bg-white p-6">
+      <h3 className="text-base font-semibold text-brand-text">{title}</h3>
+      <p className="mt-2 text-sm text-brand-text-secondary">{description}</p>
+    </div>
   );
 }

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -1,0 +1,1 @@
+export { NavHeader } from "./nav-header";

--- a/components/layout/nav-header.tsx
+++ b/components/layout/nav-header.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+/**
+ * Navigation header for authenticated pages.
+ *
+ * Provides app logo, navigation links, and a mobile hamburger menu.
+ * Highlighted link indicates the active route.
+ */
+
+interface NavLink {
+  href: string;
+  label: string;
+}
+
+const NAV_LINKS: NavLink[] = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/checkin", label: "Check-in" },
+  { href: "/children", label: "Children" },
+  { href: "/scout", label: "Scout" },
+];
+
+export function NavHeader() {
+  const pathname = usePathname();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  function isActive(href: string): boolean {
+    return pathname === href || pathname.startsWith(`${href}/`);
+  }
+
+  return (
+    <header
+      className="border-b border-brand-border bg-white"
+      data-testid="nav-header"
+    >
+      <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3 sm:px-6">
+        {/* Logo */}
+        <Link
+          href="/dashboard"
+          className="text-lg font-bold text-brand-primary"
+        >
+          Allergy Madness
+        </Link>
+
+        {/* Desktop nav links */}
+        <div className="hidden items-center gap-1 sm:flex">
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`rounded-button px-3 py-2 text-sm font-medium transition-colors ${
+                isActive(link.href)
+                  ? "bg-brand-primary-light text-brand-primary"
+                  : "text-brand-text-secondary hover:bg-brand-surface-muted hover:text-brand-text"
+              }`}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        {/* Mobile hamburger button */}
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-button p-2 text-brand-text-secondary transition-colors hover:bg-brand-surface-muted hover:text-brand-text sm:hidden"
+          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          aria-expanded={mobileMenuOpen}
+          aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+        >
+          {mobileMenuOpen ? (
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          ) : (
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+              />
+            </svg>
+          )}
+        </button>
+      </nav>
+
+      {/* Mobile menu */}
+      {mobileMenuOpen && (
+        <div className="border-t border-brand-border px-4 pb-3 pt-2 sm:hidden">
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              onClick={() => setMobileMenuOpen(false)}
+              className={`block rounded-button px-3 py-2 text-sm font-medium transition-colors ${
+                isActive(link.href)
+                  ? "bg-brand-primary-light text-brand-primary"
+                  : "text-brand-text-secondary hover:bg-brand-surface-muted hover:text-brand-text"
+              }`}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces deploy-first scaffold home page with branded Allergy Madness landing page
- Adds server-side auth check: authenticated users redirect to `/dashboard` or `/onboarding` based on profile completion
- Creates `NavHeader` component with responsive mobile menu and active route highlighting
- Wires nav header into `(app)` route group layout for all authenticated pages
- Includes FDA disclaimer in landing page footer
- Removes body max-width/padding constraint from `globals.css` so pages can control their own layout

## Changes
| File | What |
|------|------|
| `app/page.tsx` | Full branded landing page with hero, features, CTA, FDA disclaimer |
| `components/layout/nav-header.tsx` | Client component with desktop nav + mobile hamburger menu |
| `components/layout/index.ts` | Barrel export |
| `app/(app)/layout.tsx` | New layout wrapping authenticated routes with NavHeader |
| `app/globals.css` | Remove body max-width/padding (pages manage their own) |
| `__tests__/landing-page.test.tsx` | 9 tests: branding, CTAs, redirects, FDA disclaimer |
| `__tests__/components/layout/nav-header.test.tsx` | 5 tests: links, active state, mobile toggle |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — all 770 tests pass (14 new)
- [x] `npm run build` — production build succeeds
- [ ] Manual: visit root as unauthenticated user, verify landing page
- [ ] Manual: visit root as authenticated user, verify redirect
- [ ] Manual: verify nav header appears on /dashboard, /checkin, /children, /scout
- [ ] Manual: test mobile hamburger menu

Closes #103