### PR TITLE
test(subscription): strengthen cache dedup test and add JSDoc guidance

### DIFF
--- a/__tests__/subscription/check.test.ts
+++ b/__tests__/subscription/check.test.ts
@@ -16,6 +16,27 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+/**
+ * Mock React's cache() to behave like the real RSC version:
+ * memoize the factory so the same Map is returned within a test.
+ * In production, Next.js scopes cache() per request.
+ */
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    cache: <T extends (...args: unknown[]) => unknown>(fn: T): T => {
+      let result: ReturnType<T> | undefined;
+      return ((...args: unknown[]) => {
+        if (result === undefined) {
+          result = fn(...args) as ReturnType<T>;
+        }
+        return result;
+      }) as unknown as T;
+    },
+  };
+});
+
 /* ------------------------------------------------------------------ */
 /* Mock Supabase client factory                                        */
 /* ------------------------------------------------------------------ */
@@ -261,21 +282,43 @@ describe("subscription check — paywall enabled", () => {
     const { getCachedAccessStatus } = await import(
       "@/lib/subscription/check"
     );
-    const supabase = createMockSupabase(
-      { tier: "madness_plus", expires_at: null },
-      { features_unlocked: false },
-    );
+    const mockFrom = vi.fn((table: string) => ({
+      select: () => ({
+        eq: (_col: string, _val: string) => ({
+          eq: () => ({
+            single: async () => ({
+              data: table === "user_profiles" ? { features_unlocked: false } : null,
+              error: null,
+            }),
+            maybeSingle: async () => ({
+              data: table === "user_subscriptions" ? { tier: "madness_plus", expires_at: null } : null,
+              error: null,
+            }),
+          }),
+          single: async () => ({
+            data: table === "user_profiles" ? { features_unlocked: false } : null,
+            error: null,
+          }),
+          maybeSingle: async () => ({
+            data: table === "user_subscriptions" ? { tier: "madness_plus", expires_at: null } : null,
+            error: null,
+          }),
+        }),
+      }),
+    }));
+    const supabase = { from: mockFrom } as never;
 
-    // Call twice with same userId — both should resolve
-    const [first, second] = await Promise.all([
-      getCachedAccessStatus(supabase, "user-1"),
-      getCachedAccessStatus(supabase, "user-1"),
-    ]);
+    // Call twice with same userId — second call should hit cache
+    const first = await getCachedAccessStatus(supabase, "user-1");
+    const second = await getCachedAccessStatus(supabase, "user-1");
 
-    // Both return identical results
+    // Both return correct results
     expect(first.tier).toBe("madness_plus");
     expect(second.tier).toBe("madness_plus");
     expect(first.isPremium).toBe(true);
     expect(second.isPremium).toBe(true);
+
+    // DB was only queried once (2 tables per call = 2 from() calls)
+    expect(mockFrom).toHaveBeenCalledTimes(2);
   });
 });

--- a/lib/subscription/check.ts
+++ b/lib/subscription/check.ts
@@ -9,6 +9,11 @@
  * - PAYWALL_ENABLED=true: checks subscription + referral status
  * - Referral unlock is permanent and independent of subscription
  *
+ * Preferred entry point for server components: `getCachedAccessStatus`.
+ * It deduplicates DB queries within a single Next.js request via
+ * React `cache()`. Use `getAccessStatus` only when you need a fresh
+ * (uncached) query.
+ *
  * IMPORTANT: income_tier is NEVER included in any output.
  */
 


### PR DESCRIPTION
## Summary
- Mocks React `cache()` in Vitest to memoize like the real RSC environment, enabling proper dedup verification
- Strengthens the dedup test: asserts `mockFrom` was called exactly 2 times (1 DB round-trip = 2 tables), proving `getCachedAccessStatus` skips the DB on the second call
- Adds module-level JSDoc to `lib/subscription/check.ts` noting `getCachedAccessStatus` as the preferred entry point for server components

## Test plan
- [x] All 815 tests pass (13 subscription tests including strengthened dedup)
- [x] Lint and typecheck clean
- [x] `mockFrom.toHaveBeenCalledTimes(2)` confirms deduplication works

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)