### PR TITLE
fix(forecast): polish Environmental Forecast display and types

### DIFF
--- a/__tests__/components/leaderboard/environmental-forecast.test.tsx
+++ b/__tests__/components/leaderboard/environmental-forecast.test.tsx
@@ -147,9 +147,9 @@ describe("EnvironmentalForecast", () => {
     it("renders PM2.5 and PM10 values", () => {
       render(<EnvironmentalForecast data={fullForecastData} />);
       expect(screen.getByText("PM2.5")).toBeDefined();
-      expect(screen.getByText("12 ug/m3")).toBeDefined();
+      expect(screen.getByText("12 \u00B5g/m\u00B3")).toBeDefined();
       expect(screen.getByText("PM10")).toBeDefined();
-      expect(screen.getByText("18 ug/m3")).toBeDefined();
+      expect(screen.getByText("18 \u00B5g/m\u00B3")).toBeDefined();
     });
 
     it("renders weather data", () => {

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getConfidenceTierBySignals } from "@/lib/engine";
-import type { RankedAllergen } from "@/components/leaderboard/types";
+import type { RankedAllergen, CheckinSeverityQuery } from "@/components/leaderboard/types";
 import { SignOutButton } from "./sign-out-button";
 import { DashboardLeaderboard } from "./dashboard-leaderboard";
 
@@ -89,23 +89,6 @@ export default async function DashboardPage() {
   // Forecast mode activates when the user's most recent check-in has severity = 0,
   // OR when they have no Elo data yet (first-time user).
   let isEnvironmentalForecast = eloRows.length === 0;
-
-  type CheckinSeverityQuery = {
-    select: (cols: string) => {
-      eq: (col: string, val: string) => {
-        is: (col: string, val: null) => {
-          order: (col: string, opts: { ascending: boolean }) => {
-            limit: (n: number) => {
-              single: () => Promise<{
-                data: { severity: number } | null;
-                error: { message: string } | null;
-              }>;
-            };
-          };
-        };
-      };
-    };
-  };
 
   const { data: latestCheckin } = await (
     supabase.from("symptom_checkins") as unknown as CheckinSeverityQuery

--- a/components/leaderboard/environmental-forecast.tsx
+++ b/components/leaderboard/environmental-forecast.tsx
@@ -238,6 +238,8 @@ export function EnvironmentalForecast({
               value={upiLabel(data.pollen.upi_weed)}
               color={upiColor(data.pollen.upi_weed)}
             />
+            {/* Species filter: show only species with UPI > 0 (active),
+                capped at 5 to avoid overwhelming the display */}
             {data.pollen.species.length > 0 && (
               <div className="mt-2 border-t border-brand-border-light pt-2">
                 <p className="mb-1 text-xs font-medium text-brand-text-muted">
@@ -279,13 +281,13 @@ export function EnvironmentalForecast({
                 {data.aqi.pm25 !== null && (
                   <DataRow
                     label="PM2.5"
-                    value={`${data.aqi.pm25} ug/m3`}
+                    value={`${data.aqi.pm25} \u00B5g/m\u00B3`}
                   />
                 )}
                 {data.aqi.pm10 !== null && (
                   <DataRow
                     label="PM10"
-                    value={`${data.aqi.pm10} ug/m3`}
+                    value={`${data.aqi.pm10} \u00B5g/m\u00B3`}
                   />
                 )}
                 {data.aqi.dominant_pollutant && (

--- a/components/leaderboard/types.ts
+++ b/components/leaderboard/types.ts
@@ -50,6 +50,27 @@ export interface AllergenRankRowProps {
   isBlurred: boolean;
 }
 
+/**
+ * Type-safe query chain for fetching the latest check-in severity.
+ * Used to determine Environmental Forecast mode (severity = 0).
+ */
+export type CheckinSeverityQuery = {
+  select: (cols: string) => {
+    eq: (col: string, val: string) => {
+      is: (col: string, val: null) => {
+        order: (col: string, opts: { ascending: boolean }) => {
+          limit: (n: number) => {
+            single: () => Promise<{
+              data: { severity: number } | null;
+              error: { message: string } | null;
+            }>;
+          };
+        };
+      };
+    };
+  };
+};
+
 /** Props for the blur overlay */
 export interface BlurOverlayProps {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary
Three polish items from PR #65 review:

1. **PM unit symbols** — Replaced plain text `ug/m3` with proper Unicode `µg/m³` (U+00B5, U+00B3) for PM2.5 and PM10 values
2. **Extract inline type** — Moved `CheckinSeverityQuery` from inline definition in `app/(app)/dashboard/page.tsx` to `components/leaderboard/types.ts`
3. **Document species filter** — Added comment explaining the species filter threshold: UPI > 0 (active species only), capped at 5

Closes #66

## Test plan
- [ ] All tests pass (796/796 — updated PM unit assertions)
- [ ] PM values render with proper µg/m³ symbols
- [ ] Dashboard page compiles with imported CheckinSeverityQuery type
- [ ] No functional regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)