### PR TITLE
feat(ui): add sign-out link to NavHeader

### DIFF
--- a/__tests__/components/layout/nav-header.test.tsx
+++ b/__tests__/components/layout/nav-header.test.tsx
@@ -3,8 +3,19 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 // Mock next/navigation
 let mockPathname = "/dashboard";
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
 vi.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+// Mock Supabase client
+const mockSignOut = vi.fn().mockResolvedValue({ error: null });
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { signOut: mockSignOut },
+  }),
 }));
 
 // Mock next/link
@@ -72,5 +83,47 @@ describe("NavHeader", () => {
 
     // After opening, the button label should change
     expect(screen.getByLabelText("Close menu")).toBeDefined();
+  });
+
+  it("renders a sign-out button in desktop nav", () => {
+    mockPathname = "/dashboard";
+    render(<NavHeader />);
+
+    const signOutButton = screen.getByTestId("sign-out-button");
+    expect(signOutButton).toBeDefined();
+    expect(signOutButton.textContent).toBe("Sign Out");
+  });
+
+  it("renders a sign-out button in mobile menu", () => {
+    mockPathname = "/dashboard";
+    render(<NavHeader />);
+
+    // Open mobile menu
+    const menuButton = screen.getByLabelText("Open menu");
+    fireEvent.click(menuButton);
+
+    const mobileSignOut = screen.getByTestId("sign-out-button-mobile");
+    expect(mobileSignOut).toBeDefined();
+    expect(mobileSignOut.textContent).toBe("Sign Out");
+  });
+
+  it("calls signOut and redirects to / when sign-out is clicked", async () => {
+    mockPathname = "/dashboard";
+    mockSignOut.mockClear();
+    mockPush.mockClear();
+    mockRefresh.mockClear();
+
+    render(<NavHeader />);
+
+    const signOutButton = screen.getByTestId("sign-out-button");
+    fireEvent.click(signOutButton);
+
+    // Wait for async signOut
+    await vi.waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalledOnce();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/");
+    expect(mockRefresh).toHaveBeenCalled();
   });
 });

--- a/components/layout/nav-header.tsx
+++ b/components/layout/nav-header.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
 
 /**
  * Navigation header for authenticated pages.
@@ -25,10 +26,18 @@ const NAV_LINKS: NavLink[] = [
 
 export function NavHeader() {
   const pathname = usePathname();
+  const router = useRouter();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   function isActive(href: string): boolean {
     return pathname === href || pathname.startsWith(`${href}/`);
+  }
+
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/");
+    router.refresh();
   }
 
   return (
@@ -61,6 +70,14 @@ export function NavHeader() {
               {link.label}
             </Link>
           ))}
+          <button
+            type="button"
+            onClick={handleSignOut}
+            data-testid="sign-out-button"
+            className="ml-2 rounded-button px-3 py-2 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            Sign Out
+          </button>
         </div>
 
         {/* Mobile hamburger button */}
@@ -122,6 +139,14 @@ export function NavHeader() {
               {link.label}
             </Link>
           ))}
+          <button
+            type="button"
+            onClick={handleSignOut}
+            data-testid="sign-out-button-mobile"
+            className="mt-1 block w-full rounded-button border-t border-white/20 px-3 py-2 text-left text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            Sign Out
+          </button>
         </div>
       )}
     </header>


### PR DESCRIPTION
## Summary
- Adds a **Sign Out** button to the NavHeader (both desktop and mobile views)
- Uses Supabase `auth.signOut()` and redirects to `/` (landing page)
- Styled consistently with existing nav links (white text on brand primary dark)
- Desktop: appears after Scout link with a subtle `ml-2` separator
- Mobile: appears at bottom of menu with a top border separator

Closes #105

## Test plan
- [x] Sign-out button visible in desktop nav (data-testid: `sign-out-button`)
- [x] Sign-out button visible in mobile menu (data-testid: `sign-out-button-mobile`)
- [x] Clicking sign-out calls `auth.signOut()` and redirects to `/`
- [x] 3 new tests added, all 777 tests passing
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)