### PR TITLE
fix(ui): show 'Madness Family' tier in children UpgradeCta

### DIFF
--- a/__tests__/components/subscription/upgrade-cta.test.tsx
+++ b/__tests__/components/subscription/upgrade-cta.test.tsx
@@ -45,4 +45,26 @@ describe("UpgradeCta", () => {
 
     expect(screen.queryByTestId("upgrade-cta-referral")).toBeNull();
   });
+
+  it("defaults tier name to Madness+", () => {
+    render(<UpgradeCta />);
+
+    expect(
+      screen.getByText(/with Madness\+/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Upgrade to Madness+"),
+    ).toBeTruthy();
+  });
+
+  it("renders custom tier name when provided", () => {
+    render(<UpgradeCta tierName="Madness Family" />);
+
+    expect(
+      screen.getByText(/with Madness Family/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Upgrade to Madness Family"),
+    ).toBeTruthy();
+  });
 });

--- a/components/children/children-manager.tsx
+++ b/components/children/children-manager.tsx
@@ -99,7 +99,7 @@ export function ChildrenManager({
           Track allergies for up to {maxChildren} children with independent
           leaderboards and check-ins.
         </p>
-        <UpgradeCta feature="child profiles" />
+        <UpgradeCta feature="child profiles" tierName="Madness Family" />
       </div>
     );
   }

--- a/components/subscription/upgrade-cta.tsx
+++ b/components/subscription/upgrade-cta.tsx
@@ -1,7 +1,7 @@
 /**
  * Upgrade CTA (Call to Action)
  *
- * Prompts free-tier users to upgrade to Madness+ or unlock via referrals.
+ * Prompts free-tier users to upgrade or unlock via referrals.
  * Shown alongside the blur overlay on gated content.
  */
 
@@ -10,12 +10,15 @@
 export interface UpgradeCtaProps {
   /** The feature being gated (for contextual messaging) */
   feature?: string;
+  /** Tier name shown in copy (default: "Madness+") */
+  tierName?: string;
   /** Number of referrals still needed to unlock (0 if already unlocked) */
   referralsNeeded?: number;
 }
 
 export function UpgradeCta({
   feature = "premium features",
+  tierName = "Madness+",
   referralsNeeded = 3,
 }: UpgradeCtaProps) {
   return (
@@ -27,7 +30,7 @@ export function UpgradeCta({
         Unlock {feature}
       </h3>
       <p className="mb-4 text-sm text-brand-text-secondary">
-        Get the full picture of your allergen triggers with Madness+.
+        Get the full picture of your allergen triggers with {tierName}.
       </p>
 
       {/* Primary CTA — Madness+ */}
@@ -39,7 +42,7 @@ export function UpgradeCta({
           // Placeholder — will connect to RevenueCat paywall
         }}
       >
-        Upgrade to Madness+
+        Upgrade to {tierName}
       </button>
 
       {/* Secondary CTA — Referral unlock */}


### PR DESCRIPTION
## Summary
- Adds optional `tierName` prop to `UpgradeCta` component (default: `"Madness+"`)
- Replaces hardcoded "Madness+" in description and button copy with the prop value
- Children manager now passes `tierName="Madness Family"` for the child profiles gate
- All other usages (blur gate, PFAS panel, leaderboard) keep the default "Madness+"

Closes #96

## Test plan
- [x] Default render still shows "Madness+" (existing test + new test)
- [x] Custom `tierName="Madness Family"` shows in both description and button
- [x] 2 new tests added, all 779 tests passing
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)