### PR TITLE
fix(onboarding): use replaceAll for region field normalization

### DIFF
--- a/app/api/onboarding/route.ts
+++ b/app/api/onboarding/route.ts
@@ -247,7 +247,7 @@ export async function POST(
     const effectiveRegion: Region = region ?? "Southeast";
 
     // Filter allergens to those with regional presence > 0
-    const regionField = `region_${effectiveRegion.toLowerCase().replace(" ", "_")}` as keyof (typeof allergenSeed)[0];
+    const regionField = `region_${effectiveRegion.toLowerCase().replaceAll(" ", "_")}` as keyof (typeof allergenSeed)[0];
     const regionalAllergens = allergenSeed.filter(
       (a) => (a[regionField] as number) > 0,
     );

--- a/scripts/reseed-user-elo.ts
+++ b/scripts/reseed-user-elo.ts
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
     }
 
     // Filter allergens by regional presence
-    const regionField = `region_${region.toLowerCase().replace(" ", "_")}`;
+    const regionField = `region_${region.toLowerCase().replaceAll(" ", "_")}`;
     const regionalAllergens = allergenSeed.filter(
       (a: Record<string, unknown>) => (a[regionField] as number) > 0,
     );


### PR DESCRIPTION
## Summary
- Replaces `.replace(" ", "_")` with `.replaceAll(" ", "_")` in region field name construction
- Fixed in two locations:
  - `app/api/onboarding/route.ts` (line 250) — API route for onboarding flow
  - `scripts/reseed-user-elo.ts` (line 72) — admin reseed script
- Current regions with spaces ("South Central") only have one space so `replace()` works by luck, but `replaceAll()` is the robust choice

Closes #59

## Test plan
- [ ] All existing tests pass (790/790 verified locally)
- [ ] No functional regression — region field names resolve identically for current regions
- [ ] `replaceAll()` is ES2021, supported in all modern browsers and Node 15+

🤖 Generated with [Claude Code](https://claude.com/claude-code)