### PR TITLE
feat(db): add trigger-based max children constraint

### DIFF
--- a/__tests__/child-profiles/service.test.ts
+++ b/__tests__/child-profiles/service.test.ts
@@ -217,6 +217,29 @@ describe("child-profiles service", () => {
       }
     });
 
+    it("returns user-friendly error when DB constraint fires", async () => {
+      const client = makeMockClientSequential((table, callIndex) => {
+        if (table === "child_profiles" && callIndex === 1) {
+          // getChildCount — race condition: returns 4 (under limit)
+          return { count: 4, error: null };
+        }
+        if (table === "child_profiles" && callIndex === 2) {
+          // insert — DB trigger rejects (another insert snuck in)
+          return {
+            data: null,
+            error: { message: "Maximum of 5 child profiles per parent" },
+          };
+        }
+        return { data: null, error: null };
+      });
+
+      const result = await createChild(client, "parent-1", { name: "Sixth" });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe(`Maximum of ${MAX_CHILDREN} child profiles allowed`);
+      }
+    });
+
     it("creates child profile when under limit", async () => {
       const mockChild = {
         id: "new-child-1",

--- a/lib/child-profiles/service.ts
+++ b/lib/child-profiles/service.ts
@@ -185,9 +185,17 @@ export async function createChild(
     .single();
 
   if (insertError || !child) {
+    // Handle DB-level max children constraint (defense-in-depth trigger)
+    const msg = insertError?.message ?? "unknown error";
+    if (msg.includes("Maximum of 5 child profiles")) {
+      return {
+        success: false,
+        error: `Maximum of ${MAX_CHILDREN} child profiles allowed`,
+      };
+    }
     return {
       success: false,
-      error: `Failed to create child profile: ${insertError?.message ?? "unknown error"}`,
+      error: `Failed to create child profile: ${msg}`,
     };
   }
 

--- a/supabase/migrations/20260413180000_max_children_constraint.sql
+++ b/supabase/migrations/20260413180000_max_children_constraint.sql
@@ -1,0 +1,29 @@
+-- Enforce a maximum of 5 child profiles per parent at the database level.
+-- This is a defense-in-depth constraint — the application layer in
+-- lib/child-profiles/service.ts is the primary guard.
+--
+-- Uses a trigger + function rather than a CHECK constraint because
+-- CHECK cannot reference other rows in the same table.
+
+CREATE OR REPLACE FUNCTION enforce_max_children()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF (
+    SELECT COUNT(*)
+    FROM child_profiles
+    WHERE parent_id = NEW.parent_id
+  ) >= 5 THEN
+    RAISE EXCEPTION 'Maximum of 5 child profiles per parent'
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop the trigger first if it already exists (idempotent)
+DROP TRIGGER IF EXISTS trg_max_children ON child_profiles;
+
+CREATE TRIGGER trg_max_children
+  BEFORE INSERT ON child_profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_max_children();


### PR DESCRIPTION
## Summary
- Adds PostgreSQL `BEFORE INSERT` trigger (`trg_max_children`) that prevents >5 child profiles per parent at the DB level
- Updates `createChild` service to return a user-friendly error when the DB constraint fires (race condition fallback)
- Adds test for the DB constraint error handling path

Closes #95

## Test plan
- [x] New test verifies DB constraint error returns user-friendly message
- [x] Existing child profile tests unchanged and passing (19 tests)
- [x] Full suite passes (810/810 across 79 files)
- [x] Lint and typecheck clean
- [ ] Migration tested against Supabase preview branch (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)