### PR TITLE
refactor(ui): rebalance 50-30-18-2 color weighting on landing + app surfaces

### DIFF
--- a/__tests__/landing-page.test.tsx
+++ b/__tests__/landing-page.test.tsx
@@ -146,6 +146,28 @@ describe("HomePage", () => {
       ).toBeDefined();
     });
 
+    // 50-30-18-2 color balance (#153): the "How It Works" band is the
+    // middle slab on the landing page. It must render on Champ Blue
+    // (`bg-brand-primary`) — not Dusty Denim (`bg-brand-primary-dark`) —
+    // so the surface keeps its ~50% Champ Blue weight and doesn't
+    // over-index on Dusty Denim (which already owns nav + hero bottom
+    // + CTA bottom).
+    it("uses Champ Blue (not Dusty Denim) for the How It Works band", async () => {
+      const Page = await HomePage();
+      const { container } = render(Page);
+
+      const heading = screen.getByRole("heading", {
+        name: /how it works/i,
+      });
+      const section = heading.closest("section");
+      expect(section).not.toBeNull();
+      const classes = section!.className.split(/\s+/);
+      expect(classes).toContain("bg-brand-primary");
+      expect(classes).not.toContain("bg-brand-primary-dark");
+      // Silence unused-var lint for container
+      void container;
+    });
+
     it("shows the Features section", async () => {
       const Page = await HomePage();
       render(Page);

--- a/__tests__/theme/app-layout-color-balance.test.tsx
+++ b/__tests__/theme/app-layout-color-balance.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import AppLayout from "@/app/(app)/layout";
+
+/**
+ * 50-30-18-2 color balance audit (#153).
+ *
+ * Authenticated app pages (dashboard, leaderboard, checkin, etc.) render
+ * inside `app/(app)/layout.tsx`. Previously the wrapper had no surface
+ * color, so the default white body dominated the viewport and Champ Blue
+ * weight was starved on every authenticated surface.
+ *
+ * The wrapper now sets `bg-brand-surface-muted` (#F0F9FC — a pale Champ
+ * Blue tint) so the field behind cards contributes to the ~50% Champ Blue
+ * weight without changing copy, layout, or card legibility.
+ */
+
+// NavBar is a client component that uses the browser Supabase client +
+// next/navigation hooks. Mock them so the server layout renders cleanly.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard",
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { signOut: vi.fn().mockResolvedValue({ error: null }) },
+  }),
+}));
+
+describe("AppLayout color balance", () => {
+  it("tints the authenticated viewport with Champ Blue surface", () => {
+    const { container } = render(
+      <AppLayout>
+        <div data-testid="app-child">child</div>
+      </AppLayout>,
+    );
+
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    expect(wrapper).not.toBeNull();
+    const classes = wrapper!.className.split(/\s+/);
+    expect(classes).toContain("bg-brand-surface-muted");
+    expect(classes).toContain("min-h-screen");
+  });
+});

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -9,9 +9,9 @@ import { NavBar } from "@/components/layout";
  */
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
-    <>
+    <div className="min-h-screen bg-brand-surface-muted">
       <NavBar authState="authenticated" />
       {children}
-    </>
+    </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,7 +81,7 @@ export default async function HomePage() {
       </section>
 
       {/* How It Works */}
-      <section className="bg-brand-primary-dark px-4 py-16 sm:px-6">
+      <section className="bg-brand-primary px-4 py-16 sm:px-6">
         <div className="mx-auto max-w-5xl">
           <h2
             className="text-center text-2xl font-bold text-white sm:text-3xl"


### PR DESCRIPTION
Closes #153

## Summary

Per-screen visual audit of the three highest-traffic surfaces (landing, dashboard, leaderboard) against the Champ Health Design System's 50-30-18-2 weighting (Champ Blue / Dusty Denim / White / Nature Pop). Two minimal swaps applied — no new tokens, no copy/layout/structure changes.

### Audit findings (eyeballed, pre-change)

| Surface | Champ Blue | Dusty Denim | White | Nature Pop | Verdict |
|---------|------------|-------------|-------|------------|---------|
| Landing | ~22% | ~45% | ~30% | ~2% | Dusty Denim over-weighted (nav + "How It Works" slab + hero bottom + CTA bottom all stack Dusty Denim) |
| Dashboard | ~12% | ~18% | ~68% | 0% | White dominates; Champ Blue barely registers (only nav is non-white; body is default #ffffff). Nature Pop absent but correct — no CTAs on this screen |
| Leaderboard | same as dashboard | same | same | 0% | Same component + same background as dashboard |

### Rebalance swaps

1. **Landing, "How It Works" band** — `bg-brand-primary-dark` → `bg-brand-primary`. Shifts the middle slab from Dusty Denim to Champ Blue. Hero bottom + CTA bottom gradients still land on Dusty Denim so the dark anchor is preserved. New estimate: ~45% Champ Blue, ~25% Dusty Denim, ~28% White, ~2% Nature Pop.

2. **Authenticated layout wrapper** (`app/(app)/layout.tsx`) — wraps children in `<div className="min-h-screen bg-brand-surface-muted">`. Tints the field behind cards on dashboard, leaderboard, checkin, children, referral, and scout from pure white to #F0F9FC (pale Champ Blue tint). Card legibility preserved; Champ Blue weight increases toward the target ~50%. New estimate on dashboard/leaderboard: ~35% Champ Blue tint, ~18% Dusty Denim (nav + headings), ~45% White (cards), ~0-2% Nature Pop (only where CTAs exist).

## Design system notes

- No new tokens introduced. Only `bg-brand-primary` and `bg-brand-surface-muted` (both existing).
- No black / near-black introduced. `no-black-consumer-ui.test.ts` still green.
- Nature Pop 2% rule untouched — still reserved for CTAs only.
- FDA disclaimer unchanged on all ranked-allergen surfaces.

## Screenshots

This audit was performed by reading the rendered JSX + Tailwind tokens for the three target surfaces against the design-system spec rather than running the dev server and capturing screenshots. The dashboard and leaderboard require authenticated Supabase sessions + seeded Elo data that aren't available in this environment; running the dev server here would have produced an unauthenticated redirect-to-/login frame, not the actual dashboard/leaderboard views we're auditing. Reviewer may want to capture before/after locally to confirm the eyeball estimates — recommend reverting this branch's two bg swaps, screenshotting `/`, `/dashboard`, and the leaderboard, then re-applying and re-screenshotting. If the reviewer judges the rebalance insufficient on any surface, I'll iterate.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 912/912 passing (84 files), includes new regression tests for the "How It Works" band and the authenticated-layout tint
- [x] `npm run build` — clean
- [ ] Reviewer captures before/after screenshots locally (see note above)
- [ ] Reviewer subjective judgment: each of landing / dashboard / leaderboard reads closer to 50-30-18-2 than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)