### PR TITLE
feat(leaderboard): Final Four gated reveal with referral unlock CTA (#157)

### DIFF
--- a/__tests__/components/leaderboard/final-four.test.tsx
+++ b/__tests__/components/leaderboard/final-four.test.tsx
@@ -2,15 +2,15 @@
  * Final Four Tests
  *
  * Validates the bracket-style display of allergens ranked #2-#4,
- * including blur behavior for free-tier vs premium users.
+ * including the freemium gated reveal (#157) for free-tier users.
  */
 
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { FinalFour } from "@/components/leaderboard/final-four";
-import type { RankedAllergen } from "@/components/leaderboard/types";
+import type { GatedRankedAllergen } from "@/components/leaderboard/types";
 
-const mockAllergens: RankedAllergen[] = [
+const mockUnlockedAllergens: GatedRankedAllergen[] = [
   {
     allergen_id: "birch",
     common_name: "Birch",
@@ -18,6 +18,7 @@ const mockAllergens: RankedAllergen[] = [
     elo_score: 1500,
     confidence_tier: "medium",
     rank: 2,
+    locked: false,
   },
   {
     allergen_id: "ragweed",
@@ -26,6 +27,7 @@ const mockAllergens: RankedAllergen[] = [
     elo_score: 1450,
     confidence_tier: "high",
     rank: 3,
+    locked: false,
   },
   {
     allergen_id: "bermuda_grass",
@@ -34,19 +36,36 @@ const mockAllergens: RankedAllergen[] = [
     elo_score: 1400,
     confidence_tier: "low",
     rank: 4,
+    locked: false,
   },
 ];
 
+const mockLockedAllergens: GatedRankedAllergen[] = mockUnlockedAllergens.map(
+  (a) => ({
+    allergen_id: a.allergen_id,
+    rank: a.rank,
+    category: a.category,
+    common_name: null,
+    elo_score: null,
+    confidence_tier: null,
+    locked: true,
+  }),
+);
+
 describe("FinalFour", () => {
-  describe("premium user (unblurred)", () => {
+  describe("unlocked (Pro or referral-unlocked)", () => {
     it("renders all three allergen cards", () => {
-      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      render(
+        <FinalFour allergens={mockUnlockedAllergens} isUnlocked={true} />,
+      );
       const cards = screen.getAllByTestId("final-four-card");
       expect(cards.length).toBe(3);
     });
 
     it("shows allergen names", () => {
-      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      render(
+        <FinalFour allergens={mockUnlockedAllergens} isUnlocked={true} />,
+      );
       const names = screen.getAllByTestId("final-four-name");
       expect(names[0].textContent).toBe("Birch");
       expect(names[1].textContent).toBe("Ragweed");
@@ -54,7 +73,9 @@ describe("FinalFour", () => {
     });
 
     it("shows rank badges", () => {
-      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      render(
+        <FinalFour allergens={mockUnlockedAllergens} isUnlocked={true} />,
+      );
       const ranks = screen.getAllByTestId("final-four-rank");
       expect(ranks[0].textContent).toBe("#2");
       expect(ranks[1].textContent).toBe("#3");
@@ -62,7 +83,9 @@ describe("FinalFour", () => {
     });
 
     it("shows Elo scores", () => {
-      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      render(
+        <FinalFour allergens={mockUnlockedAllergens} isUnlocked={true} />,
+      );
       const scores = screen.getAllByTestId("final-four-elo");
       expect(scores[0].textContent).toBe("Elo 1500");
       expect(scores[1].textContent).toBe("Elo 1450");
@@ -70,37 +93,124 @@ describe("FinalFour", () => {
     });
 
     it("does not show blur overlay", () => {
-      render(<FinalFour allergens={mockAllergens} isBlurred={false} />);
+      render(
+        <FinalFour allergens={mockUnlockedAllergens} isUnlocked={true} />,
+      );
       expect(screen.queryByTestId("blur-overlay")).toBeNull();
+    });
+
+    it("does not show unlock CTA", () => {
+      render(
+        <FinalFour allergens={mockUnlockedAllergens} isUnlocked={true} />,
+      );
+      expect(screen.queryByTestId("final-four-unlock-cta")).toBeNull();
     });
   });
 
-  describe("free-tier user (blurred)", () => {
+  describe("locked (free tier, < 3 referral credits)", () => {
     it("renders the blur overlay", () => {
-      render(<FinalFour allergens={mockAllergens} isBlurred={true} />);
+      render(
+        <FinalFour allergens={mockLockedAllergens} isUnlocked={false} />,
+      );
       expect(screen.getByTestId("blur-overlay")).toBeDefined();
     });
 
-    it("shows the lock overlay with upgrade message", () => {
-      render(<FinalFour allergens={mockAllergens} isBlurred={true} />);
-      expect(screen.getByTestId("blur-lock-overlay")).toBeDefined();
-      expect(
-        screen.getByText("Upgrade to Madness+ to reveal")
-      ).toBeDefined();
+    it("renders the unlock CTA card", () => {
+      render(
+        <FinalFour allergens={mockLockedAllergens} isUnlocked={false} />,
+      );
+      expect(screen.getByTestId("final-four-unlock-cta")).toBeDefined();
+    });
+
+    it("renders locked cards with '???' placeholder instead of names", () => {
+      render(
+        <FinalFour allergens={mockLockedAllergens} isUnlocked={false} />,
+      );
+      const names = screen.getAllByTestId("final-four-name");
+      names.forEach((n) => expect(n.textContent).toBe("???"));
+    });
+
+    it("renders 'Elo —' placeholder instead of scores", () => {
+      render(
+        <FinalFour allergens={mockLockedAllergens} isUnlocked={false} />,
+      );
+      const elos = screen.getAllByTestId("final-four-elo");
+      elos.forEach((e) => expect(e.textContent).toBe("Elo —"));
+    });
+
+    it("does not render confidence badges for locked cards", () => {
+      render(
+        <FinalFour allergens={mockLockedAllergens} isUnlocked={false} />,
+      );
+      // ConfidenceBadge uses role="img" or specific label — easier
+      // proxy: locked cards carry data-locked="true" and we verify
+      // no confidence tier text is leaked.
+      expect(screen.queryByText(/medium|high|low/i)).toBeNull();
+    });
+
+    it("shows default headline when user has 0 referral credits", () => {
+      render(
+        <FinalFour
+          allergens={mockLockedAllergens}
+          isUnlocked={false}
+          referralCount={0}
+        />,
+      );
+      const headline = screen.getByTestId("final-four-unlock-cta-headline");
+      expect(headline.textContent).toContain("Unlock");
+    });
+
+    it("shows 'Almost there' framing when user has 1 or 2 credits", () => {
+      render(
+        <FinalFour
+          allergens={mockLockedAllergens}
+          isUnlocked={false}
+          referralCount={2}
+        />,
+      );
+      const headline = screen.getByTestId("final-four-unlock-cta-headline");
+      expect(headline.textContent).toContain("Almost there");
+      expect(headline.textContent).toContain("1 more");
+    });
+
+    it("renders a progress indicator when user has credits", () => {
+      render(
+        <FinalFour
+          allergens={mockLockedAllergens}
+          isUnlocked={false}
+          referralCount={1}
+        />,
+      );
+      expect(screen.getByTestId("final-four-unlock-progress")).toBeDefined();
+      const pips = screen.getAllByTestId("final-four-unlock-progress-pip");
+      expect(pips.length).toBe(3);
+      expect(pips[0].getAttribute("data-filled")).toBe("true");
+      expect(pips[1].getAttribute("data-filled")).toBe("false");
+    });
+
+    it("includes invite and upgrade links", () => {
+      render(
+        <FinalFour allergens={mockLockedAllergens} isUnlocked={false} />,
+      );
+      expect(screen.getByTestId("final-four-unlock-invite")).toBeDefined();
+      expect(screen.getByTestId("final-four-unlock-upgrade")).toBeDefined();
     });
   });
 
   describe("edge cases", () => {
     it("returns null for empty allergens array", () => {
       const { container } = render(
-        <FinalFour allergens={[]} isBlurred={false} />
+        <FinalFour allergens={[]} isUnlocked={true} />,
       );
       expect(container.innerHTML).toBe("");
     });
 
     it("renders correctly with fewer than 3 allergens", () => {
       render(
-        <FinalFour allergens={mockAllergens.slice(0, 1)} isBlurred={false} />
+        <FinalFour
+          allergens={mockUnlockedAllergens.slice(0, 1)}
+          isUnlocked={true}
+        />,
       );
       const cards = screen.getAllByTestId("final-four-card");
       expect(cards.length).toBe(1);

--- a/__tests__/leaderboard/gate-final-four.test.ts
+++ b/__tests__/leaderboard/gate-final-four.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Gate Final Four — server-side redaction tests (#157)
+ *
+ * Validates that the Final Four reveal is properly gated and that free
+ * users without the required referral credits receive a redacted
+ * payload — defense in depth against view-source leakage.
+ */
+
+import { describe, it, expect } from "vitest";
+import { gateFinalFour } from "@/lib/leaderboard/gate-final-four";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+const ALLERGENS: RankedAllergen[] = [
+  {
+    allergen_id: "oak",
+    common_name: "Oak",
+    category: "tree",
+    elo_score: 1650,
+    confidence_tier: "very_high",
+    rank: 1,
+  },
+  {
+    allergen_id: "birch",
+    common_name: "Birch",
+    category: "tree",
+    elo_score: 1500,
+    confidence_tier: "high",
+    rank: 2,
+  },
+  {
+    allergen_id: "ragweed",
+    common_name: "Ragweed",
+    category: "weed",
+    elo_score: 1450,
+    confidence_tier: "medium",
+    rank: 3,
+  },
+  {
+    allergen_id: "bermuda_grass",
+    common_name: "Bermuda Grass",
+    category: "grass",
+    elo_score: 1400,
+    confidence_tier: "low",
+    rank: 4,
+  },
+  {
+    allergen_id: "dust_mites",
+    common_name: "Dust Mites",
+    category: "indoor",
+    elo_score: 1350,
+    confidence_tier: "medium",
+    rank: 5,
+  },
+];
+
+describe("gateFinalFour", () => {
+  describe("unlocked paths", () => {
+    it("Pro users see the full Final Four payload", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: true,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      expect(result.isUnlocked).toBe(true);
+      expect(result.gated).toHaveLength(3);
+      result.gated.forEach((entry) => {
+        expect(entry.locked).toBe(false);
+        expect(entry.common_name).not.toBeNull();
+        expect(entry.elo_score).not.toBeNull();
+        expect(entry.confidence_tier).not.toBeNull();
+      });
+    });
+
+    it("free users with referralUnlocked=true see the full payload", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: false,
+        referralCount: 0,
+        referralUnlocked: true,
+      });
+      expect(result.isUnlocked).toBe(true);
+      expect(result.gated.every((e) => !e.locked)).toBe(true);
+    });
+
+    it("free users with >= 3 referral credits see the full payload", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: false,
+        referralCount: 3,
+        referralUnlocked: false,
+      });
+      expect(result.isUnlocked).toBe(true);
+      expect(result.gated.every((e) => !e.locked)).toBe(true);
+      expect(result.gated[0].common_name).toBe("Birch");
+    });
+  });
+
+  describe("locked (redacted) paths", () => {
+    it("free users with 0 credits receive a fully redacted Final Four", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: false,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      expect(result.isUnlocked).toBe(false);
+      expect(result.gated).toHaveLength(3);
+      result.gated.forEach((entry) => {
+        expect(entry.locked).toBe(true);
+        expect(entry.common_name).toBeNull();
+        expect(entry.elo_score).toBeNull();
+        expect(entry.confidence_tier).toBeNull();
+      });
+    });
+
+    it("free users with 1 or 2 credits still receive a redacted Final Four", () => {
+      for (const count of [1, 2]) {
+        const result = gateFinalFour({
+          allergens: ALLERGENS,
+          isPremium: false,
+          referralCount: count,
+          referralUnlocked: false,
+        });
+        expect(result.isUnlocked).toBe(false);
+        expect(result.gated.every((e) => e.locked)).toBe(true);
+      }
+    });
+
+    it("category is preserved in redacted entries (for silhouette rendering)", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: false,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      expect(result.gated[0].category).toBe("tree");
+      expect(result.gated[1].category).toBe("weed");
+      expect(result.gated[2].category).toBe("grass");
+    });
+
+    it("allergen_id and rank are preserved (for stable React keys + #N labels)", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: false,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      expect(result.gated.map((e) => e.rank)).toEqual([2, 3, 4]);
+      expect(result.gated.map((e) => e.allergen_id)).toEqual([
+        "birch",
+        "ragweed",
+        "bermuda_grass",
+      ]);
+    });
+  });
+
+  describe("client payload shaping", () => {
+    it("strips the Final Four slice from allergensForClient so raw values never cross the wire", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: false,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      const names = result.allergensForClient.map((a) => a.common_name);
+      // Champion + rank 5+ only
+      expect(names).toEqual(["Oak", "Dust Mites"]);
+      expect(names).not.toContain("Birch");
+      expect(names).not.toContain("Ragweed");
+      expect(names).not.toContain("Bermuda Grass");
+    });
+
+    it("preserves the champion even when locked", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: false,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      expect(result.allergensForClient[0]?.common_name).toBe("Oak");
+      expect(result.allergensForClient[0]?.elo_score).toBe(1650);
+    });
+
+    it("strips the Final Four from allergensForClient even when unlocked (client reads from `gated`)", () => {
+      const result = gateFinalFour({
+        allergens: ALLERGENS,
+        isPremium: true,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      // The Final Four data lives in `gated`; `allergensForClient` is
+      // champion + ranks #5+ to avoid duplicate rendering.
+      expect(result.allergensForClient.map((a) => a.rank)).toEqual([1, 5]);
+    });
+
+    it("handles empty allergens input", () => {
+      const result = gateFinalFour({
+        allergens: [],
+        isPremium: false,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      expect(result.allergensForClient).toEqual([]);
+      expect(result.gated).toEqual([]);
+      expect(result.isUnlocked).toBe(false);
+    });
+
+    it("handles a list with only a champion (no Final Four)", () => {
+      const result = gateFinalFour({
+        allergens: [ALLERGENS[0]],
+        isPremium: false,
+        referralCount: 0,
+        referralUnlocked: false,
+      });
+      expect(result.allergensForClient).toHaveLength(1);
+      expect(result.gated).toEqual([]);
+    });
+  });
+});

--- a/app/(app)/dashboard/dashboard-leaderboard.tsx
+++ b/app/(app)/dashboard/dashboard-leaderboard.tsx
@@ -6,13 +6,23 @@
  * Client component that receives server-computed ranked allergens
  * and renders the Leaderboard component. Confidence tiers are
  * computed server-side via the engine module and passed as props.
+ *
+ * The gated Final Four payload (#157) is also prepared server-side
+ * to prevent raw ranks #2-#4 values from leaking to free users who
+ * have not yet unlocked the reveal.
  */
 
 import { Leaderboard } from "@/components/leaderboard";
-import type { RankedAllergen } from "@/components/leaderboard/types";
+import type {
+  RankedAllergen,
+  GatedRankedAllergen,
+} from "@/components/leaderboard/types";
 
 interface DashboardLeaderboardProps {
   allergens: RankedAllergen[];
+  finalFourGated?: GatedRankedAllergen[];
+  isFinalFourUnlocked?: boolean;
+  referralCount?: number;
   isPremium: boolean;
   isEnvironmentalForecast: boolean;
   fdaAcknowledged: boolean;
@@ -21,6 +31,9 @@ interface DashboardLeaderboardProps {
 
 export function DashboardLeaderboard({
   allergens,
+  finalFourGated,
+  isFinalFourUnlocked,
+  referralCount,
   isPremium,
   isEnvironmentalForecast,
   fdaAcknowledged,
@@ -29,6 +42,9 @@ export function DashboardLeaderboard({
   return (
     <Leaderboard
       allergens={allergens}
+      finalFourGated={finalFourGated}
+      isFinalFourUnlocked={isFinalFourUnlocked}
+      referralCount={referralCount}
       isPremium={isPremium}
       isEnvironmentalForecast={isEnvironmentalForecast}
       fdaAcknowledged={fdaAcknowledged}

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,7 +1,12 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { getConfidenceTierBySignals } from "@/lib/engine";
-import type { RankedAllergen, CheckinSeverityQuery } from "@/components/leaderboard/types";
+import type {
+  RankedAllergen,
+  GatedRankedAllergen,
+  CheckinSeverityQuery,
+} from "@/components/leaderboard/types";
+import { gateFinalFour } from "@/lib/leaderboard/gate-final-four";
 import { DashboardLeaderboard } from "./dashboard-leaderboard";
 import { PageContainer } from "@/components/layout";
 
@@ -51,6 +56,24 @@ export default async function DashboardPage() {
   const subscription = subscriptionData as { tier: string } | null;
   const tier = subscription?.tier ?? "free";
   const isPremium = tier === "madness_plus" || tier === "madness_family";
+
+  // Fetch referral status — drives the Final Four gated reveal (#157).
+  // The user_profiles row carries both the referral count and a
+  // permanent `features_unlocked` flag that the record_referral RPC
+  // flips once the threshold (3) is crossed.
+  const { data: referralProfile } = await supabase
+    .from("user_profiles")
+    .select("referral_count, features_unlocked")
+    .eq("id", user.id)
+    .single();
+
+  const referralRow = referralProfile as {
+    referral_count: number | null;
+    features_unlocked: boolean | null;
+  } | null;
+
+  const referralCount = referralRow?.referral_count ?? 0;
+  const referralUnlocked = referralRow?.features_unlocked ?? false;
 
   // Fetch allergen Elo rankings
   const { data: rawEloRows } = await supabase
@@ -104,6 +127,16 @@ export default async function DashboardPage() {
     isEnvironmentalForecast = true;
   }
 
+  // Compute the client-facing payload. The Final Four (ranks #2-#4) is
+  // redacted for free users without the required referral credits. The
+  // champion (#1) and rows beyond #4 are passed through unchanged.
+  const finalFourView = gateFinalFour({
+    allergens,
+    isPremium,
+    referralCount,
+    referralUnlocked,
+  });
+
   return (
     <PageContainer>
       <div className="mb-6">
@@ -116,7 +149,10 @@ export default async function DashboardPage() {
       </div>
 
       <DashboardLeaderboard
-        allergens={allergens}
+        allergens={finalFourView.allergensForClient}
+        finalFourGated={finalFourView.gated}
+        isFinalFourUnlocked={finalFourView.isUnlocked}
+        referralCount={referralCount}
         isPremium={isPremium}
         isEnvironmentalForecast={isEnvironmentalForecast}
         fdaAcknowledged={fdaAcknowledged}

--- a/components/leaderboard/final-four-unlock-cta.tsx
+++ b/components/leaderboard/final-four-unlock-cta.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+/**
+ * Final Four Unlock CTA
+ *
+ * The growth-loop CTA that sits beneath the blurred Final Four reveal.
+ * Offers two paths to unlock ranks #2-#4 and their confidence scores:
+ *   1. Primary: invite 3 friends (referral unlock — free, viral)
+ *   2. Secondary: upgrade to Pro (existing upgrade route)
+ *
+ * Design tokens:
+ *   - Background: brand-accent (Nature Pop) — sanctioned Final Four use per
+ *     Champ Health Design System 2% rule.
+ *   - Text: brand-primary-dark (Dusty Denim) for AA contrast on Nature Pop.
+ *
+ * Achievement framing: when the user has 1-2 referral credits, the copy
+ * shifts to "Almost there — unlock N more" with a progress indicator.
+ *
+ * Tracking: impression fires on mount; invite/upgrade clicks fire before
+ * navigation so analytics land even if the user leaves the page.
+ */
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { REFERRAL_UNLOCK_THRESHOLD } from "@/lib/referral/constants";
+
+export interface FinalFourUnlockCtaProps {
+  /** Current referral credit count (0, 1, 2, or 3+). */
+  referralCount?: number;
+  /** Fires once on mount; use for impression analytics. */
+  onImpression?: () => void;
+  /** Fires before navigating to the invite/share surface. */
+  onInviteClick?: () => void;
+  /** Fires before navigating to the upgrade route. */
+  onUpgradeClick?: () => void;
+}
+
+export function FinalFourUnlockCta({
+  referralCount = 0,
+  onImpression,
+  onInviteClick,
+  onUpgradeClick,
+}: FinalFourUnlockCtaProps) {
+  useEffect(() => {
+    onImpression?.();
+    // We intentionally only fire once per mount — analytics impression.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const remaining = Math.max(
+    0,
+    REFERRAL_UNLOCK_THRESHOLD - referralCount,
+  );
+  const almostThere = referralCount > 0 && remaining > 0;
+
+  const headline = almostThere
+    ? `Almost there — unlock ${remaining} more`
+    : "Unlock the Final Four & Full Confidence Scores";
+
+  const inviteLabel =
+    remaining === REFERRAL_UNLOCK_THRESHOLD
+      ? "Invite 3 Friends"
+      : `Invite ${remaining} More Friend${remaining === 1 ? "" : "s"}`;
+
+  return (
+    <div
+      data-testid="final-four-unlock-cta"
+      className="mt-6 rounded-xl bg-brand-accent p-6 text-center shadow-md"
+    >
+      <h3
+        data-testid="final-four-unlock-cta-headline"
+        className="mb-2 text-lg font-bold text-brand-primary-dark"
+      >
+        {headline}
+      </h3>
+      <p className="mb-4 text-sm text-brand-primary-dark/80">
+        See ranks #2-#4 and their confidence scores. Invite 3 friends to
+        unlock free — or upgrade to Pro.
+      </p>
+
+      {almostThere && (
+        <div
+          data-testid="final-four-unlock-progress"
+          aria-label={`${referralCount} of ${REFERRAL_UNLOCK_THRESHOLD} friends invited`}
+          className="mx-auto mb-4 flex max-w-xs items-center gap-1"
+        >
+          {Array.from({ length: REFERRAL_UNLOCK_THRESHOLD }).map(
+            (_, idx) => (
+              <span
+                key={idx}
+                data-testid="final-four-unlock-progress-pip"
+                data-filled={idx < referralCount}
+                className={
+                  idx < referralCount
+                    ? "h-2 flex-1 rounded-full bg-brand-primary-dark"
+                    : "h-2 flex-1 rounded-full bg-brand-primary-dark/20"
+                }
+              />
+            ),
+          )}
+        </div>
+      )}
+
+      {/* Primary CTA — referral share */}
+      <Link
+        href="/referral"
+        data-testid="final-four-unlock-invite"
+        onClick={() => onInviteClick?.()}
+        className="mb-3 inline-block w-full rounded-lg bg-brand-primary-dark px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-primary"
+      >
+        {inviteLabel}
+      </Link>
+
+      {/* Secondary CTA — upgrade to Pro */}
+      <Link
+        href="/referral"
+        data-testid="final-four-unlock-upgrade"
+        onClick={() => onUpgradeClick?.()}
+        className="inline-block text-xs font-medium text-brand-primary-dark underline underline-offset-2 hover:text-brand-primary"
+      >
+        Or upgrade to Pro
+      </Link>
+    </div>
+  );
+}

--- a/components/leaderboard/final-four.tsx
+++ b/components/leaderboard/final-four.tsx
@@ -2,19 +2,30 @@
  * Final Four Display
  *
  * Bracket-style display of allergens ranked #2-#4.
- * Free-tier users see these blurred; premium users see them clearly.
+ *
+ * Two rendering modes:
+ *   - Unlocked (Pro or >= 3 referral credits): cards show name, category,
+ *     Elo, and confidence tier in full.
+ *   - Locked (free tier, < 3 referral credits): ranks 2-4 are redacted
+ *     server-side (name/score/tier are null), cards render as plant
+ *     silhouettes wrapped in a Dusty Denim BlurOverlay, and the
+ *     FinalFourUnlockCta is shown beneath. This is the freemium reveal
+ *     mechanic and the growth loop (see #157).
  */
 
-import type { FinalFourProps } from "./types";
+import type { FinalFourProps, GatedRankedAllergen } from "./types";
 import { ConfidenceBadge } from "./confidence-badge";
 import { CategoryIcon } from "./category-icon";
 import { BlurOverlay } from "./blur-overlay";
-import type { RankedAllergen } from "./types";
+import { FinalFourUnlockCta } from "./final-four-unlock-cta";
 
-function FinalFourCard({ allergen }: { allergen: RankedAllergen }) {
+function FinalFourCard({ allergen }: { allergen: GatedRankedAllergen }) {
+  const locked = allergen.locked;
+
   return (
     <div
       data-testid="final-four-card"
+      data-locked={locked}
       className="rounded-lg border border-brand-border bg-white p-4 shadow-sm"
     >
       {/* Rank badge */}
@@ -25,24 +36,30 @@ function FinalFourCard({ allergen }: { allergen: RankedAllergen }) {
         >
           #{allergen.rank}
         </span>
-        <ConfidenceBadge tier={allergen.confidence_tier} />
+        {!locked && allergen.confidence_tier && (
+          <ConfidenceBadge tier={allergen.confidence_tier} />
+        )}
       </div>
 
-      {/* Allergen info */}
+      {/* Allergen info (silhouette if locked) */}
       <div className="flex items-center gap-2">
         <CategoryIcon category={allergen.category} />
         <div>
           <p
             data-testid="final-four-name"
-            className="text-sm font-semibold text-brand-primary-dark"
+            className={
+              locked
+                ? "text-sm font-semibold tracking-widest text-brand-text-muted"
+                : "text-sm font-semibold text-brand-primary-dark"
+            }
           >
-            {allergen.common_name}
+            {locked ? "???" : allergen.common_name}
           </p>
           <p
             data-testid="final-four-elo"
             className="text-xs text-brand-text-muted"
           >
-            Elo {allergen.elo_score}
+            {locked ? "Elo —" : `Elo ${allergen.elo_score}`}
           </p>
         </div>
       </div>
@@ -50,7 +67,14 @@ function FinalFourCard({ allergen }: { allergen: RankedAllergen }) {
   );
 }
 
-export function FinalFour({ allergens, isBlurred }: FinalFourProps) {
+export function FinalFour({
+  allergens,
+  isUnlocked,
+  referralCount = 0,
+  onUnlockCtaImpression,
+  onInviteClick,
+  onUpgradeClick,
+}: FinalFourProps) {
   if (allergens.length === 0) return null;
 
   const content = (
@@ -64,9 +88,19 @@ export function FinalFour({ allergens, isBlurred }: FinalFourProps) {
     </div>
   );
 
-  if (isBlurred) {
-    return <BlurOverlay>{content}</BlurOverlay>;
+  if (isUnlocked) {
+    return content;
   }
 
-  return content;
+  return (
+    <div data-testid="final-four-locked-wrapper">
+      <BlurOverlay>{content}</BlurOverlay>
+      <FinalFourUnlockCta
+        referralCount={referralCount}
+        onImpression={onUnlockCtaImpression}
+        onInviteClick={onInviteClick}
+        onUpgradeClick={onUpgradeClick}
+      />
+    </div>
+  );
 }

--- a/components/leaderboard/index.ts
+++ b/components/leaderboard/index.ts
@@ -9,6 +9,8 @@ export type { LeaderboardClientProps } from "./leaderboard";
 
 export { TriggerChampionCard } from "./trigger-champion-card";
 export { FinalFour } from "./final-four";
+export { FinalFourUnlockCta } from "./final-four-unlock-cta";
+export type { FinalFourUnlockCtaProps } from "./final-four-unlock-cta";
 export { BlurOverlay } from "./blur-overlay";
 export { ConfidenceBadge } from "./confidence-badge";
 export { CategoryIcon } from "./category-icon";
@@ -17,6 +19,7 @@ export type { ForecastData, EnvironmentalForecastProps } from "./environmental-f
 
 export type {
   RankedAllergen,
+  GatedRankedAllergen,
   LeaderboardProps,
   TriggerChampionCardProps,
   FinalFourProps,

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -28,11 +28,30 @@ import { CategoryIcon } from "./category-icon";
 import { UpgradeCta } from "@/components/subscription/upgrade-cta";
 import { PfasPanel } from "@/components/pfas/pfas-panel";
 import type { PfasCrossReactivity } from "@/lib/pfas/types";
-import type { RankedAllergen } from "./types";
+import type { RankedAllergen, GatedRankedAllergen } from "./types";
 
 export interface LeaderboardClientProps {
-  /** Ranked allergens sorted by Elo descending */
+  /** Ranked allergens sorted by Elo descending. */
   allergens: RankedAllergen[];
+  /**
+   * Optional server-redacted Final Four payload (ranks #2-#4). When
+   * provided, these entries are used in place of `allergens[1..4]` for
+   * the Final Four section — any `locked: true` entries render as
+   * silhouettes because the server stripped their common_name, elo_score,
+   * and confidence_tier before serialization. Defense in depth: free
+   * users with < 3 referral credits never receive the raw values over
+   * the wire. When omitted, the component falls back to deriving the
+   * Final Four from `allergens` (backward compatible, used in tests).
+   */
+  finalFourGated?: GatedRankedAllergen[];
+  /**
+   * Whether the Final Four reveal is unlocked. True for Pro users or
+   * free users with >= 3 referral credits. When undefined, falls back
+   * to `isPremium` (backward compatible).
+   */
+  isFinalFourUnlocked?: boolean;
+  /** Current successful referral invite count (0, 1, 2, or 3+). */
+  referralCount?: number;
   /** Whether the user has premium access */
   isPremium: boolean;
   /** Whether severity is 0 (Environmental Forecast mode) */
@@ -47,6 +66,9 @@ export interface LeaderboardClientProps {
 
 export function Leaderboard({
   allergens,
+  finalFourGated,
+  isFinalFourUnlocked,
+  referralCount = 0,
   isPremium,
   isEnvironmentalForecast,
   fdaAcknowledged,
@@ -114,7 +136,34 @@ export function Leaderboard({
   }
 
   const champion = allergens[0] ?? null;
-  const finalFour = allergens.slice(1, 4);
+
+  // If the server provided a gated payload, use it — it may contain
+  // redacted entries. Otherwise derive from the full `allergens` list and
+  // mark every entry as unlocked (backward-compatible path for tests and
+  // legacy callers).
+  const finalFour: GatedRankedAllergen[] =
+    finalFourGated ??
+    allergens.slice(1, 4).map((a) => ({
+      allergen_id: a.allergen_id,
+      rank: a.rank,
+      category: a.category,
+      common_name: a.common_name,
+      elo_score: a.elo_score,
+      confidence_tier: a.confidence_tier,
+      locked: false,
+    }));
+
+  // Full Rankings (ranks #5+). When a gated payload is supplied, the
+  // server stripped ranks #2-#4 from `allergens` to prevent raw values
+  // from crossing the wire — in that case, anything past rank 1 is
+  // already "#5+". When no gated payload is supplied (legacy/tests), we
+  // slice off the first 4 entries (champion + Final Four).
+  const fullRankings = finalFourGated
+    ? allergens.filter((a) => a.rank >= 5)
+    : allergens.slice(4);
+
+  // Unlock gate: explicit server value wins; fall back to premium.
+  const finalFourUnlocked = isFinalFourUnlocked ?? isPremium;
 
   return (
     <div
@@ -141,12 +190,16 @@ export function Leaderboard({
           <h2 className="mb-3 text-lg font-semibold text-brand-text-accent">
             Final Four
           </h2>
-          <FinalFour allergens={finalFour} isBlurred={!isPremium} />
+          <FinalFour
+            allergens={finalFour}
+            isUnlocked={finalFourUnlocked}
+            referralCount={referralCount}
+          />
         </div>
       )}
 
       {/* Full Ranked List (beyond top 4) */}
-      {allergens.length > 4 && (
+      {fullRankings.length > 0 && (
         <div className="mt-6">
           <h2 className="mb-3 text-lg font-semibold text-brand-text-accent">
             Full Rankings
@@ -155,7 +208,7 @@ export function Leaderboard({
             data-testid="full-rankings"
             className="divide-y divide-brand-border-light rounded-lg border border-brand-border bg-white"
           >
-            {allergens.slice(4).map((allergen) => (
+            {fullRankings.map((allergen) => (
               <div
                 key={allergen.allergen_id}
                 data-testid="ranked-allergen-row"

--- a/components/leaderboard/types.ts
+++ b/components/leaderboard/types.ts
@@ -19,6 +19,27 @@ export interface RankedAllergen {
   rank: number;
 }
 
+/**
+ * A ranked allergen entry that may be redacted server-side for gated tiers.
+ * When `locked` is true, `common_name`, `elo_score`, and `confidence_tier`
+ * are stripped before the payload is serialized to the client, so the
+ * browser never receives the underlying values (defense in depth against
+ * view-source reveal). Used for Final Four ranks #2-#4 on the free tier.
+ */
+export interface GatedRankedAllergen {
+  allergen_id: string;
+  rank: number;
+  category: AllergenCategory;
+  /** null when locked — client must render a placeholder */
+  common_name: string | null;
+  /** null when locked */
+  elo_score: number | null;
+  /** null when locked */
+  confidence_tier: ConfidenceTier | null;
+  /** true means the entry is server-redacted and should render as a silhouette */
+  locked: boolean;
+}
+
 /** Props for the full leaderboard container */
 export interface LeaderboardProps {
   /** Ranked allergens sorted by Elo descending */
@@ -37,10 +58,29 @@ export interface TriggerChampionCardProps {
 
 /** Props for the Final Four bracket display */
 export interface FinalFourProps {
-  /** Allergens ranked #2-#4 */
-  allergens: RankedAllergen[];
-  /** Whether to blur for free-tier users */
-  isBlurred: boolean;
+  /**
+   * Allergens ranked #2-#4. May be fully revealed (common_name, elo_score,
+   * confidence_tier all present) or server-redacted for free users with
+   * fewer than 3 referral credits (values set to null, `locked: true`).
+   */
+  allergens: GatedRankedAllergen[];
+  /**
+   * Whether the Final Four reveal is unlocked. When false, the entire
+   * bracket renders behind a BlurOverlay plus the unlock CTA card.
+   * This is independent of `locked` on individual entries: `isUnlocked`
+   * controls chrome (blur, CTA); `locked` controls whether the card's
+   * data is redacted.
+   */
+  isUnlocked: boolean;
+  /** Number of successful referral invites the user has. 0-3+. */
+  referralCount?: number;
+  /**
+   * Optional tracking callbacks fired from the unlock CTA. Callers can
+   * wire these to analytics; default is a no-op.
+   */
+  onUnlockCtaImpression?: () => void;
+  onInviteClick?: () => void;
+  onUpgradeClick?: () => void;
 }
 
 /** Props for a single allergen row in the ranked list */

--- a/lib/leaderboard/gate-final-four.ts
+++ b/lib/leaderboard/gate-final-four.ts
@@ -1,0 +1,110 @@
+/**
+ * Final Four Gated Reveal — server-side payload shaping
+ *
+ * Transforms the full ranked allergen list into the client-facing shape
+ * used by the leaderboard, applying the freemium gate to ranks #2-#4:
+ *
+ *   - Pro users (isPremium): Final Four is fully revealed.
+ *   - Free users with >= 3 referral credits (or referralUnlocked=true):
+ *     Final Four is fully revealed.
+ *   - Free users with < 3 credits: each Final Four entry is redacted —
+ *     common_name, elo_score, and confidence_tier are set to null and
+ *     `locked: true` is set. Category is preserved so the client can
+ *     render a category-appropriate silhouette.
+ *
+ * The champion (#1) is always returned unredacted — that's the hook.
+ * Rows beyond the Final Four (ranks #5+) pass through unchanged; their
+ * gating (score visibility) is handled separately in the Full Rankings
+ * section of the leaderboard.
+ *
+ * Guardrail (#157): the blur is on the server-rendered payload too —
+ * raw name/score/tier for ranks 2-4 are NEVER sent to the browser for
+ * free users without credits, defending against view-source reveal.
+ */
+
+import { REFERRAL_UNLOCK_THRESHOLD } from "@/lib/referral/constants";
+import type {
+  RankedAllergen,
+  GatedRankedAllergen,
+} from "@/components/leaderboard/types";
+
+export interface GateFinalFourInput {
+  /** Ranked allergens sorted by Elo descending (as produced by the engine). */
+  allergens: RankedAllergen[];
+  /** Whether the user has an active Madness+/Family subscription. */
+  isPremium: boolean;
+  /** Current successful referral invite count (0+). */
+  referralCount: number;
+  /**
+   * Whether the user's profile carries the permanent `features_unlocked`
+   * flag set by the referral RPC once the threshold is crossed.
+   * When true, this grants Final Four access even if the live count
+   * later drops (e.g., referred user deletes their account).
+   */
+  referralUnlocked: boolean;
+}
+
+export interface GateFinalFourResult {
+  /**
+   * The allergens payload to pass to the client leaderboard. Ranks #1
+   * and #5+ are always present in full; ranks #2-#4 are stripped from
+   * this array to prevent their raw values from ever reaching the
+   * browser for locked users. The `gated` array below carries the
+   * client-safe (possibly redacted) Final Four.
+   */
+  allergensForClient: RankedAllergen[];
+  /** Client-safe Final Four payload; may contain redacted entries. */
+  gated: GatedRankedAllergen[];
+  /** Whether the Final Four reveal is unlocked for this user. */
+  isUnlocked: boolean;
+}
+
+export function gateFinalFour(input: GateFinalFourInput): GateFinalFourResult {
+  const { allergens, isPremium, referralCount, referralUnlocked } = input;
+
+  const isUnlocked =
+    isPremium ||
+    referralUnlocked ||
+    referralCount >= REFERRAL_UNLOCK_THRESHOLD;
+
+  const finalFourSlice = allergens.slice(1, 4);
+  const champion = allergens[0];
+  const tail = allergens.slice(4);
+
+  const gated: GatedRankedAllergen[] = finalFourSlice.map((a) => {
+    if (isUnlocked) {
+      return {
+        allergen_id: a.allergen_id,
+        rank: a.rank,
+        category: a.category,
+        common_name: a.common_name,
+        elo_score: a.elo_score,
+        confidence_tier: a.confidence_tier,
+        locked: false,
+      };
+    }
+    // Redacted: strip identifying fields so they never cross the wire.
+    return {
+      allergen_id: a.allergen_id,
+      rank: a.rank,
+      category: a.category,
+      common_name: null,
+      elo_score: null,
+      confidence_tier: null,
+      locked: true,
+    };
+  });
+
+  // Remove the raw Final Four slice from the client-facing allergens
+  // array — the leaderboard component reads Final Four data from
+  // `gated` instead.
+  const allergensForClient: RankedAllergen[] = champion
+    ? [champion, ...tail]
+    : [...tail];
+
+  return {
+    allergensForClient,
+    gated,
+    isUnlocked,
+  };
+}


### PR DESCRIPTION
Closes #157

## Summary

Implements the Final Four **gated reveal** — the freemium conversion mechanic and core growth loop. Rank #1 is always fully visible (the hook), while ranks #2-#4 sit behind a Dusty Denim frosted-glass overlay with a Nature Pop unlock CTA. The CTA offers two paths to unlock:

1. **Invite 3 Friends** (primary) — viral growth loop via existing referral flow
2. **Upgrade to Pro** (secondary) — existing upgrade path

When the user has 1 or 2 successful invites, the CTA shifts to "Almost there — unlock N more" with a 3-pip progress indicator.

## Defense in Depth

Per the #157 guardrail, the blur is enforced server-side too. The new `gateFinalFour()` helper strips `common_name`, `elo_score`, and `confidence_tier` for ranks #2-#4 before the payload reaches the browser for free users with < 3 referral credits. The client renders a `???` placeholder and `Elo —` for locked cards — raw values never cross the wire.

## Changes

- `lib/leaderboard/gate-final-four.ts` — new server-side helper that builds the gated payload (12 unit tests)
- `components/leaderboard/final-four-unlock-cta.tsx` — new Nature Pop + Dusty Denim CTA card with optional tracking hooks (impression, invite click, upgrade click)
- `components/leaderboard/final-four.tsx` — reworked to accept `GatedRankedAllergen[]`, render silhouettes for locked entries, and wrap content in BlurOverlay + unlock CTA when locked
- `components/leaderboard/types.ts` — added `GatedRankedAllergen` type; `FinalFourProps` now uses `isUnlocked` + `referralCount` + tracking callbacks
- `components/leaderboard/leaderboard.tsx` — additive props `finalFourGated`, `isFinalFourUnlocked`, `referralCount`; legacy callers continue to work (fallback derives the Final Four from `allergens[1..4]` and uses `isPremium` as the unlock gate)
- `app/(app)/dashboard/page.tsx` — fetches referral_count + features_unlocked and calls `gateFinalFour()` before passing to client
- Tests: 12 new unit tests for `gateFinalFour`, 17 updated tests for `FinalFour` covering locked/almost-unlocked/unlocked states and progress framing

## Tracking

`FinalFourUnlockCta` accepts optional `onImpression`, `onInviteClick`, and `onUpgradeClick` callbacks. Default is a no-op so analytics wiring is non-breaking; wire them up in a follow-up ticket once the analytics layer is chosen.

## Known Stub (flagged)

Per ticket guardrails, this PR does not add a Stripe upgrade flow. The secondary "upgrade to Pro" link currently routes to `/referral` (same destination as the primary invite CTA) because no dedicated `/upgrade` or `/account/subscription` route exists yet in the app. Follow-up ticket should add that route and re-point the upgrade CTA.

## Dependency Note

#151 (Dusty Denim overlay style refactor) is still open in Backlog. This PR uses the existing `BlurOverlay` component as-is; when #151 lands, the overlay's visual treatment will update automatically — no code changes needed in this ticket's surface.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 863/863 passing (added 29 tests)
- [x] `npm run build` clean
- [ ] Screenshots in locked (0 credits), almost-unlocked (2 credits), and unlocked (Pro) states — attach on manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)