### PR TITLE
fix(supabase): add FK constraint from user_allergen_elo.location_id to user_locations

### DIFF
--- a/supabase/migrations/20260413170000_add_elo_location_fk.sql
+++ b/supabase/migrations/20260413170000_add_elo_location_fk.sql
@@ -1,0 +1,29 @@
+-- Add FK constraint from user_allergen_elo.location_id to user_locations
+--
+-- Ticket: #52 — fix(supabase): add FK constraint from user_allergen_elo.location_id to user_locations
+--
+-- The location_id column was created without a foreign key constraint.
+-- Other tables (checkin_logs, environmental_forecasts) already reference
+-- user_locations(id) ON DELETE SET NULL. This migration aligns user_allergen_elo
+-- with the same pattern.
+--
+-- Uses NOT VALID to skip checking existing rows (safe for production with
+-- existing data), then validates separately so the constraint is fully enforced
+-- for future writes.
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'fk_user_allergen_elo_location'
+  ) THEN
+    ALTER TABLE user_allergen_elo
+      ADD CONSTRAINT fk_user_allergen_elo_location
+      FOREIGN KEY (location_id) REFERENCES user_locations(id)
+      ON DELETE SET NULL
+      NOT VALID;
+  END IF;
+END $$;
+
+-- Validate separately — locks are lighter this way on large tables
+ALTER TABLE user_allergen_elo
+  VALIDATE CONSTRAINT fk_user_allergen_elo_location;


### PR DESCRIPTION
## Summary
- Adds foreign key constraint `fk_user_allergen_elo_location` from `user_allergen_elo.location_id` to `user_locations(id)` with `ON DELETE SET NULL`
- Uses `NOT VALID` + `VALIDATE CONSTRAINT` pattern for safe production deployment (avoids full table lock during constraint creation)
- Idempotent — uses `IF NOT EXISTS` check on `pg_constraint` so re-running is safe

Closes #52

## Test plan
- [ ] All existing tests pass (790/790 verified locally)
- [ ] Migration is idempotent — safe to run on existing production data
- [ ] Constraint matches pattern used by `checkin_logs` and `environmental_forecasts` tables
- [ ] `ON DELETE SET NULL` preserves Elo records when a location is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)