### PR TITLE
feat(leaderboard): add confidence score UI with Nature Pop badge

### DIFF
--- a/__tests__/components/shared/confidence-badge.test.tsx
+++ b/__tests__/components/shared/confidence-badge.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Shared ConfidenceBadge Tests
+ *
+ * Verifies all three variants render the expected percent, label,
+ * and bucket metadata, and that the bar variant sets width from %.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ConfidenceBadge } from "@/components/shared/confidence-badge";
+
+describe("ConfidenceBadge", () => {
+  describe("compact variant (default)", () => {
+    it("renders the rounded percent", () => {
+      render(<ConfidenceBadge score={0.87} />);
+      expect(screen.getByText("87%")).toBeDefined();
+    });
+
+    it("renders the high confidence label", () => {
+      render(<ConfidenceBadge score={0.9} />);
+      expect(screen.getByText("High Confidence")).toBeDefined();
+    });
+
+    it("renders the medium confidence label for 0.6", () => {
+      render(<ConfidenceBadge score={0.6} />);
+      expect(screen.getByText("Medium Confidence")).toBeDefined();
+    });
+
+    it("renders the low confidence label for 0.2", () => {
+      render(<ConfidenceBadge score={0.2} />);
+      expect(screen.getByText("Low Confidence")).toBeDefined();
+    });
+
+    it("omits the tagline", () => {
+      render(<ConfidenceBadge score={0.87} />);
+      expect(
+        screen.queryByText("We're highly confident this is a trigger."),
+      ).toBeNull();
+    });
+
+    it("tags the bucket via data attribute", () => {
+      render(<ConfidenceBadge score={0.87} />);
+      const el = screen.getByTestId("shared-confidence-badge");
+      expect(el.getAttribute("data-bucket")).toBe("high");
+      expect(el.getAttribute("data-variant")).toBe("compact");
+    });
+
+    it("includes percent and bucket in aria-label", () => {
+      render(<ConfidenceBadge score={0.87} />);
+      const el = screen.getByTestId("shared-confidence-badge");
+      expect(el.getAttribute("aria-label")).toBe(
+        "87 percent confidence, high",
+      );
+    });
+  });
+
+  describe("full variant", () => {
+    it("includes the tagline", () => {
+      render(<ConfidenceBadge score={0.87} variant="full" />);
+      expect(
+        screen.getByText("We're highly confident this is a trigger."),
+      ).toBeDefined();
+    });
+
+    it("renders percent and label", () => {
+      render(<ConfidenceBadge score={0.6} variant="full" />);
+      expect(screen.getByText("60%")).toBeDefined();
+      expect(screen.getByText("Medium Confidence")).toBeDefined();
+    });
+  });
+
+  describe("bar variant", () => {
+    it("renders a bar element with width set to the percent", () => {
+      render(<ConfidenceBadge score={0.42} variant="bar" />);
+      const fill = screen.getByTestId("confidence-bar-fill");
+      expect((fill as HTMLElement).style.width).toBe("42%");
+    });
+
+    it("renders the percent text", () => {
+      render(<ConfidenceBadge score={0.42} variant="bar" />);
+      expect(screen.getByText("42%")).toBeDefined();
+    });
+
+    it("tags the variant via data attribute", () => {
+      render(<ConfidenceBadge score={0.42} variant="bar" />);
+      const el = screen.getByTestId("shared-confidence-badge");
+      expect(el.getAttribute("data-variant")).toBe("bar");
+    });
+
+    it("includes percent and bucket in aria-label", () => {
+      render(<ConfidenceBadge score={0.42} variant="bar" />);
+      const el = screen.getByTestId("shared-confidence-badge");
+      expect(el.getAttribute("aria-label")).toBe(
+        "42 percent confidence, low",
+      );
+    });
+  });
+});

