### PR TITLE
refactor(layout): unify landing page and authenticated nav bars

### DIFF
--- a/__tests__/components/layout/nav-header.test.tsx
+++ b/__tests__/components/layout/nav-header.test.tsx
@@ -127,3 +127,40 @@ describe("NavHeader", () => {
     expect(mockRefresh).toHaveBeenCalled();
   });
 });
+
+/* ------------------------------------------------------------------ */
+/* Unauthenticated state                                               */
+/* ------------------------------------------------------------------ */
+
+describe("NavHeader — unauthenticated", () => {
+  it("renders Sign In and Get Started links", () => {
+    render(<NavHeader isAuthenticated={false} />);
+
+    expect(screen.getByTestId("nav-sign-in")).toBeDefined();
+    expect(screen.getByTestId("nav-sign-in").getAttribute("href")).toBe("/login");
+    expect(screen.getByTestId("nav-get-started")).toBeDefined();
+    expect(screen.getByTestId("nav-get-started").getAttribute("href")).toBe("/signup");
+  });
+
+  it("does not render authenticated nav links or sign-out", () => {
+    render(<NavHeader isAuthenticated={false} />);
+
+    expect(screen.queryByText("Dashboard")).toBeNull();
+    expect(screen.queryByText("Check-in")).toBeNull();
+    expect(screen.queryByText("Sign Out")).toBeNull();
+    expect(screen.queryByTestId("sign-out-button")).toBeNull();
+  });
+
+  it("links logo to / instead of /dashboard", () => {
+    render(<NavHeader isAuthenticated={false} />);
+
+    const logoImg = screen.getByAltText("Champ Allergy");
+    expect(logoImg.closest("a")?.getAttribute("href")).toBe("/");
+  });
+
+  it("does not render mobile hamburger menu", () => {
+    render(<NavHeader isAuthenticated={false} />);
+
+    expect(screen.queryByLabelText("Open menu")).toBeNull();
+  });
+});

--- a/__tests__/landing-page.test.tsx
+++ b/__tests__/landing-page.test.tsx
@@ -11,6 +11,8 @@ vi.mock("next/navigation", () => ({
     // redirect throws in Next.js to halt rendering
     throw new Error("NEXT_REDIRECT");
   },
+  usePathname: () => "/",
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }));
 
 // Mock next/link as a simple anchor
@@ -28,6 +30,13 @@ vi.mock("next/link", () => ({
       {children}
     </a>
   ),
+}));
+
+// Mock Supabase browser client (used by NavHeader)
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { signOut: vi.fn().mockResolvedValue({ error: null }) },
+  }),
 }));
 
 // Default: unauthenticated user

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import {
   FDA_DISCLAIMER_LABEL,
   FDA_DISCLAIMER_FULL_TEXT,
 } from "@/components/shared/fda-disclaimer";
+import { NavHeader } from "@/components/layout";
 
 /**
  * Root Landing Page
@@ -37,29 +38,8 @@ export default async function HomePage() {
 
   return (
     <div className="min-h-screen bg-brand-surface">
-      {/* Navigation */}
-      <header className="border-b border-white/20 bg-brand-primary-dark">
-        <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-4 sm:px-6">
-          <div className="flex items-center gap-2">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/champ-logo-alt.png" alt="Champ Allergy" className="h-10 w-auto" />
-          </div>
-          <div className="flex items-center gap-3">
-            <Link
-              href="/login"
-              className="rounded-button px-4 py-2 text-sm font-medium text-white/80 transition-colors hover:text-white"
-            >
-              Sign In
-            </Link>
-            <Link
-              href="/signup"
-              className="rounded-button bg-brand-accent px-4 py-2 text-sm font-semibold text-brand-primary-dark transition-colors hover:bg-brand-accent-dark"
-            >
-              Get Started
-            </Link>
-          </div>
-        </nav>
-      </header>
+      {/* Navigation — unified component */}
+      <NavHeader isAuthenticated={false} />
 
       {/* Hero Section */}
       <section className="bg-gradient-to-b from-brand-primary to-brand-primary-dark px-4 py-16 sm:px-6 sm:py-24">

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -1,3 +1,4 @@
 export { NavHeader } from "./nav-header";
+export type { NavHeaderProps } from "./nav-header";
 export { PageContainer } from "./page-container";
 export type { PageContainerProps, ContainerWidth } from "./page-container";

--- a/components/layout/nav-header.tsx
+++ b/components/layout/nav-header.tsx
@@ -1,30 +1,38 @@
 "use client";
 
+/**
+ * Unified Navigation Header
+ *
+ * Single nav component that adapts based on authentication state.
+ * - Authenticated: app links (Dashboard, Check-in, Children, Scout) + Sign Out
+ * - Unauthenticated: Sign In + Get Started
+ *
+ * Used in both `app/(app)/layout.tsx` and `app/page.tsx`.
+ */
+
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-
-/**
- * Navigation header for authenticated pages.
- *
- * Provides app logo, navigation links, and a mobile hamburger menu.
- * Highlighted link indicates the active route.
- */
 
 interface NavLink {
   href: string;
   label: string;
 }
 
