### PR TITLE
fix(deploy): seed allergens table in CI and surface Elo errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,3 +115,16 @@ jobs:
           fi
           echo "Running Supabase migrations..."
           npx supabase db push --db-url "$SUPABASE_DB_URL"
+
+      - name: Seed allergen reference data
+        if: steps.check_secrets.outputs.skip != 'true'
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not configured — skipping seed."
+            exit 0
+          fi
+          echo "Seeding allergens and seasonal calendar..."
+          npx tsx scripts/seed-allergens.ts

--- a/app/api/checkin/route.ts
+++ b/app/api/checkin/route.ts
@@ -472,7 +472,7 @@ export async function POST(
         const currentPositive = existingRow?.positive_signals ?? 0;
         const currentNegative = existingRow?.negative_signals ?? 0;
 
-        await (supabase.from("user_allergen_elo") as unknown as EloUpdateQuery)
+        const { error: eloUpdateError } = await (supabase.from("user_allergen_elo") as unknown as EloUpdateQuery)
           .update({
             elo_score: update.new_elo,
             positive_signals:
@@ -484,6 +484,10 @@ export async function POST(
           .eq("user_id", user.id)
           .eq("allergen_id", update.allergen_id)
           .is("child_id", null);
+
+        if (eloUpdateError) {
+          console.error(`Elo update failed for ${update.allergen_id}:`, eloUpdateError.message);
+        }
       }
     }
 

--- a/app/api/onboarding/route.ts
+++ b/app/api/onboarding/route.ts
@@ -292,7 +292,11 @@ export async function POST(
         .insert(eloInserts);
 
       if (eloError) {
-        console.error("Elo seeding warning:", eloError.message);
+        console.error("Elo seeding failed:", eloError.message);
+        return NextResponse.json(
+          { success: false, error: "Failed to initialize allergen data. Please try again." },
+          { status: 500 },
+        );
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds allergen seed step to deploy workflow after migrations — populates `allergens` and `seasonal_calendar` tables
- Captures and logs Elo update errors in check-in route (previously silently swallowed)
- Returns 500 from onboarding if Elo seeding fails (previously returned `success: true`)

Closes #110

## Test plan
- [ ] Verify `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` secrets are set in repo settings
- [ ] After merge + deploy, confirm `allergens` table has 47 rows in Supabase dashboard
- [ ] Re-onboard a test user and verify `user_allergen_elo` rows are created
- [ ] Submit check-in with severity > 0 and verify leaderboard appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)