### PR TITLE
fix(ui): remove duplicate inline styles from children page

### DIFF
--- a/app/(app)/children/page.tsx
+++ b/app/(app)/children/page.tsx
@@ -39,25 +39,10 @@ export default async function ChildrenPage() {
   return (
     <PageContainer>
       <div className="mb-6">
-        <h1
-          className="text-2xl font-bold text-brand-primary-dark"
-          style={{
-            fontSize: "1.5rem",
-            fontWeight: 700,
-            color: "#045A82",
-            margin: 0,
-          }}
-        >
+        <h1 className="m-0 text-2xl font-bold text-brand-primary-dark">
           Child Profiles
         </h1>
-        <p
-          className="mt-1 text-sm text-brand-text-secondary"
-          style={{
-            fontSize: "0.875rem",
-            color: "#056DA5",
-            margin: "0.25rem 0 0 0",
-          }}
-        >
+        <p className="mt-1 mb-0 text-sm text-brand-text-secondary">
           Track allergies independently for each child in your family.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- Removes 2 remaining inline `style={}` attributes from `app/(app)/children/page.tsx`
- Tailwind classes (`m-0`, `mb-0`, `text-2xl`, `font-bold`, `text-brand-primary-dark`, `mt-1`, `text-sm`, `text-brand-text-secondary`) already cover the same styling
- Net change: -17 lines, +2 lines

## Test plan
- [x] `grep style= children/page.tsx` returns no matches
- [x] All 813 tests pass
- [x] Lint and typecheck clean

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)