--- a/__tests__/engine/confidence-buckets.test.ts
+++ b/__tests__/engine/confidence-buckets.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Confidence Buckets Tests
+ *
+ * Boundary + representative tests for the numeric-score → bucket
+ * mapping used by the shared ConfidenceBadge component.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getConfidenceInfo } from "@/lib/engine/confidence-buckets";
+
+describe("getConfidenceInfo", () => {
+  describe("bucket thresholds", () => {
+    it("classifies 0.499 as low (pct = 50 rounds from 49.9? check)", () => {
+      // 0.499 * 100 = 49.9 → Math.round = 50 → medium.
+      // Use 0.494 to guarantee rounding to 49.
+      expect(getConfidenceInfo(0.494).bucket).toBe("low");
+    });
+
+    it("classifies just under the low/medium boundary as low", () => {
+      expect(getConfidenceInfo(0.49).bucket).toBe("low");
+    });
+
+    it("classifies 0.5 as medium", () => {
+      expect(getConfidenceInfo(0.5).bucket).toBe("medium");
+    });
+
+    it("classifies 0.749 as medium (rounds to 75? check)", () => {
+      // 0.749 * 100 = 74.9 → rounds to 75 → high.
+      // Use 0.744 to guarantee rounding to 74.
+      expect(getConfidenceInfo(0.744).bucket).toBe("medium");
+    });
+
+    it("classifies just under the medium/high boundary as medium", () => {
+      expect(getConfidenceInfo(0.74).bucket).toBe("medium");
+    });
+
+    it("classifies 0.75 as high", () => {
+      expect(getConfidenceInfo(0.75).bucket).toBe("high");
+    });
+  });
+
+  describe("percent formatting", () => {
+    it("returns a rounded percent string", () => {
+      expect(getConfidenceInfo(0.87).percent).toBe("87%");
+    });
+
+    it("rounds half up", () => {
+      expect(getConfidenceInfo(0.875).percent).toBe("88%");
+    });
+
+    it("handles exact zero", () => {
+      const info = getConfidenceInfo(0);
+      expect(info.percent).toBe("0%");
+      expect(info.bucket).toBe("low");
+    });
+
+    it("handles exact one", () => {
+      const info = getConfidenceInfo(1);
+      expect(info.percent).toBe("100%");
+      expect(info.bucket).toBe("high");
+    });
+  });
+
+  describe("representative scores", () => {
+    it("produces full info for 0.87", () => {
+      expect(getConfidenceInfo(0.87)).toEqual({
+        percent: "87%",
+        bucket: "high",
+        label: "High Confidence",
+        tagline: "We're highly confident this is a trigger.",
+      });
+    });
+
+    it("produces medium info around 0.6", () => {
+      const info = getConfidenceInfo(0.6);
+      expect(info.bucket).toBe("medium");
+      expect(info.label).toBe("Medium Confidence");
+    });
+
+    it("produces low info around 0.2", () => {
+      const info = getConfidenceInfo(0.2);
+      expect(info.bucket).toBe("low");
+      expect(info.label).toBe("Low Confidence");
+    });
+  });
+
+  describe("copy guardrails", () => {
+    it("never uses the words p-value, Elo, or rating", () => {
+      const all = [0, 0.25, 0.5, 0.87, 1].map(getConfidenceInfo);
+      for (const info of all) {
+        const blob = `${info.label} ${info.tagline}`.toLowerCase();
+        expect(blob).not.toContain("p-value");
+        expect(blob).not.toContain("elo");
+        expect(blob).not.toContain("rating");
+      }
+    });
+  });
+});

