### PR TITLE
fix(ui): remove inline color overrides across all authenticated pages

### DIFF
--- a/app/(app)/checkin/page.tsx
+++ b/app/(app)/checkin/page.tsx
@@ -65,38 +65,17 @@ export default async function CheckinPage() {
   return (
     <PageContainer width="sm">
       {/* Header */}
-      <div
-        className="mb-6"
-        style={{ marginBottom: "1.5rem" }}
-      >
-        <h1
-          className="text-2xl font-bold text-brand-primary-dark"
-          style={{
-            fontSize: "1.5rem",
-            fontWeight: 700,
-            color: "#045A82",
-            margin: "0 0 0.25rem 0",
-          }}
-        >
+      <div className="mb-6">
+        <h1 className="m-0 mb-1 text-2xl font-bold text-brand-primary-dark">
           Daily Check-in
         </h1>
-        <p
-          className="text-sm text-brand-text-secondary"
-          style={{
-            fontSize: "0.875rem",
-            color: "#056DA5",
-            margin: 0,
-          }}
-        >
+        <p className="m-0 text-sm text-brand-text-secondary">
           How are your allergies today? Your response updates the leaderboard.
         </p>
       </div>
 
       {/* FDA Disclaimer */}
-      <div
-        className="mb-6"
-        style={{ marginBottom: "1.5rem" }}
-      >
+      <div className="mb-6">
         <FdaDisclaimer variant="compact" />
       </div>
 
@@ -104,18 +83,10 @@ export default async function CheckinPage() {
       <CheckinForm alreadyCheckedIn={alreadyCheckedIn} />
 
       {/* Navigation back to dashboard */}
-      <div
-        className="mt-6 text-center"
-        style={{ marginTop: "1.5rem", textAlign: "center" }}
-      >
+      <div className="mt-6 text-center">
         <a
           href="/dashboard"
-          className="text-sm text-brand-primary hover:text-brand-primary-dark hover:underline"
-          style={{
-            fontSize: "0.875rem",
-            color: "#00B6E2",
-            textDecoration: "none",
-          }}
+          className="text-sm text-brand-primary no-underline hover:text-brand-primary-dark hover:underline"
         >
           Back to Dashboard
         </a>

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -107,35 +107,12 @@ export default async function DashboardPage() {
 
   return (
     <PageContainer>
-      <div
-        className="mb-6 flex items-center justify-between"
-        style={{
-          marginBottom: "1.5rem",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
+      <div className="mb-6 flex items-center justify-between">
         <div>
-          <h1
-            className="text-2xl font-bold text-brand-primary-dark"
-            style={{
-              fontSize: "1.5rem",
-              fontWeight: 700,
-              color: "#045A82",
-              margin: 0,
-            }}
-          >
+          <h1 className="m-0 text-2xl font-bold text-brand-primary-dark">
             Welcome to Allergy Madness
           </h1>
-          <p
-            className="text-sm text-brand-text-secondary"
-            style={{
-              fontSize: "0.875rem",
-              color: "#056DA5",
-              margin: "0.25rem 0 0 0",
-            }}
-          >
+          <p className="mt-1 mb-0 text-sm text-brand-text-secondary">
             Signed in as {user.email}
           </p>
         </div>

--- a/app/(app)/onboarding/page.tsx
+++ b/app/(app)/onboarding/page.tsx
@@ -35,13 +35,7 @@ export default async function OnboardingPage() {
   }
 
   return (
-    <main
-      className="min-h-screen bg-white"
-      style={{
-        minHeight: "100vh",
-        backgroundColor: "#ffffff",
-      }}
-    >
+    <main className="min-h-screen bg-white">
       <OnboardingWizard />
     </main>
   );

--- a/app/(app)/referral/page.tsx
+++ b/app/(app)/referral/page.tsx
@@ -29,25 +29,10 @@ export default async function ReferralPage() {
   return (
     <PageContainer width="sm" className="space-y-6">
       <div>
-        <h1
-          className="text-2xl font-bold text-brand-primary-dark"
-          style={{
-            fontSize: "1.5rem",
-            fontWeight: 700,
-            color: "#045A82",
-            margin: 0,
-          }}
-        >
+        <h1 className="m-0 text-2xl font-bold text-brand-primary-dark">
           Invite Friends
         </h1>
-        <p
-          className="mt-1 text-sm text-brand-text-muted"
-          style={{
-            fontSize: "0.875rem",
-            color: "#0682BB",
-            marginTop: "0.25rem",
-          }}
-        >
+        <p className="mt-1 mb-0 text-sm text-brand-text-muted">
           Share Allergy Madness with friends and unlock all features for free.
         </p>
       </div>

--- a/app/(app)/scout/page.tsx
+++ b/app/(app)/scout/page.tsx
@@ -30,39 +30,18 @@ export default async function ScoutPage() {
   return (
     <PageContainer width="sm">
       {/* Header */}
-      <div
-        className="mb-6"
-        style={{ marginBottom: "1.5rem" }}
-      >
-        <h1
-          className="text-2xl font-bold text-brand-primary-dark"
-          style={{
-            fontSize: "1.5rem",
-            fontWeight: 700,
-            color: "#045A82",
-            margin: "0 0 0.25rem 0",
-          }}
-        >
+      <div className="mb-6">
+        <h1 className="m-0 mb-1 text-2xl font-bold text-brand-primary-dark">
           Trigger Scout
         </h1>
-        <p
-          className="text-sm text-brand-text-secondary"
-          style={{
-            fontSize: "0.875rem",
-            color: "#056DA5",
-            margin: 0,
-          }}
-        >
+        <p className="m-0 text-sm text-brand-text-secondary">
           Photograph a plant you suspect causes reactions. AI will identify it
           and check it against your allergen profile.
         </p>
       </div>
 
       {/* FDA Disclaimer */}
-      <div
-        className="mb-6"
-        style={{ marginBottom: "1.5rem" }}
-      >
+      <div className="mb-6">
         <FdaDisclaimer variant="compact" />
       </div>
 
@@ -70,18 +49,10 @@ export default async function ScoutPage() {
       <ScanForm />
 
       {/* Navigation back to dashboard */}
-      <div
-        className="mt-6 text-center"
-        style={{ marginTop: "1.5rem", textAlign: "center" }}
-      >
+      <div className="mt-6 text-center">
         <a
           href="/dashboard"
-          className="text-sm text-brand-primary hover:text-brand-primary-dark hover:underline"
-          style={{
-            fontSize: "0.875rem",
-            color: "#00B6E2",
-            textDecoration: "none",
-          }}
+          className="text-sm text-brand-primary no-underline hover:text-brand-primary-dark hover:underline"
         >
           Back to Dashboard
         </a>


### PR DESCRIPTION
## Summary
- Removes all remaining inline `style={}` attributes from 5 authenticated pages: scout, checkin, dashboard, referral, onboarding
- Fixes brand color divergence where `#045A82` was hard-coded instead of using the `text-brand-primary-dark` Tailwind token (`#0682BB`)
- Net change: -120 lines, +18 lines — zero inline styles remain under `app/(app)/`

## Pages changed
| Page | Inline styles removed |
|------|----------------------|
| `scout/page.tsx` | 5 (h1 color/font, p color/font, link color, 2x margin) |
| `checkin/page.tsx` | 5 (h1 color/font, p color/font, link color, 2x margin) |
| `dashboard/page.tsx` | 3 (h1 color/font, p color/font, flex layout) |
| `referral/page.tsx` | 2 (h1 color/font, p color/font) |
| `onboarding/page.tsx` | 1 (bg-white + min-height fallback) |

## Test plan
- [x] `grep -r 'style={' app/(app)/` returns zero matches
- [x] All 815 tests pass
- [x] Lint and typecheck clean

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)