### PR TITLE
fix(apis): differentiate timeout vs network errors in geocoding

### DIFF
--- a/__tests__/api/geocoding.test.ts
+++ b/__tests__/api/geocoding.test.ts
@@ -121,6 +121,29 @@ describe("geocodeAddress", () => {
     );
   });
 
+  it("throws timeout error for AbortError", async () => {
+    vi.stubEnv("GOOGLE_MAPS_API_KEY", "test-key");
+
+    const abortError = new DOMException("The operation was aborted", "AbortError");
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(abortError);
+
+    await expect(geocodeAddress("123 Main St")).rejects.toThrow(
+      "Geocoding API timeout",
+    );
+  });
+
+  it("throws descriptive error for non-timeout failures", async () => {
+    vi.stubEnv("GOOGLE_MAPS_API_KEY", "test-key");
+
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
+      new TypeError("Failed to fetch"),
+    );
+
+    await expect(geocodeAddress("123 Main St")).rejects.toThrow(
+      "Geocoding API error: Failed to fetch",
+    );
+  });
+
   it("flags non-continental US coordinates", async () => {
     vi.stubEnv("GOOGLE_MAPS_API_KEY", "test-key");
 

--- a/lib/apis/geocoding.ts
+++ b/lib/apis/geocoding.ts
@@ -74,8 +74,13 @@ export async function geocodeAddress(
   let response: Response;
   try {
     response = await fetchWithTimeout(url.toString());
-  } catch {
-    throw new Error("Geocoding API timeout");
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error("Geocoding API timeout");
+    }
+    throw new Error(
+      `Geocoding API error: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
   if (!response.ok) {
     throw new Error(`Geocoding API HTTP error: ${response.status}`);


### PR DESCRIPTION
## Summary
- Differentiates `AbortError` (timeout) from other fetch failures (DNS, network, parse errors) in the geocoding catch block
- Timeout: throws `"Geocoding API timeout"` (unchanged behavior)
- Other errors: throws `"Geocoding API error: {message}"` (new, descriptive)
- Adds 2 new tests covering both error paths

Closes #77

## Test plan
- [ ] All tests pass (798/798, including 2 new geocoding error tests)
- [ ] Timeout errors still throw "Geocoding API timeout"
- [ ] Network errors now throw descriptive "Geocoding API error: ..." message
- [ ] No functional regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)