### PR TITLE
fix(ui): convert remaining static inline styles to Tailwind classes

### DIFF
--- a/components/checkin/symptom-zones.tsx
+++ b/components/checkin/symptom-zones.tsx
@@ -91,10 +91,7 @@ export function SymptomZones({ symptoms, onChange }: SymptomZonesProps) {
                     </span>
                   )}
                   <span
-                    className="text-sm text-brand-text-faint transition-transform"
-                    style={{
-                      transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
-                    }}
+                    className={`text-sm text-brand-text-faint transition-transform ${isExpanded ? "rotate-180" : ""}`}
                     aria-hidden="true"
                   >
                     &#9660;

--- a/components/leaderboard/environmental-forecast.tsx
+++ b/components/leaderboard/environmental-forecast.tsx
@@ -122,8 +122,8 @@ function DataRow({
         {label}
       </span>
       <span
-        className="text-sm font-medium"
-        style={{ color: color ?? "#045A82" }}
+        className={`text-sm font-medium ${color ? "" : "text-brand-text"}`}
+        style={color ? { color } : undefined}
       >
         {value}
       </span>

--- a/components/onboarding/processing-screen.tsx
+++ b/components/onboarding/processing-screen.tsx
@@ -96,11 +96,11 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
   if (error) {
     return (
       <div className="space-y-4 text-center">
-        <div className="rounded-md border border-[#B8E4F0] bg-[#E0F0F8] p-4">
-          <p className="text-sm font-medium text-[#055A8C]">
+        <div className="rounded-md border border-brand-border bg-brand-premium-light p-4">
+          <p className="text-sm font-medium text-brand-premium">
             Something went wrong
           </p>
-          <p className="mt-1 text-sm text-[#056DA5]">
+          <p className="mt-1 text-sm text-brand-text-secondary">
             {error}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- Converts 3 static inline `style={}` usages to Tailwind utility classes across component files
- **symptom-zones.tsx**: replaces `style={{ transform: rotate() }}` with Tailwind `rotate-180` class
- **environmental-forecast.tsx**: replaces hard-coded `#045A82` default in DataRow with `text-brand-text` class; keeps `style` only when dynamic color is passed
- **processing-screen.tsx**: replaces 4 arbitrary hex classes (`[#B8E4F0]`, `[#E0F0F8]`, `[#055A8C]`, `[#056DA5]`) with brand token classes

## What remains
7 `style={}` attributes remain — all truly dynamic (runtime data-driven colors and progress bar widths) that cannot be expressed as static Tailwind:
- `severity-slider.tsx` — severity level colors
- `pfas-panel.tsx` — severity badge colors
- `environmental-forecast.tsx` — UPI/AQI dynamic colors (3x)
- `referral-progress.tsx` — progress bar width
- `processing-screen.tsx` — progress bar width

## Test plan
- [x] All 815 tests pass
- [x] Lint and typecheck clean
- [x] Verified remaining `style=` are all dynamic values

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)