### PR TITLE
fix(build): add autoprefixer to PostCSS config

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -2,6 +2,7 @@
 const config = {
   plugins: {
     "@tailwindcss/postcss": {},
+    autoprefixer: {},
   },
 };
 


### PR DESCRIPTION
## Summary
- Adds `autoprefixer` plugin to `postcss.config.mjs` for vendor-prefixed CSS output
- Package was already installed (`^10.4.27`), just missing from PostCSS plugin chain

Closes #89

## Test plan
- [x] `npm run build` succeeds
- [x] All tests pass (812/812)
- [x] Lint and typecheck clean
- [x] No visual changes — build tooling only

🤖 Generated with [Claude Code](https://claude.com/claude-code)