### PR TITLE
docs(engine): document particle_size_um as metadata-only in MC simulation

### DIFF
--- a/lib/engine/monte-carlo.ts
+++ b/lib/engine/monte-carlo.ts
@@ -25,7 +25,14 @@ import type { PollenResult } from "@/lib/apis/pollen";
 /** Allergen data needed for Monte Carlo simulation */
 export interface MCAllergenInput {
   allergen_id: string;
-  /** Mean particle size in micrometers */
+  /**
+   * Mean particle size in micrometers.
+   *
+   * Not used directly in the simulation formula — settling_velocity_cm_s
+   * already encodes particle size physics via Stokes' Law, so using both
+   * would double-count. Retained as metadata for display (PDF reports,
+   * leaderboard tooltips) and potential future inhalation-depth modeling.
+   */
   particle_size_um: number;
   /** Stokes' Law settling velocity in cm/s */
   settling_velocity_cm_s: number;

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -223,7 +223,10 @@ export interface AllergenSeedData {
   region_south_central: number;
   region_southeast: number;
   region_southwest: number;
-  /** Mean particle size in micrometers */
+  /**
+   * Mean particle size in micrometers.
+   * Metadata only — settling_velocity_cm_s encodes size via Stokes' Law.
+   */
   particle_size_um: number;
   /** Stokes' Law settling velocity in cm/s */
   settling_velocity_cm_s: number;


### PR DESCRIPTION
## Summary
- Documents why `particle_size_um` is not used in the Monte Carlo simulation formula
- `settling_velocity_cm_s` already encodes particle size via Stokes' Law — using both would double-count
- Field is retained as metadata for display (PDF reports, leaderboard tooltips) and potential future inhalation-depth modeling
- JSDoc comments added in both `MCAllergenInput` (monte-carlo.ts) and `AllergenSeed` (types.ts)

Closes #49 (Option B — Document)

## Test plan
- [ ] All tests pass (798/798)
- [ ] No functional changes — documentation only
- [ ] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)