### PR TITLE
refactor(ui): extract shared LockIcon component

### DIFF
--- a/components/leaderboard/blur-overlay.tsx
+++ b/components/leaderboard/blur-overlay.tsx
@@ -8,6 +8,7 @@
 
 import type { BlurOverlayProps } from "./types";
 import { UpgradeCta } from "@/components/subscription/upgrade-cta";
+import { LockIcon } from "@/components/shared";
 
 export function BlurOverlay({
   children,
@@ -37,10 +38,7 @@ export function BlurOverlay({
           className="mb-2 inline-flex h-12 w-12 animate-pulse items-center justify-center rounded-full bg-brand-primary"
           aria-hidden="true"
         >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-            <path d="M7 11V7a5 5 0 0110 0v4" />
-          </svg>
+          <LockIcon size={24} stroke="white" />
         </span>
         {!showUpgradeCta && (
           <p className="text-sm font-medium text-brand-text-secondary">

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -17,6 +17,7 @@
 import { useState, useEffect } from "react";
 import { FdaDisclaimer } from "@/components/shared/fda-disclaimer";
 import { DisclaimerModal } from "@/components/shared/disclaimer-modal";
+import { LockIcon } from "@/components/shared";
 import { TriggerChampionCard } from "./trigger-champion-card";
 import { FinalFour } from "./final-four";
 import { EnvironmentalForecast } from "./environmental-forecast";
@@ -187,10 +188,7 @@ export function Leaderboard({
                       aria-hidden="true"
                       className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand-primary"
                     >
-                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-                        <path d="M7 11V7a5 5 0 0110 0v4" />
-                      </svg>
+                      <LockIcon size={12} stroke="white" strokeWidth={2.5} />
                     </span>
                     <span className="text-xs font-medium text-brand-primary">
                       Upgrade

--- a/components/shared/index.ts
+++ b/components/shared/index.ts
@@ -13,3 +13,6 @@ export type { FdaDisclaimerProps, FdaDisclaimerVariant } from "./fda-disclaimer"
 
 export { DisclaimerModal } from "./disclaimer-modal";
 export type { DisclaimerModalProps } from "./disclaimer-modal";
+
+export { LockIcon } from "./lock-icon";
+export type { LockIconProps } from "./lock-icon";

--- a/components/shared/lock-icon.tsx
+++ b/components/shared/lock-icon.tsx
@@ -1,0 +1,42 @@
+/**
+ * Shared Lock Icon
+ *
+ * Reusable SVG lock icon used across premium/freemium gates.
+ * Accepts configurable size and stroke properties.
+ */
+
+export interface LockIconProps {
+  /** Icon width and height in pixels */
+  size?: number;
+  /** SVG stroke color */
+  stroke?: string;
+  /** SVG stroke width */
+  strokeWidth?: number;
+  /** Additional class names */
+  className?: string;
+}
+
+export function LockIcon({
+  size = 24,
+  stroke = "currentColor",
+  strokeWidth = 2,
+  className,
+}: LockIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0110 0v4" />
+    </svg>
+  );
+}

--- a/components/subscription/premium-badge.tsx
+++ b/components/subscription/premium-badge.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { SubscriptionTier } from "@/lib/subscription/types";
+import { LockIcon } from "@/components/shared";
 
 export interface PremiumBadgeProps {
   /** The user's current tier (affects badge display) */
@@ -45,10 +46,7 @@ export function PremiumBadge({
     >
       {!compact && (
         <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-brand-surface-muted">
-          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-            <path d="M7 11V7a5 5 0 0110 0v4" />
-          </svg>
+          <LockIcon size={10} strokeWidth={2.5} />
         </span>
       )}
       Premium


### PR DESCRIPTION
## Summary
- Creates `components/shared/lock-icon.tsx` — a reusable `LockIcon` SVG component with configurable `size`, `stroke`, and `strokeWidth` props
- Replaces 3 duplicate inline lock SVGs:
  - `blur-overlay.tsx` (size 24, white stroke)
  - `leaderboard.tsx` (size 12, white stroke, strokeWidth 2.5)
  - `premium-badge.tsx` (size 10, currentColor stroke, strokeWidth 2.5)
- Exports `LockIcon` and `LockIconProps` from `components/shared/index.ts`

## Test plan
- [x] Lock SVG path only exists in `lock-icon.tsx` (verified via grep)
- [x] All 815 tests pass
- [x] Lint and typecheck clean
- [x] No snapshot tests to update (none exist in this repo)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)