### PR TITLE
feat(ui): add PageContainer component for authenticated pages

### DIFF
--- a/app/(app)/checkin/page.tsx
+++ b/app/(app)/checkin/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { FdaDisclaimer } from "@/components/shared/fda-disclaimer";
 import { CheckinForm } from "@/components/checkin/checkin-form";
+import { PageContainer } from "@/components/layout";
 
 /**
  * /checkin — Daily Check-in Page
@@ -62,14 +63,7 @@ export default async function CheckinPage() {
   const alreadyCheckedIn = (count ?? 0) > 0;
 
   return (
-    <div
-      className="mx-auto max-w-md px-4 py-8"
-      style={{
-        maxWidth: "28rem",
-        margin: "0 auto",
-        padding: "2rem 1rem",
-      }}
-    >
+    <PageContainer width="sm">
       {/* Header */}
       <div
         className="mb-6"
@@ -126,6 +120,6 @@ export default async function CheckinPage() {
           Back to Dashboard
         </a>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/app/(app)/children/page.tsx
+++ b/app/(app)/children/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { isFeatureAvailable } from "@/lib/subscription";
 import { listChildren } from "@/lib/child-profiles";
 import { ChildrenManager } from "@/components/children";
+import { PageContainer } from "@/components/layout";
 
 /**
  * /children — Child Profiles Management Page
@@ -36,14 +37,7 @@ export default async function ChildrenPage() {
   }
 
   return (
-    <div
-      className="mx-auto max-w-2xl px-4 py-8"
-      style={{
-        maxWidth: "42rem",
-        margin: "0 auto",
-        padding: "2rem 1rem",
-      }}
-    >
+    <PageContainer>
       <div className="mb-6">
         <h1
           className="text-2xl font-bold text-brand-primary-dark"
@@ -72,6 +66,6 @@ export default async function ChildrenPage() {
         initialChildren={children}
         hasAccess={hasAccess}
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { getConfidenceTierBySignals } from "@/lib/engine";
 import type { RankedAllergen, CheckinSeverityQuery } from "@/components/leaderboard/types";
 import { SignOutButton } from "./sign-out-button";
 import { DashboardLeaderboard } from "./dashboard-leaderboard";
+import { PageContainer } from "@/components/layout";
 
 /**
  * Shape returned by the Supabase join query.
@@ -105,14 +106,7 @@ export default async function DashboardPage() {
   }
 
   return (
-    <div
-      className="mx-auto max-w-2xl px-4 py-8"
-      style={{
-        maxWidth: "42rem",
-        margin: "0 auto",
-        padding: "2rem 1rem",
-      }}
-    >
+    <PageContainer>
       <div
         className="mb-6 flex items-center justify-between"
         style={{
@@ -155,6 +149,6 @@ export default async function DashboardPage() {
         fdaAcknowledged={fdaAcknowledged}
         userId={user.id}
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/app/(app)/referral/page.tsx
+++ b/app/(app)/referral/page.tsx
@@ -12,6 +12,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getReferralStatus } from "@/lib/referral";
 import { ReferralProgress } from "@/components/referral/referral-progress";
 import { ReferralPageClient } from "./referral-page-client";
+import { PageContainer } from "@/components/layout";
 
 export default async function ReferralPage() {
   const supabase = await createClient();
@@ -26,15 +27,7 @@ export default async function ReferralPage() {
   const status = await getReferralStatus(supabase, user.id);
 
   return (
-    <div
-      className="mx-auto max-w-md space-y-6 px-4 py-8"
-      style={{
-        maxWidth: "28rem",
-        marginLeft: "auto",
-        marginRight: "auto",
-        padding: "2rem 1rem",
-      }}
-    >
+    <PageContainer width="sm" className="space-y-6">
       <div>
         <h1
           className="text-2xl font-bold text-brand-primary-dark"
@@ -65,6 +58,6 @@ export default async function ReferralPage() {
       />
 
       <ReferralPageClient referralCode={status.referral_code} />
-    </div>
+    </PageContainer>
   );
 }

--- a/app/(app)/scout/page.tsx
+++ b/app/(app)/scout/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { FdaDisclaimer } from "@/components/shared/fda-disclaimer";
 import { ScanForm } from "@/components/scout/scan-form";
+import { PageContainer } from "@/components/layout";
 
 /**
  * /scout — Trigger Scout Page
@@ -27,14 +28,7 @@ export default async function ScoutPage() {
   }
 
   return (
-    <div
-      className="mx-auto max-w-md px-4 py-8"
-      style={{
-        maxWidth: "28rem",
-        margin: "0 auto",
-        padding: "2rem 1rem",
-      }}
-    >
+    <PageContainer width="sm">
       {/* Header */}
       <div
         className="mb-6"
@@ -92,6 +86,6 @@ export default async function ScoutPage() {
           Back to Dashboard
         </a>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -1,1 +1,3 @@
 export { NavHeader } from "./nav-header";
+export { PageContainer } from "./page-container";
+export type { PageContainerProps, ContainerWidth } from "./page-container";

--- a/components/layout/page-container.tsx
+++ b/components/layout/page-container.tsx
@@ -1,0 +1,40 @@
+/**
+ * PageContainer
+ *
+ * Reusable layout wrapper for authenticated app pages.
+ * Provides centered, max-width-constrained content with consistent padding.
+ *
+ * Replaces repeated inline `mx-auto max-w-2xl px-4 py-8` patterns
+ * across dashboard, checkin, children, referral, and scout pages.
+ */
+
+export type ContainerWidth = "sm" | "md" | "lg";
+
+const WIDTH_CLASSES: Record<ContainerWidth, string> = {
+  sm: "max-w-md",
+  md: "max-w-2xl",
+  lg: "max-w-3xl",
+};
+
+export interface PageContainerProps {
+  /** Max-width preset: "sm" (28rem), "md" (42rem), "lg" (48rem). Default: "md" */
+  width?: ContainerWidth;
+  /** Additional CSS classes */
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function PageContainer({
+  width = "md",
+  className = "",
+  children,
+}: PageContainerProps) {
+  return (
+    <div
+      data-testid="page-container"
+      className={`mx-auto ${WIDTH_CLASSES[width]} px-4 py-8 ${className}`.trim()}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `PageContainer` component (`components/layout/page-container.tsx`) with `sm`/`md`/`lg` width presets and optional `className` prop
- Replaces repeated `mx-auto max-w-{x} px-4 py-8` + inline style fallbacks across 5 authenticated pages:
  - **dashboard** — `md` (42rem)
  - **checkin** — `sm` (28rem)
  - **children** — `md` (42rem)
  - **referral** — `sm` (28rem) + `space-y-6`
  - **scout** — `sm` (28rem)
- Removes inline `style={}` fallbacks from these container divs (Tailwind handles it now)

Closes #107

## Test plan
- [x] `npm run build` succeeds — no layout regressions
- [x] All tests pass (813/813)
- [x] Lint and typecheck clean
- [x] Landing page unaffected (uses its own full-width layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)