### PR TITLE
refactor(children): extract shared ChildFormFields from Add/Edit forms

### DIFF
--- a/components/children/add-child-form.tsx
+++ b/components/children/add-child-form.tsx
@@ -4,10 +4,11 @@
  * AddChildForm
  *
  * Form for creating a new child profile.
- * Collects name and optional birth year.
+ * Collects name and optional birth year via the shared ChildFormFields.
  */
 
 import { useState } from "react";
+import { ChildFormFields } from "./child-form-fields";
 
 export interface AddChildFormProps {
   onSubmit: (data: { name: string; birth_year?: number | null }) => Promise<void>;
@@ -19,8 +20,6 @@ export interface AddChildFormProps {
 export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildFormProps) {
   const [name, setName] = useState("");
   const [birthYear, setBirthYear] = useState("");
-
-  const currentYear = new Date().getFullYear();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -39,54 +38,14 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
     >
       <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">Add Child</h3>
 
-      {error && (
-        <p
-          data-testid="add-child-error"
-          className="mb-3 rounded-md bg-[#E0F0F8] p-2 text-xs text-[#055A8C]"
-        >
-          {error}
-        </p>
-      )}
-
-      <div className="mb-3">
-        <label
-          htmlFor="child-name"
-          className="mb-1 block text-xs font-medium text-brand-text"
-        >
-          Name *
-        </label>
-        <input
-          id="child-name"
-          data-testid="child-name-input"
-          type="text"
-          required
-          maxLength={100}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Enter child's name"
-          className="w-full rounded-md border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-        />
-      </div>
-
-      <div className="mb-4">
-        <label
-          htmlFor="child-birth-year"
-          className="mb-1 block text-xs font-medium text-brand-text"
-        >
-          Birth Year (optional)
-        </label>
-        <input
-          id="child-birth-year"
-          data-testid="child-birth-year-input"
-          type="number"
-          min={currentYear - 18}
-          max={currentYear}
-          value={birthYear}
-          onChange={(e) => setBirthYear(e.target.value)}
-          placeholder={`e.g. ${currentYear - 5}`}
-          className="w-full rounded-md border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-        />
-      </div>
+      <ChildFormFields
+        idPrefix="add"
+        name={name}
+        onNameChange={setName}
+        birthYear={birthYear}
+        onBirthYearChange={setBirthYear}
+        error={error}
+      />
 
       <div className="flex justify-end gap-2">
         <button

--- a/components/children/child-form-fields.tsx
+++ b/components/children/child-form-fields.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+/**
+ * ChildFormFields
+ *
+ * Shared input fields and error display for child profile forms.
+ * Used by both AddChildForm (create) and EditChildForm (update).
+ *
+ * Each form keeps its own heading, submit handler, and action buttons;
+ * this component owns only the repeating name input, birth year input,
+ * and error banner markup.
+ */
+
+import type { ChangeEvent } from "react";
+
+export interface ChildFormFieldsProps {
+  /**
+   * Prefix used to build stable `id` and `data-testid` values for inputs.
+   * Pass "add" for the Add form and "edit" for the Edit form to preserve
+   * the existing test ids the surrounding tests already rely on.
+   */
+  idPrefix: "add" | "edit";
+
+  name: string;
+  onNameChange: (value: string) => void;
+
+  birthYear: string;
+  onBirthYearChange: (value: string) => void;
+
+  error: string | null;
+}
+
+const INPUT_CLASS =
+  "w-full rounded-md border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary";
+const LABEL_CLASS = "mb-1 block text-xs font-medium text-brand-text";
+
+export function ChildFormFields({
+  idPrefix,
+  name,
+  onNameChange,
+  birthYear,
+  onBirthYearChange,
+  error,
+}: ChildFormFieldsProps) {
+  const currentYear = new Date().getFullYear();
+
+  // Preserve the exact id/testid shapes the existing tests depend on.
+  const nameId = idPrefix === "add" ? "child-name" : "edit-child-name";
+  const yearId = idPrefix === "add" ? "child-birth-year" : "edit-child-birth-year";
+  const nameTestId = idPrefix === "add" ? "child-name-input" : "edit-child-name-input";
+  const yearTestId =
+    idPrefix === "add" ? "child-birth-year-input" : "edit-child-birth-year-input";
+  const errorTestId = idPrefix === "add" ? "add-child-error" : "edit-child-error";
+
+  return (
+    <>
+      {error && (
+        <p
+          data-testid={errorTestId}
+          className="mb-3 rounded-md bg-[#E0F0F8] p-2 text-xs text-[#055A8C]"
+        >
+          {error}
+        </p>
+      )}
+
+      <div className="mb-3">
+        <label htmlFor={nameId} className={LABEL_CLASS}>
+          Name *
+        </label>
+        <input
+          id={nameId}
+          data-testid={nameTestId}
+          type="text"
+          required
+          maxLength={100}
+          value={name}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onNameChange(e.target.value)}
+          placeholder="Enter child's name"
+          className={INPUT_CLASS}
+        />
+      </div>
+
+      <div className="mb-4">
+        <label htmlFor={yearId} className={LABEL_CLASS}>
+          Birth Year (optional)
+        </label>
+        <input
+          id={yearId}
+          data-testid={yearTestId}
+          type="number"
+          min={currentYear - 18}
+          max={currentYear}
+          value={birthYear}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onBirthYearChange(e.target.value)}
+          placeholder={`e.g. ${currentYear - 5}`}
+          className={INPUT_CLASS}
+        />
+      </div>
+    </>
+  );
+}

