### PR TITLE
refactor(ui): enforce Nature Pop 2% rule across consumer surfaces

### DIFF
--- a/components/referral/referral-share.tsx
+++ b/components/referral/referral-share.tsx
@@ -95,7 +95,7 @@ export function ReferralShare({
           data-testid="referral-copy-btn"
           className={`flex-1 cursor-pointer rounded-md border-none px-4 py-2 text-sm font-medium text-white transition-colors ${
             copied
-              ? "bg-brand-accent"
+              ? "bg-brand-primary-dark"
               : "bg-brand-primary hover:bg-brand-primary-dark"
           }`}
         >


### PR DESCRIPTION
Closes #148

## Summary

Audit every Nature Pop (`brand-accent` / `#CCDC29`) usage across `app/` and `components/` per the Champ Health Design System 2% rule. Nature Pop is reserved for primary conversion CTAs, confidence-score highlights, and pop-up / winner highlights. Decorative or feedback-chrome usages are swapped to Dusty Denim / Surface tokens.

## Inventory

| File:line | Context | Classification | Action |
|-----------|---------|----------------|--------|
| `app/page.tsx:56` | Nav "Get Started" — signup CTA | Keep — primary conversion CTA | none |
| `app/page.tsx:86` | Hero "Get Started Free" — signup CTA | Keep — primary conversion CTA | none |
| `app/page.tsx:188` | Bottom "Get Started Free" — signup CTA | Keep — primary conversion CTA | none |
| `components/referral/referral-share.tsx:98` | "Copied!" transient button feedback | Remove — feedback chrome, not CTA | swap to `bg-brand-primary-dark` |
| `components/scout/scan-form.tsx:132` | "Take Photo or Upload" — sole primary action on Scout screen | Keep — primary CTA on feature surface | none |
| `components/shared/confidence-badge.tsx:21-23,56-58,86` | ConfidenceBadge (#156) high/med/low text + progress-bar fill | Keep — confidence-score highlight (explicit guardrail) | none |
| `app/globals.css:8,25-27` | `--color-brand-accent*` token definitions | Skip — source of truth | none |
| `app/globals.css:91-93` | Legacy `--champ-accent*` aliases | Skip — token defs, out of scope | none |

Totals: 8 hits in scope / 7 kept / 1 removed / 0 deferred. (Hex-literal grep returned 0 hits outside `app/globals.css`.)

## Per-screen Nature Pop count (post-change)

- Landing (`app/page.tsx`): **3 CTAs** — nav + hero + closing CTA. All three are the same "Get Started" conversion flow. Flagged as overflow below.
- Dashboard (`app/(app)/dashboard/page.tsx`): **0 direct hits.** ConfidenceBadge renders inside the leaderboard so ~N accent pixels appear via the confidence bar only — within the 2% budget.
- Onboarding (`app/(app)/onboarding/page.tsx`): **0 hits.**

## Overflow flagged for #153

- `app/page.tsx` carries three Nature Pop signup CTAs (nav / hero / closing). Per the 2% rule the page should collapse to a single hero CTA plus muted secondaries. Left in place here because they are all genuine conversion CTAs on a landing surface — the rebalance (consolidate to 1, or demote nav/closing to outline style) belongs to landing-page redesign ticket #153.

## Guardrails respected

- No changes to `app/globals.css` @theme tokens.
- No changes under `app/api/reports/*`.
- ConfidenceBadge (#156) accent untouched.
- All "Get Started" / "Upgrade" primary CTAs untouched.
- No new Nature Pop usages introduced.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 843 tests pass
- [x] `npm run build` succeeds
- [ ] Visual spot-check on PR preview: referral "Copied!" state is still legibly distinct (Dusty Denim vs. default Champ Blue)