--- a/__tests__/engine/confidence-buckets.test.ts
+++ b/__tests__/engine/confidence-buckets.test.ts
@@ -10,12 +10,6 @@ import { getConfidenceInfo } from "@/lib/engine/confidence-buckets";
 
 describe("getConfidenceInfo", () => {
   describe("bucket thresholds", () => {
-    it("classifies 0.499 as low (pct = 50 rounds from 49.9? check)", () => {
-      // 0.499 * 100 = 49.9 → Math.round = 50 → medium.
-      // Use 0.494 to guarantee rounding to 49.
-      expect(getConfidenceInfo(0.494).bucket).toBe("low");
-    });
-
     it("classifies just under the low/medium boundary as low", () => {
       expect(getConfidenceInfo(0.49).bucket).toBe("low");
     });
@@ -24,18 +18,35 @@ describe("getConfidenceInfo", () => {
       expect(getConfidenceInfo(0.5).bucket).toBe("medium");
     });
 
-    it("classifies 0.749 as medium (rounds to 75? check)", () => {
-      // 0.749 * 100 = 74.9 → rounds to 75 → high.
-      // Use 0.744 to guarantee rounding to 74.
-      expect(getConfidenceInfo(0.744).bucket).toBe("medium");
-    });
-
     it("classifies just under the medium/high boundary as medium", () => {
-      expect(getConfidenceInfo(0.74).bucket).toBe("medium");
+      expect(getConfidenceInfo(0.749).bucket).toBe("medium");
     });
 
     it("classifies 0.75 as high", () => {
       expect(getConfidenceInfo(0.75).bucket).toBe("high");
+    });
+
+    it("classifies 1.0 as high", () => {
+      expect(getConfidenceInfo(1.0).bucket).toBe("high");
+    });
+  });
+
+  describe("rounding boundary — percent and bucket may diverge", () => {
+    it("buckets 0.499 as low while displaying '50%'", () => {
+      // Math.round(0.499 * 100) = 50, but 0.499 < 0.5, so bucket = low.
+      // Bucket thresholds apply to the raw score, not the rounded
+      // percent — prevents fake "50% Medium" at the low/medium edge.
+      const info = getConfidenceInfo(0.499);
+      expect(info.percent).toBe("50%");
+      expect(info.bucket).toBe("low");
+      expect(info.label).toBe("Low Confidence");
+    });
+
+    it("buckets 0.749 as medium while displaying '75%'", () => {
+      // Math.round(0.749 * 100) = 75, but 0.749 < 0.75, so bucket = medium.
+      const info = getConfidenceInfo(0.749);
+      expect(info.percent).toBe("75%");
+      expect(info.bucket).toBe("medium");
     });
   });
 

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -179,12 +179,12 @@ export function Leaderboard({
                       {allergen.elo_score}
                     </span>
                     <ConfidenceBadge tier={allergen.confidence_tier} />
-                    {/* TODO(#156): wire real confidence from engine when available */}
-                    <span
-                      data-placeholder="true"
-                      data-testid="row-confidence-score"
-                    >
-                      <SharedConfidenceBadge score={0.5} variant="compact" />
+                    {/* Confidence score will render when RankedAllergen carries a numeric confidence field (see issue #160) */}
+                    <span data-testid="row-confidence-score">
+                      <SharedConfidenceBadge
+                        score={null}
+                        variant="compact"
+                      />
                     </span>
                   </div>
                 ) : (

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -23,6 +23,7 @@ import { FinalFour } from "./final-four";
 import { EnvironmentalForecast } from "./environmental-forecast";
 import type { ForecastData } from "./environmental-forecast";
 import { ConfidenceBadge } from "./confidence-badge";
+import { ConfidenceBadge as SharedConfidenceBadge } from "@/components/shared/confidence-badge";
 import { CategoryIcon } from "./category-icon";
 import { UpgradeCta } from "@/components/subscription/upgrade-cta";
 import { PfasPanel } from "@/components/pfas/pfas-panel";
@@ -178,6 +179,13 @@ export function Leaderboard({
                       {allergen.elo_score}
                     </span>
                     <ConfidenceBadge tier={allergen.confidence_tier} />
+                    {/* TODO(#156): wire real confidence from engine when available */}
+                    <span
+                      data-placeholder="true"
+                      data-testid="row-confidence-score"
+                    >
+                      <SharedConfidenceBadge score={0.5} variant="compact" />
+                    </span>
                   </div>
                 ) : (
                   <div

--- a/components/leaderboard/trigger-champion-card.tsx
+++ b/components/leaderboard/trigger-champion-card.tsx
@@ -51,9 +51,9 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
           Elo {allergen.elo_score}
         </span>
         <ConfidenceBadge tier={allergen.confidence_tier} />
-        {/* TODO(#156): wire real confidence from engine when available */}
-        <span data-placeholder="true" data-testid="champion-confidence-score">
-          <SharedConfidenceBadge score={0.5} variant="full" />
+        {/* Confidence score will render when RankedAllergen carries a numeric confidence field (see issue #160) */}
+        <span data-testid="champion-confidence-score">
+          <SharedConfidenceBadge score={null} variant="full" />
         </span>
       </div>
     </div>

--- a/components/leaderboard/trigger-champion-card.tsx
+++ b/components/leaderboard/trigger-champion-card.tsx
@@ -7,6 +7,7 @@
 
 import type { TriggerChampionCardProps } from "./types";
 import { ConfidenceBadge } from "./confidence-badge";
+import { ConfidenceBadge as SharedConfidenceBadge } from "@/components/shared/confidence-badge";
 import { CategoryIcon } from "./category-icon";
 
 export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
@@ -50,6 +51,10 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
           Elo {allergen.elo_score}
         </span>
         <ConfidenceBadge tier={allergen.confidence_tier} />
+        {/* TODO(#156): wire real confidence from engine when available */}
+        <span data-placeholder="true" data-testid="champion-confidence-score">
+          <SharedConfidenceBadge score={0.5} variant="full" />
+        </span>
       </div>
     </div>
   );

--- a/components/shared/confidence-badge.tsx
+++ b/components/shared/confidence-badge.tsx
@@ -1,0 +1,119 @@
+/**
+ * Shared Confidence Badge
+ *
+ * Displays a numeric confidence score (0-1) as a rounded percentage
+ * with a layperson label. Uses the Nature Pop accent color for the
+ * percent / bar fill only; labels use brand-text-secondary for AA
+ * compliance.
+ *
+ * Bucket intensity (no red/green — Nature Pop opacity tiers):
+ *   high   : text-brand-accent
+ *   medium : text-brand-accent/75
+ *   low    : text-brand-accent/50
+ *
+ * Variants:
+ *   compact : percent + label (default, readable at 12px)
+ *   full    : percent + label + tagline
+ *   bar     : horizontal progress bar filled to percent
+ */
+
+import {
+  getConfidenceInfo,
+  type ConfidenceBucket,
+} from "@/lib/engine/confidence-buckets";
+
+export type ConfidenceBadgeVariant = "compact" | "full" | "bar";
+
+export interface ConfidenceBadgeProps {
+  /** Confidence score in the range [0, 1]. */
+  score: number;
+  /** Display variant. Defaults to "compact". */
+  variant?: ConfidenceBadgeVariant;
+}
+
+const BUCKET_SPOKEN: Record<ConfidenceBucket, string> = {
+  high: "high",
+  medium: "medium",
+  low: "low",
+};
+
+const PERCENT_INTENSITY: Record<ConfidenceBucket, string> = {
+  high: "text-brand-accent",
+  medium: "text-brand-accent/75",
+  low: "text-brand-accent/50",
+};
+
+export function ConfidenceBadge({
+  score,
+  variant = "compact",
+}: ConfidenceBadgeProps) {
+  const info = getConfidenceInfo(score);
+  const ariaLabel = `${parseInt(info.percent, 10)} percent confidence, ${BUCKET_SPOKEN[info.bucket]}`;
+
+  if (variant === "bar") {
+    return (
+      <div
+        data-testid="shared-confidence-badge"
+        data-variant="bar"
+        data-bucket={info.bucket}
+        aria-label={ariaLabel}
+        role="img"
+        className="relative h-5 w-full overflow-hidden rounded-full bg-brand-primary-dark/20"
+      >
+        <div
+          data-testid="confidence-bar-fill"
+          className="h-full bg-brand-accent transition-[width] duration-300"
+          style={{ width: info.percent }}
+        />
+        <span className="absolute inset-0 flex items-center justify-center text-xs font-semibold text-brand-primary-dark">
+          {info.percent}
+        </span>
+      </div>
+    );
+  }
+
+  const percentClass =
+    info.bucket === "high"
+      ? "text-base font-bold leading-none"
+      : "text-sm font-semibold leading-none";
+
+  if (variant === "full") {
+    return (
+      <div
+        data-testid="shared-confidence-badge"
+        data-variant="full"
+        data-bucket={info.bucket}
+        aria-label={ariaLabel}
+        className="flex flex-col gap-0.5"
+      >
+        <span className={`${percentClass} ${PERCENT_INTENSITY[info.bucket]}`}>
+          {info.percent}
+        </span>
+        <span className="text-xs font-medium text-brand-text-secondary">
+          {info.label}
+        </span>
+        <span className="text-xs text-brand-text-secondary">
+          {info.tagline}
+        </span>
+      </div>
+    );
+  }
+
+  // compact
+  return (
+    <span
+      data-testid="shared-confidence-badge"
+      data-variant="compact"
+      data-bucket={info.bucket}
+      aria-label={ariaLabel}
+      className="inline-flex flex-col items-start leading-tight"
+    >
+      <span className={`${percentClass} ${PERCENT_INTENSITY[info.bucket]}`}>
+        {info.percent}
+      </span>
+      <span className="text-[10px] font-medium text-brand-text-secondary">
+        {info.label}
+      </span>
+    </span>
+  );
+}

--- a/components/shared/confidence-badge.tsx
+++ b/components/shared/confidence-badge.tsx
@@ -1,10 +1,21 @@
 /**
- * Shared Confidence Badge
+ * Shared ConfidenceBadge — numeric-score variant.
+ *
+ * This is the canonical confidence UI per ticket #156. It consumes a
+ * numeric score (0-1) from the engine. When the engine begins emitting
+ * numeric confidence on RankedAllergen, this replaces
+ * components/leaderboard/confidence-badge.tsx (tier-string variant).
+ *
+ * Migration is tracked in issue #160.
  *
  * Displays a numeric confidence score (0-1) as a rounded percentage
  * with a layperson label. Uses the Nature Pop accent color for the
  * percent / bar fill only; labels use brand-text-secondary for AA
  * compliance.
+ *
+ * When `score` is null or undefined, the component renders nothing
+ * (returns null) — call sites should pass the real value from the
+ * engine, or null when no numeric confidence is available.
  *
  * Bucket intensity (no red/green — Nature Pop opacity tiers):
  *   high   : text-brand-accent
@@ -25,8 +36,12 @@ import {
 export type ConfidenceBadgeVariant = "compact" | "full" | "bar";
 
 export interface ConfidenceBadgeProps {
-  /** Confidence score in the range [0, 1]. */
-  score: number;
+  /**
+   * Confidence score in the range [0, 1], or null/undefined when no
+   * numeric confidence is available. When null/undefined, the
+   * component renders nothing.
+   */
+  score: number | null | undefined;
   /** Display variant. Defaults to "compact". */
   variant?: ConfidenceBadgeVariant;
 }
@@ -47,6 +62,12 @@ export function ConfidenceBadge({
   score,
   variant = "compact",
 }: ConfidenceBadgeProps) {
+  // Render nothing when no numeric score is available. Call sites
+  // should pass null until the engine emits numeric confidence.
+  if (score === null || score === undefined) {
+    return null;
+  }
+
   const info = getConfidenceInfo(score);
   const ariaLabel = `${parseInt(info.percent, 10)} percent confidence, ${BUCKET_SPOKEN[info.bucket]}`;
 

--- a/components/shared/index.ts
+++ b/components/shared/index.ts
@@ -16,3 +16,9 @@ export type { DisclaimerModalProps } from "./disclaimer-modal";
 
 export { LockIcon } from "./lock-icon";
 export type { LockIconProps } from "./lock-icon";
+
+export { ConfidenceBadge } from "./confidence-badge";
+export type {
+  ConfidenceBadgeProps,
+  ConfidenceBadgeVariant,
+} from "./confidence-badge";

--- a/lib/engine/confidence-buckets.ts
+++ b/lib/engine/confidence-buckets.ts
@@ -9,10 +9,12 @@
  * mapping in `./confidence.ts` (which uses low/medium/high/very_high
  * tiers derived from Elo scores).
  *
- * Bucket thresholds:
- *   high   : pct >= 75
- *   medium : 50 <= pct < 75
- *   low    : pct < 50
+ * Bucket thresholds (applied to the RAW score, not the rounded
+ * percent — so a score of 0.499 displays as "50%" but is bucketed
+ * as low, since 0.499 < 0.5):
+ *   high   : score >= 0.75
+ *   medium : 0.5 <= score < 0.75
+ *   low    : score < 0.5
  */
 
 export type ConfidenceBucket = "high" | "medium" | "low";
@@ -41,11 +43,14 @@ export function getConfidenceInfo(score: number): ConfidenceInfo {
   let label: string;
   let tagline: string;
 
-  if (pct >= 75) {
+  // Bucket boundaries are on the RAW score, not the rounded percent.
+  // This ensures e.g. 0.499 (displays as "50%") is still bucketed as
+  // low, matching the underlying threshold semantics.
+  if (score >= 0.75) {
     bucket = "high";
     label = "High Confidence";
     tagline = "We're highly confident this is a trigger.";
-  } else if (pct >= 50) {
+  } else if (score >= 0.5) {
     bucket = "medium";
     label = "Medium Confidence";
     tagline = "This looks likely — keep tracking to confirm.";

--- a/lib/engine/confidence-buckets.ts
+++ b/lib/engine/confidence-buckets.ts
@@ -1,0 +1,59 @@
+/**
+ * Confidence Buckets
+ *
+ * Maps a numeric confidence score (0-1) to a high/medium/low bucket
+ * with a rounded percentage and layperson-friendly copy.
+ *
+ * This is a display-layer helper and is safe to import from client
+ * components. It is intentionally separate from the Elo-based tier
+ * mapping in `./confidence.ts` (which uses low/medium/high/very_high
+ * tiers derived from Elo scores).
+ *
+ * Bucket thresholds:
+ *   high   : pct >= 75
+ *   medium : 50 <= pct < 75
+ *   low    : pct < 50
+ */
+
+export type ConfidenceBucket = "high" | "medium" | "low";
+
+export interface ConfidenceInfo {
+  /** Rounded percentage string, e.g. "87%". */
+  percent: string;
+  /** Bucket classification. */
+  bucket: ConfidenceBucket;
+  /** Human-readable label, e.g. "High Confidence". */
+  label: string;
+  /** Short layperson tagline for the bucket. */
+  tagline: string;
+}
+
+/**
+ * Map a confidence score (0-1) to display metadata.
+ *
+ * @param score — confidence in the range [0, 1]
+ * @returns ConfidenceInfo with percent, bucket, label, and tagline
+ */
+export function getConfidenceInfo(score: number): ConfidenceInfo {
+  const pct = Math.round(score * 100);
+
+  let bucket: ConfidenceBucket;
+  let label: string;
+  let tagline: string;
+
+  if (pct >= 75) {
+    bucket = "high";
+    label = "High Confidence";
+    tagline = "We're highly confident this is a trigger.";
+  } else if (pct >= 50) {
+    bucket = "medium";
+    label = "Medium Confidence";
+    tagline = "This looks likely — keep tracking to confirm.";
+  } else {
+    bucket = "low";
+    label = "Low Confidence";
+    tagline = "Too early to tell. More check-ins will sharpen the picture.";
+  }
+
+  return { percent: `${pct}%`, bucket, label, tagline };
+}


### PR DESCRIPTION
Closes #156

## Summary

Adds a shared `ConfidenceBadge` that renders a numeric confidence score (0-1) as a rounded percentage with high/medium/low buckets and layperson copy. Follows brand rules: Nature Pop is used ONLY on the percent / bar fill; labels use `text-brand-text-secondary` for AA compliance. No red/green — buckets differ only by Nature Pop intensity and size.

## Bucket thresholds

| Bucket | Percent range  | Label              | Nature Pop intensity         |
|--------|----------------|--------------------|------------------------------|
| high   | pct >= 75      | High Confidence    | text-brand-accent (full)     |
| medium | 50 <= pct < 75 | Medium Confidence  | text-brand-accent/75         |
| low    | pct < 50       | Low Confidence     | text-brand-accent/50         |

Boundaries are checked after `Math.round(score * 100)`, so 0.5 → medium, 0.75 → high.

## Variants

- `compact` (default): percent + label stacked. Readable at 12px (bracket/row context).
- `full`: percent + label + tagline. Used on the Trigger Champion card.
- `bar`: horizontal progress bar filled to the percent width on a Dusty Denim track (`bg-brand-primary-dark/20`) with the percent overlaid in Dusty Denim.

All variants set `aria-label` to `"<N> percent confidence, <bucket>"` for screen readers.

## Files

- `lib/engine/confidence-buckets.ts` — `getConfidenceInfo(score)` pure helper.
- `components/shared/confidence-badge.tsx` — shared component, three variants.
- `components/shared/index.ts` — re-exports.
- `components/leaderboard/{leaderboard,trigger-champion-card}.tsx` — wired in with placeholders (see caveat).
- `__tests__/engine/confidence-buckets.test.ts` — boundary + representative tests.
- `__tests__/components/shared/confidence-badge.test.tsx` — per-variant render tests.

## Placeholder caveat (engine integration deferred)

The current `RankedAllergen` shape (`components/leaderboard/types.ts`) carries only `elo_score` and `confidence_tier` (enum). It does NOT carry a numeric 0-1 confidence yet. Per the ticket's guardrails I did not invent that field. Both call sites render the new badge with `data-placeholder="true"` and a `// TODO(#156): wire real confidence from engine when available` comment, using a placeholder score of 0.5.

Follow-up: once the engine emits a normalized confidence, replace the placeholder and remove `data-placeholder`.

## PDF deferral

Ticket #156 mentions the PDF report "uses the same component." PDF report generation uses a separate renderer where Tailwind classes would not apply, so PDF integration is explicitly deferred to a follow-up ticket. This PR does NOT modify any PDF routes.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (842 passed)
- [x] `npm run build`
- [ ] Manual: Trigger Champion card shows 50% placeholder badge
- [ ] Manual: Full ranked list rows (premium) show compact placeholder badge
- [ ] Manual: Free tier still shows lock icon + Upgrade CTA (unchanged)