### PR TITLE
feat(children): wire up child profile edit form

### DIFF
--- a/__tests__/components/children/children-manager.test.tsx
+++ b/__tests__/components/children/children-manager.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ChildrenManager } from "@/components/children/children-manager";
 import type { ChildProfileSummary } from "@/lib/child-profiles/types";
 
@@ -118,5 +118,73 @@ describe("ChildrenManager", () => {
 
     expect(screen.getByTestId("max-children-notice")).toBeTruthy();
     expect(screen.queryByTestId("add-child-trigger")).toBeNull();
+  });
+
+  it("shows edit form when edit button is clicked", () => {
+    render(
+      <ChildrenManager
+        initialChildren={mockChildren}
+        hasAccess={true}
+      />,
+    );
+
+    const editButtons = screen.getAllByTestId("edit-child-btn");
+    fireEvent.click(editButtons[0]);
+
+    expect(screen.getByTestId("edit-child-form")).toBeTruthy();
+    expect(screen.getByTestId("edit-child-name-input")).toBeTruthy();
+  });
+
+  it("cancels edit and returns to card view", () => {
+    render(
+      <ChildrenManager
+        initialChildren={mockChildren}
+        hasAccess={true}
+      />,
+    );
+
+    const editButtons = screen.getAllByTestId("edit-child-btn");
+    fireEvent.click(editButtons[0]);
+
+    expect(screen.getByTestId("edit-child-form")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("edit-child-cancel-btn"));
+
+    expect(screen.queryByTestId("edit-child-form")).toBeNull();
+    expect(screen.getAllByTestId("child-profile-card")).toHaveLength(2);
+  });
+
+  it("submits edit and updates child in list", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ success: true }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(
+      <ChildrenManager
+        initialChildren={mockChildren}
+        hasAccess={true}
+      />,
+    );
+
+    const editButtons = screen.getAllByTestId("edit-child-btn");
+    fireEvent.click(editButtons[0]);
+
+    const nameInput = screen.getByTestId("edit-child-name-input");
+    fireEvent.change(nameInput, { target: { value: "Alicia" } });
+
+    fireEvent.click(screen.getByTestId("edit-child-save-btn"));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/children?id=child-1"),
+        expect.objectContaining({ method: "PATCH" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("edit-child-form")).toBeNull();
+      expect(screen.getByText("Alicia")).toBeTruthy();
+    });
   });
 });

