### PR TITLE
fix(ui): replace emoji icons with brand-compliant SVGs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,7 +42,7 @@ export default async function HomePage() {
         <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4 sm:px-6">
           <div className="flex items-center gap-2">
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/champ-logo-alt.png" alt="Champ Allergy" className="h-8 w-auto" />
+            <img src="/champ-logo-alt.png" alt="Champ Allergy" className="h-10 w-auto" />
           </div>
           <div className="flex items-center gap-3">
             <Link

--- a/components/layout/nav-header.tsx
+++ b/components/layout/nav-header.tsx
@@ -43,7 +43,7 @@ export function NavHeader() {
           className="flex items-center"
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src="/champ-logo-alt.png" alt="Champ Allergy" className="h-8 w-auto" />
+          <img src="/champ-logo-alt.png" alt="Champ Allergy" className="h-10 w-auto" />
         </Link>
 
         {/* Desktop nav links */}

--- a/components/leaderboard/blur-overlay.tsx
+++ b/components/leaderboard/blur-overlay.tsx
@@ -34,10 +34,13 @@ export function BlurOverlay({
         className="absolute inset-0 flex flex-col items-center justify-center"
       >
         <span
-          className="mb-2 animate-pulse text-3xl"
+          className="mb-2 inline-flex h-12 w-12 animate-pulse items-center justify-center rounded-full bg-brand-primary"
           aria-hidden="true"
         >
-          &#x1F512;
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0110 0v4" />
+          </svg>
         </span>
         {!showUpgradeCta && (
           <p className="text-sm font-medium text-brand-text-secondary">

--- a/components/leaderboard/category-icon.tsx
+++ b/components/leaderboard/category-icon.tsx
@@ -1,27 +1,48 @@
 /**
  * Category Icon
  *
- * Renders a text-based icon representing the allergen category.
- * Uses Unicode symbols to avoid image dependency.
+ * Renders a brand-compliant SVG icon for each allergen category.
+ * Per brand guide: round + simple, white stroke on Champ Blue circle.
  */
 
 import type { AllergenCategory } from "@/lib/supabase/types";
 
 interface CategoryIconProps {
   category: AllergenCategory;
+  /** Size in pixels (default 32) */
+  size?: number;
 }
 
-const CATEGORY_ICONS: Record<AllergenCategory, { icon: string; label: string }> = {
-  tree: { icon: "\u{1F333}", label: "Tree pollen" },
-  grass: { icon: "\u{1F33F}", label: "Grass pollen" },
-  weed: { icon: "\u{1F33E}", label: "Weed pollen" },
-  mold: { icon: "\u{1F344}", label: "Mold" },
-  indoor: { icon: "\u{1F3E0}", label: "Indoor allergen" },
-  food: { icon: "\u{1F34E}", label: "Food allergen" },
+/** SVG path data for each category — simple, rounded strokes */
+const CATEGORY_PATHS: Record<AllergenCategory, { d: string; label: string }> = {
+  tree: {
+    label: "Tree pollen",
+    d: "M12 22V12M12 12C12 12 8 9 8 6.5C8 4 10 2 12 2C14 2 16 4 16 6.5C16 9 12 12 12 12ZM9 18C7 18 5 16.5 5 14.5C5 12.5 7 11 9 11M15 18C17 18 19 16.5 19 14.5C19 12.5 17 11 15 11",
+  },
+  grass: {
+    label: "Grass pollen",
+    d: "M12 22V8M12 8L8 4M12 8L16 4M7 22C7 18 9 16 12 16M17 22C17 18 15 16 12 16M5 14L9 12M19 14L15 12",
+  },
+  weed: {
+    label: "Weed pollen",
+    d: "M12 22V10M12 10C9 10 7 8 7 5.5C7 3 9 2 12 2C15 2 17 3 17 5.5C17 8 15 10 12 10ZM8 18L5 15M16 18L19 15M8 14L5 11M16 14L19 11",
+  },
+  mold: {
+    label: "Mold",
+    d: "M12 22V16M12 16C8.5 16 6 13.5 6 10C6 6.5 8.5 4 12 4C15.5 4 18 6.5 18 10C18 13.5 15.5 16 12 16ZM9 8.5C9 8.5 10 10 12 10C14 10 15 8.5 15 8.5M9 12C10 13 14 13 15 12",
+  },
+  indoor: {
+    label: "Indoor allergen",
+    d: "M3 12L12 4L21 12M5 10V20H19V10M9 20V14H15V20",
+  },
+  food: {
+    label: "Food allergen",
+    d: "M12 2C6.5 2 2 6 2 11C2 16 6.5 20 12 20C17.5 20 22 16 22 11C22 6 17.5 2 12 2ZM12 6V11L16 14M8 11H12",
+  },
 };
 
-export function CategoryIcon({ category }: CategoryIconProps) {
-  const config = CATEGORY_ICONS[category];
+export function CategoryIcon({ category, size = 32 }: CategoryIconProps) {
+  const config = CATEGORY_PATHS[category];
 
   return (
     <span
@@ -29,9 +50,22 @@ export function CategoryIcon({ category }: CategoryIconProps) {
       aria-label={config.label}
       data-testid="category-icon"
       data-category={category}
-      className="text-lg"
+      className="inline-flex items-center justify-center rounded-full bg-brand-primary"
+      style={{ width: size, height: size }}
     >
-      {config.icon}
+      <svg
+        width={size * 0.6}
+        height={size * 0.6}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="white"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d={config.d} />
+      </svg>
     </span>
   );
 }

--- a/components/leaderboard/environmental-forecast.tsx
+++ b/components/leaderboard/environmental-forecast.tsx
@@ -185,8 +185,18 @@ export function EnvironmentalForecast({
       {/* Good news banner */}
       <div className="rounded-xl border border-brand-border bg-brand-primary-light p-5">
         <div className="flex items-center gap-3">
-          <span className="text-2xl" aria-hidden="true">
-            &#x2600;
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="5" />
+              <line x1="12" y1="1" x2="12" y2="3" />
+              <line x1="12" y1="21" x2="12" y2="23" />
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+              <line x1="1" y1="12" x2="3" y2="12" />
+              <line x1="21" y1="12" x2="23" y2="12" />
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+            </svg>
           </span>
           <div>
             <h2 className="text-base font-bold text-brand-primary-dark">

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -185,9 +185,12 @@ export function Leaderboard({
                   >
                     <span
                       aria-hidden="true"
-                      className="text-sm"
+                      className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand-primary"
                     >
-                      &#x1F512;
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                        <path d="M7 11V7a5 5 0 0110 0v4" />
+                      </svg>
                     </span>
                     <span className="text-xs font-medium text-brand-primary">
                       Upgrade

--- a/components/leaderboard/trigger-champion-card.tsx
+++ b/components/leaderboard/trigger-champion-card.tsx
@@ -15,10 +15,15 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
       data-testid="trigger-champion-card"
       className="rounded-xl border-2 border-brand-primary bg-gradient-to-br from-[#E0F5FB] to-[#D6F0F8] p-6 shadow-lg"
     >
-      {/* Crown / header */}
+      {/* Champion header — white icon on blue circle per brand guide */}
       <div className="mb-3 flex items-center gap-2">
-        <span className="text-2xl" aria-hidden="true">
-          &#x1F451;
+        <span
+          className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-primary"
+          aria-hidden="true"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M2 4L6 12H18L22 4M6 12L4 20H20L18 12M12 4V2M8 4L7 2M16 4L17 2" />
+          </svg>
         </span>
         <h2 className="text-sm font-bold uppercase tracking-wider text-brand-primary-dark">
           Trigger Champion

--- a/components/subscription/premium-badge.tsx
+++ b/components/subscription/premium-badge.tsx
@@ -26,7 +26,13 @@ export function PremiumBadge({
         data-testid="premium-badge"
         className="inline-flex items-center gap-1 rounded-full bg-brand-primary-light px-2 py-0.5 text-xs font-medium text-brand-primary-dark"
       >
-        {!compact && <span aria-hidden="true">&#x2B50;</span>}
+        {!compact && (
+          <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-brand-primary">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" />
+            </svg>
+          </span>
+        )}
         Madness+
       </span>
     );
@@ -37,7 +43,14 @@ export function PremiumBadge({
       data-testid="premium-badge-locked"
       className="inline-flex items-center gap-1 rounded-full bg-brand-surface-muted px-2 py-0.5 text-xs font-medium text-brand-text-muted"
     >
-      {!compact && <span aria-hidden="true">&#x1F512;</span>}
+      {!compact && (
+        <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-brand-surface-muted">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0110 0v4" />
+          </svg>
+        </span>
+      )}
       Premium
     </span>
   );


### PR DESCRIPTION
## Summary
- Replaced all Unicode emoji icons (👑⭐🔒☀🏠🍄🌾🌿🌳) with white-stroke SVG icons on Champ Blue circular backgrounds per brand guide
- Updated 8 files: category-icon, trigger-champion-card, blur-overlay, environmental-forecast, leaderboard, premium-badge, nav-header, landing page
- Increased logo size from h-8 to h-10 in nav header and landing page

Follows up on PR #113 (merged) to complete the remaining emoji-to-SVG icon replacements that were still showing gold/red colored emojis.

## Test plan
- [ ] Verify leaderboard shows blue circle SVG icons for all allergen categories (tree, grass, weed, mold, indoor, food)
- [ ] Verify trigger champion card shows SVG crown icon (not 👑 emoji)
- [ ] Verify lock icons on free-tier gated content are blue circle SVGs
- [ ] Verify environmental forecast sun icon is blue circle SVG
- [ ] Verify premium badge star/lock are small blue circle SVGs
- [ ] All 774 tests passing, lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)