--- a/components/children/edit-child-form.tsx
+++ b/components/children/edit-child-form.tsx
@@ -5,10 +5,12 @@
  *
  * Inline form for editing an existing child profile.
  * Pre-populates with current values; submits via parent callback.
+ * Shares name/birth-year markup with AddChildForm via ChildFormFields.
  */
 
 import { useState } from "react";
 import type { ChildProfileSummary } from "@/lib/child-profiles/types";
+import { ChildFormFields } from "./child-form-fields";
 
 export interface EditChildFormProps {
   child: ChildProfileSummary;
@@ -21,8 +23,6 @@ export interface EditChildFormProps {
 export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: EditChildFormProps) {
   const [name, setName] = useState(child.name);
   const [birthYear, setBirthYear] = useState(child.birth_year?.toString() ?? "");
-
-  const currentYear = new Date().getFullYear();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -41,54 +41,14 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
     >
       <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">Edit Child</h3>
 
-      {error && (
-        <p
-          data-testid="edit-child-error"
-          className="mb-3 rounded-md bg-[#E0F0F8] p-2 text-xs text-[#055A8C]"
-        >
-          {error}
-        </p>
-      )}
-
-      <div className="mb-3">
-        <label
-          htmlFor="edit-child-name"
-          className="mb-1 block text-xs font-medium text-brand-text"
-        >
-          Name *
-        </label>
-        <input
-          id="edit-child-name"
-          data-testid="edit-child-name-input"
-          type="text"
-          required
-          maxLength={100}
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Enter child's name"
-          className="w-full rounded-md border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-        />
-      </div>
-
-      <div className="mb-4">
-        <label
-          htmlFor="edit-child-birth-year"
-          className="mb-1 block text-xs font-medium text-brand-text"
-        >
-          Birth Year (optional)
-        </label>
-        <input
-          id="edit-child-birth-year"
-          data-testid="edit-child-birth-year-input"
-          type="number"
-          min={currentYear - 18}
-          max={currentYear}
-          value={birthYear}
-          onChange={(e) => setBirthYear(e.target.value)}
-          placeholder={`e.g. ${currentYear - 5}`}
-          className="w-full rounded-md border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-        />
-      </div>
+      <ChildFormFields
+        idPrefix="edit"
+        name={name}
+        onNameChange={setName}
+        birthYear={birthYear}
+        onBirthYearChange={setBirthYear}
+        error={error}
+      />
 
       <div className="flex justify-end gap-2">
         <button

--- a/components/children/index.ts
+++ b/components/children/index.ts
@@ -6,5 +6,6 @@
 
 export { ChildProfileCard } from "./child-profile-card";
 export { AddChildForm } from "./add-child-form";
+export { ChildFormFields } from "./child-form-fields";
 export { ProfileSwitcher } from "./profile-switcher";
 export { ChildrenManager } from "./children-manager";


### PR DESCRIPTION
## Summary

- Extract `ChildFormFields` component containing the name input, birth-year input, and error banner shared by `AddChildForm` and `EditChildForm`.
- Refactor both forms to use the shared component; each retains its own heading, submit handler, and button labels.
- Preserve existing `data-testid` values via an `idPrefix` prop so every existing test passes without modification.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (908 passed, no test file edits)
- [x] `npm run build`

Closes #122