--- a/__tests__/components/children/edit-child-form.test.tsx
+++ b/__tests__/components/children/edit-child-form.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * EditChildForm Component Tests
+ *
+ * Tests the inline edit form for child profiles.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { EditChildForm } from "@/components/children/edit-child-form";
+import type { ChildProfileSummary } from "@/lib/child-profiles/types";
+
+const mockChild: ChildProfileSummary = {
+  id: "child-1",
+  name: "Alice",
+  birth_year: 2020,
+  created_at: "2024-01-15T00:00:00Z",
+  has_pets: false,
+  prior_allergy_diagnosis: false,
+  known_allergens: null,
+};
+
+describe("EditChildForm", () => {
+  it("pre-populates with the child's current values", () => {
+    render(
+      <EditChildForm
+        child={mockChild}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    const nameInput = screen.getByTestId("edit-child-name-input") as HTMLInputElement;
+    const yearInput = screen.getByTestId("edit-child-birth-year-input") as HTMLInputElement;
+
+    expect(nameInput.value).toBe("Alice");
+    expect(yearInput.value).toBe("2020");
+  });
+
+  it("calls onSubmit with updated values", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <EditChildForm
+        child={mockChild}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    const nameInput = screen.getByTestId("edit-child-name-input");
+    fireEvent.change(nameInput, { target: { value: "Alicia" } });
+
+    const saveBtn = screen.getByTestId("edit-child-save-btn");
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith("child-1", {
+        name: "Alicia",
+        birth_year: 2020,
+      });
+    });
+  });
+
+  it("calls onCancel when cancel button is clicked", () => {
+    const onCancel = vi.fn();
+
+    render(
+      <EditChildForm
+        child={mockChild}
+        onSubmit={vi.fn()}
+        onCancel={onCancel}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("edit-child-cancel-btn"));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("displays validation error when provided", () => {
+    render(
+      <EditChildForm
+        child={mockChild}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        isLoading={false}
+        error="Child name cannot be empty"
+      />,
+    );
+
+    expect(screen.getByTestId("edit-child-error")).toBeTruthy();
+    expect(screen.getByText("Child name cannot be empty")).toBeTruthy();
+  });
+
+  it("disables save button when name is empty", () => {
+    render(
+      <EditChildForm
+        child={mockChild}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    const nameInput = screen.getByTestId("edit-child-name-input");
+    fireEvent.change(nameInput, { target: { value: "" } });
+
+    const saveBtn = screen.getByTestId("edit-child-save-btn") as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+  });
+
+  it("shows loading state", () => {
+    render(
+      <EditChildForm
+        child={mockChild}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        isLoading={true}
+        error={null}
+      />,
+    );
+
+    expect(screen.getByText("Saving...")).toBeTruthy();
+    const cancelBtn = screen.getByTestId("edit-child-cancel-btn") as HTMLButtonElement;
+    expect(cancelBtn.disabled).toBe(true);
+  });
+
+  it("handles child with no birth year", () => {
+    const childNoBirthYear: ChildProfileSummary = {
+      ...mockChild,
+      birth_year: null,
+    };
+
+    render(
+      <EditChildForm
+        child={childNoBirthYear}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    const yearInput = screen.getByTestId("edit-child-birth-year-input") as HTMLInputElement;
+    expect(yearInput.value).toBe("");
+  });
+});

--- a/components/children/children-manager.tsx
+++ b/components/children/children-manager.tsx
@@ -10,6 +10,7 @@
 import { useState, useCallback } from "react";
 import { ChildProfileCard } from "./child-profile-card";
 import { AddChildForm } from "./add-child-form";
+import { EditChildForm } from "./edit-child-form";
 import { UpgradeCta } from "@/components/subscription/upgrade-cta";
 import type { ChildProfileSummary } from "@/lib/child-profiles/types";
 import { MAX_CHILDREN } from "@/lib/child-profiles/types";
@@ -88,8 +89,47 @@ export function ChildrenManager({
 
   const handleEdit = useCallback((childId: string) => {
     setEditingId(childId);
-    void childId;
+    setShowAddForm(false);
+    setError(null);
   }, []);
+
+  const handleEditSubmit = useCallback(
+    async (childId: string, data: { name: string; birth_year?: number | null }) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const res = await fetch(
+          `${window.location.origin}/api/children?id=${childId}`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+          },
+        );
+
+        const result = await res.json();
+
+        if (!result.success) {
+          setError(result.error ?? "Failed to update child");
+          return;
+        }
+
+        setChildList((prev) =>
+          prev.map((c) =>
+            c.id === childId ? { ...c, name: data.name, birth_year: data.birth_year ?? null } : c,
+          ),
+        );
+        setEditingId(null);
+        setError(null);
+      } catch {
+        setError("An unexpected error occurred");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [],
+  );
 
   // Gate: show upgrade CTA if no family tier access
   if (!hasAccess) {
@@ -163,14 +203,28 @@ export function ChildrenManager({
         </div>
       ) : (
         <div className="space-y-3">
-          {childList.map((child) => (
-            <ChildProfileCard
-              key={child.id}
-              child={child}
-              onDelete={handleDelete}
-              onEdit={handleEdit}
-            />
-          ))}
+          {childList.map((child) =>
+            editingId === child.id ? (
+              <EditChildForm
+                key={child.id}
+                child={child}
+                onSubmit={handleEditSubmit}
+                onCancel={() => {
+                  setEditingId(null);
+                  setError(null);
+                }}
+                isLoading={isLoading}
+                error={error}
+              />
+            ) : (
+              <ChildProfileCard
+                key={child.id}
+                child={child}
+                onDelete={handleDelete}
+                onEdit={handleEdit}
+              />
+            ),
+          )}
         </div>
       )}
 
@@ -184,8 +238,6 @@ export function ChildrenManager({
         </p>
       )}
 
-      {/* Suppress unused state for future edit form */}
-      {editingId && null}
     </div>
   );
 }

--- a/components/children/edit-child-form.tsx
+++ b/components/children/edit-child-form.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * EditChildForm
+ *
+ * Inline form for editing an existing child profile.
+ * Pre-populates with current values; submits via parent callback.
+ */
+
+import { useState } from "react";
+import type { ChildProfileSummary } from "@/lib/child-profiles/types";
+
+export interface EditChildFormProps {
+  child: ChildProfileSummary;
+  onSubmit: (childId: string, data: { name: string; birth_year?: number | null }) => Promise<void>;
+  onCancel: () => void;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: EditChildFormProps) {
+  const [name, setName] = useState(child.name);
+  const [birthYear, setBirthYear] = useState(child.birth_year?.toString() ?? "");
+
+  const currentYear = new Date().getFullYear();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const parsedYear = birthYear ? parseInt(birthYear, 10) : null;
+    await onSubmit(child.id, {
+      name: name.trim(),
+      birth_year: parsedYear && !isNaN(parsedYear) ? parsedYear : null,
+    });
+  };
+
+  return (
+    <form
+      data-testid="edit-child-form"
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-brand-primary-light bg-white p-4 shadow-sm"
+    >
+      <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">Edit Child</h3>
+
+      {error && (
+        <p
+          data-testid="edit-child-error"
+          className="mb-3 rounded-md bg-[#E0F0F8] p-2 text-xs text-[#055A8C]"
+        >
+          {error}
+        </p>
+      )}
+
+      <div className="mb-3">
+        <label
+          htmlFor="edit-child-name"
+          className="mb-1 block text-xs font-medium text-brand-text"
+        >
+          Name *
+        </label>
+        <input
+          id="edit-child-name"
+          data-testid="edit-child-name-input"
+          type="text"
+          required
+          maxLength={100}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Enter child's name"
+          className="w-full rounded-md border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+        />
+      </div>
+
+      <div className="mb-4">
+        <label
+          htmlFor="edit-child-birth-year"
+          className="mb-1 block text-xs font-medium text-brand-text"
+        >
+          Birth Year (optional)
+        </label>
+        <input
+          id="edit-child-birth-year"
+          data-testid="edit-child-birth-year-input"
+          type="number"
+          min={currentYear - 18}
+          max={currentYear}
+          value={birthYear}
+          onChange={(e) => setBirthYear(e.target.value)}
+          placeholder={`e.g. ${currentYear - 5}`}
+          className="w-full rounded-md border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+        />
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isLoading}
+          data-testid="edit-child-cancel-btn"
+          className="rounded-md border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          data-testid="edit-child-save-btn"
+          disabled={isLoading || !name.trim()}
+          className="rounded-md bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark disabled:opacity-50"
+        >
+          {isLoading ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `EditChildForm` component that pre-populates with current child name and birth year
- Replaces the stub `{editingId && null}` in `ChildrenManager` with a real inline edit flow
- Clicking Edit on a child card swaps it for the edit form in-place
- Submit sends PATCH to `/api/children?id=<childId>` and updates the list on success
- Cancel exits edit mode and returns to card view
- Validation errors display inline (same styling as AddChildForm)
- Clicking Edit hides the Add form if it's open

Closes #94

## Test plan
- [x] 7 new tests for `EditChildForm` (pre-populate, submit, cancel, error, empty name, loading, null birth year)
- [x] 3 new tests for `ChildrenManager` (show edit form, cancel edit, submit edit with list update)
- [x] All 787 tests passing (77 files)
- [x] Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)