-const NAV_LINKS: NavLink[] = [
+const AUTH_NAV_LINKS: NavLink[] = [
   { href: "/dashboard", label: "Dashboard" },
   { href: "/checkin", label: "Check-in" },
   { href: "/children", label: "Children" },
   { href: "/scout", label: "Scout" },
 ];
 
-export function NavHeader() {
+export interface NavHeaderProps {
+  /** Whether the user is authenticated. Determines which links to show. */
+  isAuthenticated?: boolean;
+}
+
+export function NavHeader({ isAuthenticated = true }: NavHeaderProps) {
   const pathname = usePathname();
   const router = useRouter();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -48,84 +56,106 @@ export function NavHeader() {
       <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3 sm:px-6">
         {/* Logo */}
         <Link
-          href="/dashboard"
+          href={isAuthenticated ? "/dashboard" : "/"}
           className="flex items-center"
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src="/champ-logo-alt.png" alt="Champ Allergy" className="h-10 w-auto" />
         </Link>
 
-        {/* Desktop nav links */}
-        <div className="hidden items-center gap-1 sm:flex">
-          {NAV_LINKS.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className={`rounded-button px-3 py-2 text-sm font-medium transition-colors ${
-                isActive(link.href)
-                  ? "bg-white/20 text-white"
-                  : "text-white/80 hover:bg-white/10 hover:text-white"
-              }`}
-            >
-              {link.label}
-            </Link>
-          ))}
-          <button
-            type="button"
-            onClick={handleSignOut}
-            data-testid="sign-out-button"
-            className="ml-2 rounded-button px-3 py-2 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
-          >
-            Sign Out
-          </button>
-        </div>
+        {isAuthenticated ? (
+          <>
+            {/* Desktop nav links — authenticated */}
+            <div className="hidden items-center gap-1 sm:flex">
+              {AUTH_NAV_LINKS.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={`rounded-button px-3 py-2 text-sm font-medium transition-colors ${
+                    isActive(link.href)
+                      ? "bg-white/20 text-white"
+                      : "text-white/80 hover:bg-white/10 hover:text-white"
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              ))}
+              <button
+                type="button"
+                onClick={handleSignOut}
+                data-testid="sign-out-button"
+                className="ml-2 rounded-button px-3 py-2 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+              >
+                Sign Out
+              </button>
+            </div>
 
-        {/* Mobile hamburger button */}
-        <button
-          type="button"
-          className="inline-flex items-center justify-center rounded-button p-2 text-white/80 transition-colors hover:bg-white/10 hover:text-white sm:hidden"
-          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-          aria-expanded={mobileMenuOpen}
-          aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
-        >
-          {mobileMenuOpen ? (
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-              aria-hidden="true"
+            {/* Mobile hamburger button — authenticated */}
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-button p-2 text-white/80 transition-colors hover:bg-white/10 hover:text-white sm:hidden"
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              aria-expanded={mobileMenuOpen}
+              aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          ) : (
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-              aria-hidden="true"
+              {mobileMenuOpen ? (
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+                  />
+                </svg>
+              )}
+            </button>
+          </>
+        ) : (
+          /* Desktop + mobile links — unauthenticated */
+          <div className="flex items-center gap-3">
+            <Link
+              href="/login"
+              data-testid="nav-sign-in"
+              className="rounded-button px-4 py-2 text-sm font-medium text-white/80 transition-colors hover:text-white"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-              />
-            </svg>
-          )}
-        </button>
+              Sign In
+            </Link>
+            <Link
+              href="/signup"
+              data-testid="nav-get-started"
+              className="rounded-button bg-brand-accent px-4 py-2 text-sm font-semibold text-brand-primary-dark transition-colors hover:bg-brand-accent-dark"
+            >
+              Get Started
+            </Link>
+          </div>
+        )}
       </nav>
 
-      {/* Mobile menu */}
-      {mobileMenuOpen && (
+      {/* Mobile menu — authenticated only */}
+      {isAuthenticated && mobileMenuOpen && (
         <div className="border-t border-white/20 bg-brand-primary-dark px-4 pb-3 pt-2 sm:hidden">
-          {NAV_LINKS.map((link) => (
+          {AUTH_NAV_LINKS.map((link) => (
             <Link
               key={link.href}
               href={link.href}


### PR DESCRIPTION
## Summary
- Extends `NavHeader` with an `isAuthenticated` prop (defaults to `true` for backward compatibility)
- **Authenticated mode**: app links (Dashboard, Check-in, Children, Scout) + Sign Out + mobile hamburger
- **Unauthenticated mode**: Sign In + Get Started links, logo → `/`
- Replaces the inline `<header>` in `app/page.tsx` with `<NavHeader isAuthenticated={false} />`
- Single nav component now serves both the landing page and all authenticated pages

## Files changed
| File | Change |
|------|--------|
| `components/layout/nav-header.tsx` | Added `isAuthenticated` prop, conditional rendering |
| `components/layout/index.ts` | Export `NavHeaderProps` type |
| `app/page.tsx` | Replace inline nav with `<NavHeader isAuthenticated={false} />` |
| `__tests__/components/layout/nav-header.test.tsx` | 4 new tests for unauthenticated state |
| `__tests__/landing-page.test.tsx` | Added `usePathname`, `useRouter`, Supabase client mocks |

## Test plan
- [x] 12 nav-header tests pass (8 authenticated + 4 unauthenticated)
- [x] 10 landing page tests pass (mocks updated for NavHeader hooks)
- [x] All 819 tests pass
- [x] Lint and typecheck clean

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)