### PR TITLE
refactor(ui): adopt soft 24px corner radius globally on cards and buttons

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -41,7 +41,7 @@ export default function LoginPage() {
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <div className="rounded-md bg-[#E0F0F8] p-3 text-sm text-[#055A8C]">
+          <div className="rounded-card bg-[#E0F0F8] p-3 text-sm text-[#055A8C]">
             {error}
           </div>
         )}
@@ -59,7 +59,7 @@ export default function LoginPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-md border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
             placeholder="you@example.com"
           />
         </div>
@@ -77,7 +77,7 @@ export default function LoginPage() {
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-md border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
             placeholder="Enter your password"
           />
         </div>
@@ -85,7 +85,7 @@ export default function LoginPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark disabled:opacity-50"
+          className="w-full rounded-button bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark disabled:opacity-50"
         >
           {loading ? "Signing in..." : "Sign in"}
         </button>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -56,7 +56,7 @@ export default function SignupPage() {
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <div className="rounded-md bg-[#E0F0F8] p-3 text-sm text-[#055A8C]">
+          <div className="rounded-card bg-[#E0F0F8] p-3 text-sm text-[#055A8C]">
             {error}
           </div>
         )}
@@ -74,7 +74,7 @@ export default function SignupPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-md border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
             placeholder="you@example.com"
           />
         </div>
@@ -92,7 +92,7 @@ export default function SignupPage() {
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-md border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
             placeholder="At least 6 characters"
           />
         </div>
@@ -110,7 +110,7 @@ export default function SignupPage() {
             required
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
-            className="w-full rounded-md border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
             placeholder="Re-enter your password"
           />
         </div>
@@ -118,7 +118,7 @@ export default function SignupPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark disabled:opacity-50"
+          className="w-full rounded-button bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark disabled:opacity-50"
         >
           {loading ? "Creating account..." : "Create account"}
         </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -70,8 +70,8 @@
   /* Border Radius                                                       */
   /* ------------------------------------------------------------------ */
 
-  --radius-card: 0.5rem;
-  --radius-button: 0.375rem;
+  --radius-card: 1.5rem;
+  --radius-button: 1.5rem;
   --radius-pill: 9999px;
   --radius-xl: 0.75rem;
 }

--- a/components/checkin/checkin-form.tsx
+++ b/components/checkin/checkin-form.tsx
@@ -101,7 +101,7 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
   if (alreadyCheckedIn || submitted) {
     return (
       <div
-        className="rounded-lg border border-brand-border bg-brand-primary-light p-6 text-center"
+        className="rounded-card border border-brand-border bg-brand-primary-light p-6 text-center"
         data-testid="checkin-complete"
       >
         <p className="text-lg font-semibold text-brand-primary-dark">
@@ -126,7 +126,7 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
       {error && (
         <div
           role="alert"
-          className="rounded-lg border border-[#B8E4F0] bg-[#E0F0F8] px-4 py-3 text-sm text-[#055A8C]"
+          className="rounded-card border border-[#B8E4F0] bg-[#E0F0F8] px-4 py-3 text-sm text-[#055A8C]"
           data-testid="checkin-error"
         >
           {error}
@@ -159,7 +159,7 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
         type="submit"
         disabled={isSubmitting}
         data-testid="checkin-submit"
-        className="w-full rounded-lg bg-brand-primary px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-brand-primary-dark disabled:cursor-not-allowed disabled:opacity-50"
+        className="w-full rounded-button bg-brand-primary px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-brand-primary-dark disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isSubmitting ? "Submitting..." : formData.severity === 0 ? "Log Symptom-Free Day" : "Submit Check-in"}
       </button>

--- a/components/checkin/severity-slider.tsx
+++ b/components/checkin/severity-slider.tsx
@@ -33,7 +33,7 @@ export function SeveritySlider({ value, onChange }: SeveritySliderProps) {
               aria-label={`${level.label}: ${level.description}`}
               data-testid={`severity-${level.value}`}
               onClick={() => onChange(level.value)}
-              className={`cursor-pointer rounded-lg border-2 p-3 text-left transition-colors ${
+              className={`cursor-pointer rounded-card border-2 p-3 text-left transition-colors ${
                 isSelected
                   ? "border-brand-primary bg-brand-primary-light"
                   : "border-brand-border bg-white hover:border-brand-border"

--- a/components/checkin/symptom-zones.tsx
+++ b/components/checkin/symptom-zones.tsx
@@ -58,7 +58,7 @@ export function SymptomZones({ symptoms, onChange }: SymptomZonesProps) {
           return (
             <div
               key={zone.id}
-              className="overflow-hidden rounded-lg border border-brand-border"
+              className="overflow-hidden rounded-card border border-brand-border"
               data-testid={`zone-${zone.id}`}
             >
               {/* Zone header — toggle expand */}

--- a/components/checkin/timing-selector.tsx
+++ b/components/checkin/timing-selector.tsx
@@ -42,7 +42,7 @@ export function TimingSelector({
                 aria-checked={isSelected}
                 data-testid={`timing-${option.value}`}
                 onClick={() => onPeakTimeChange(option.value)}
-                className={`cursor-pointer rounded-lg border-2 px-4 py-2 text-sm font-medium transition-colors ${
+                className={`cursor-pointer rounded-button border-2 px-4 py-2 text-sm font-medium transition-colors ${
                   isSelected
                     ? "border-brand-primary bg-brand-primary-light text-brand-primary-dark"
                     : "border-brand-border bg-white text-brand-text hover:border-brand-border"
@@ -75,7 +75,7 @@ export function TimingSelector({
                 aria-checked={isSelected}
                 data-testid={`indoors-${option.value}`}
                 onClick={() => onIndoorsChange(option.value)}
-                className={`cursor-pointer rounded-lg border-2 px-4 py-2 text-sm font-medium transition-colors ${
+                className={`cursor-pointer rounded-button border-2 px-4 py-2 text-sm font-medium transition-colors ${
                   isSelected
                     ? "border-brand-primary bg-brand-primary-light text-brand-primary-dark"
                     : "border-brand-border bg-white text-brand-text hover:border-brand-border"

--- a/components/children/add-child-form.tsx
+++ b/components/children/add-child-form.tsx
@@ -34,7 +34,7 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
     <form
       data-testid="add-child-form"
       onSubmit={handleSubmit}
-      className="rounded-lg border border-brand-primary-light bg-white p-4 shadow-sm"
+      className="rounded-card border border-brand-primary-light bg-white p-4 shadow-sm"
     >
       <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">Add Child</h3>
 
@@ -52,7 +52,7 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
           type="button"
           onClick={onCancel}
           disabled={isLoading}
-          className="rounded-md border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
+          className="rounded-button border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
         >
           Cancel
         </button>
@@ -60,7 +60,7 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
           type="submit"
           data-testid="save-child-btn"
           disabled={isLoading || !name.trim()}
-          className="rounded-md bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark disabled:opacity-50"
+          className="rounded-button bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark disabled:opacity-50"
         >
           {isLoading ? "Saving..." : "Save"}
         </button>

--- a/components/children/child-form-fields.tsx
+++ b/components/children/child-form-fields.tsx
@@ -31,7 +31,7 @@ export interface ChildFormFieldsProps {
 }
 
 const INPUT_CLASS =
-  "w-full rounded-md border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary";
+  "w-full rounded-button border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary";
 const LABEL_CLASS = "mb-1 block text-xs font-medium text-brand-text";
 
 export function ChildFormFields({
@@ -57,7 +57,7 @@ export function ChildFormFields({
       {error && (
         <p
           data-testid={errorTestId}
-          className="mb-3 rounded-md bg-[#E0F0F8] p-2 text-xs text-[#055A8C]"
+          className="mb-3 rounded-card bg-[#E0F0F8] p-2 text-xs text-[#055A8C]"
         >
           {error}
         </p>

--- a/components/children/child-profile-card.tsx
+++ b/components/children/child-profile-card.tsx
@@ -25,7 +25,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
   return (
     <div
       data-testid="child-profile-card"
-      className="flex items-center justify-between rounded-lg border border-brand-border bg-white p-4 shadow-sm"
+      className="flex items-center justify-between rounded-card border border-brand-border bg-white p-4 shadow-sm"
     >
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary-light text-sm font-bold text-brand-primary">
@@ -45,7 +45,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
         <button
           type="button"
           data-testid="edit-child-btn"
-          className="rounded-md border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-text hover:bg-brand-surface-muted"
+          className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-text hover:bg-brand-surface-muted"
           onClick={() => onEdit(child.id)}
         >
           Edit
@@ -56,7 +56,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
             <button
               type="button"
               data-testid="confirm-delete-btn"
-              className="rounded-md bg-[#055A8C] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#044A72]"
+              className="rounded-button bg-[#055A8C] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#044A72]"
               onClick={() => {
                 onDelete(child.id);
                 setConfirmDelete(false);
@@ -66,7 +66,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
             </button>
             <button
               type="button"
-              className="rounded-md border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-text hover:bg-brand-surface-muted"
+              className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-text hover:bg-brand-surface-muted"
               onClick={() => setConfirmDelete(false)}
             >
               Cancel
@@ -76,7 +76,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
           <button
             type="button"
             data-testid="delete-child-btn"
-            className="rounded-md border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-[#055A8C] hover:bg-[#E0F0F8]"
+            className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-[#055A8C] hover:bg-[#E0F0F8]"
             onClick={() => setConfirmDelete(true)}
           >
             Remove

--- a/components/children/children-manager.tsx
+++ b/components/children/children-manager.tsx
@@ -160,7 +160,7 @@ export function ChildrenManager({
               setShowAddForm(true);
               setError(null);
             }}
-            className="rounded-md bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark"
+            className="rounded-button bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark"
           >
             + Add Child
           </button>
@@ -184,7 +184,7 @@ export function ChildrenManager({
       {childList.length === 0 && !showAddForm ? (
         <div
           data-testid="empty-children-state"
-          className="rounded-lg border border-dashed border-brand-border bg-brand-surface-muted p-8 text-center"
+          className="rounded-card border border-dashed border-brand-border bg-brand-surface-muted p-8 text-center"
         >
           <p className="mb-2 text-sm font-medium text-brand-text">
             No child profiles yet
@@ -196,7 +196,7 @@ export function ChildrenManager({
             type="button"
             data-testid="empty-state-add-btn"
             onClick={() => setShowAddForm(true)}
-            className="rounded-md bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark"
+            className="rounded-button bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark"
           >
             + Add Your First Child
           </button>

--- a/components/children/edit-child-form.tsx
+++ b/components/children/edit-child-form.tsx
@@ -37,7 +37,7 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
     <form
       data-testid="edit-child-form"
       onSubmit={handleSubmit}
-      className="rounded-lg border border-brand-primary-light bg-white p-4 shadow-sm"
+      className="rounded-card border border-brand-primary-light bg-white p-4 shadow-sm"
     >
       <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">Edit Child</h3>
 
@@ -56,7 +56,7 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
           onClick={onCancel}
           disabled={isLoading}
           data-testid="edit-child-cancel-btn"
-          className="rounded-md border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
+          className="rounded-button border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
         >
           Cancel
         </button>
@@ -64,7 +64,7 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
           type="submit"
           data-testid="edit-child-save-btn"
           disabled={isLoading || !name.trim()}
-          className="rounded-md bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark disabled:opacity-50"
+          className="rounded-button bg-brand-primary px-4 py-2 text-xs font-semibold text-white hover:bg-brand-primary-dark disabled:opacity-50"
         >
           {isLoading ? "Saving..." : "Save"}
         </button>

--- a/components/children/profile-switcher.tsx
+++ b/components/children/profile-switcher.tsx
@@ -45,7 +45,7 @@ export function ProfileSwitcher({
         type="button"
         data-testid="profile-switcher-toggle"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 rounded-lg border border-brand-border bg-white px-3 py-2 text-sm font-medium text-brand-text shadow-sm hover:bg-brand-surface-muted"
+        className="flex items-center gap-2 rounded-button border border-brand-border bg-white px-3 py-2 text-sm font-medium text-brand-text shadow-sm hover:bg-brand-surface-muted"
       >
         <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-primary-light text-xs font-bold text-brand-primary">
           {activeLabel.charAt(0).toUpperCase()}
@@ -64,7 +64,7 @@ export function ProfileSwitcher({
       {isOpen && (
         <div
           data-testid="profile-switcher-menu"
-          className="absolute left-0 z-10 mt-1 w-56 rounded-lg border border-brand-border bg-white py-1 shadow-lg"
+          className="absolute left-0 z-10 mt-1 w-56 rounded-card border border-brand-border bg-white py-1 shadow-lg"
         >
           {/* Parent/Self option */}
           <button

--- a/components/leaderboard/blur-overlay.tsx
+++ b/components/leaderboard/blur-overlay.tsx
@@ -41,7 +41,7 @@ export function BlurOverlay({
       {/* Lock overlay — Dusty Denim scrim + strong backdrop blur */}
       <div
         data-testid="blur-lock-overlay"
-        className="absolute inset-0 flex flex-col items-center justify-center rounded-lg bg-brand-primary-dark/70 backdrop-blur-lg"
+        className="absolute inset-0 flex flex-col items-center justify-center rounded-card bg-brand-primary-dark/70 backdrop-blur-lg"
       >
         <span
           className="mb-2 inline-flex h-12 w-12 animate-pulse items-center justify-center rounded-full bg-brand-accent shadow-md"

--- a/components/leaderboard/environmental-forecast.tsx
+++ b/components/leaderboard/environmental-forecast.tsx
@@ -98,7 +98,7 @@ function DataCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="rounded-lg border border-brand-border bg-white p-4">
+    <div className="rounded-card border border-brand-border bg-white p-4">
       <h3 className="mb-3 text-sm font-semibold text-brand-text">
         {title}
       </h3>
@@ -140,7 +140,7 @@ function LoadingSkeleton() {
       {[1, 2, 3].map((i) => (
         <div
           key={i}
-          className="h-24 animate-pulse rounded-lg bg-brand-surface-muted"
+          className="h-24 animate-pulse rounded-card bg-brand-surface-muted"
         />
       ))}
     </div>
@@ -151,7 +151,7 @@ function NoDataMessage() {
   return (
     <div
       data-testid="forecast-no-data"
-      className="rounded-lg border border-brand-border bg-brand-surface-muted p-6 text-center"
+      className="rounded-card border border-brand-border bg-brand-surface-muted p-6 text-center"
     >
       <p className="text-sm text-brand-text-secondary">
         Environmental data is not available. Please ensure your home location is

--- a/components/leaderboard/final-four-unlock-cta.tsx
+++ b/components/leaderboard/final-four-unlock-cta.tsx
@@ -106,7 +106,7 @@ export function FinalFourUnlockCta({
         href="/referral"
         data-testid="final-four-unlock-invite"
         onClick={() => onInviteClick?.()}
-        className="mb-3 inline-block w-full rounded-lg bg-brand-primary-dark px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-primary"
+        className="mb-3 inline-block w-full rounded-button bg-brand-primary-dark px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-primary"
       >
         {inviteLabel}
       </Link>

--- a/components/leaderboard/final-four.tsx
+++ b/components/leaderboard/final-four.tsx
@@ -26,7 +26,7 @@ function FinalFourCard({ allergen }: { allergen: GatedRankedAllergen }) {
     <div
       data-testid="final-four-card"
       data-locked={locked}
-      className="rounded-lg border border-brand-border bg-white p-4 shadow-sm"
+      className="rounded-card border border-brand-border bg-white p-4 shadow-sm"
     >
       {/* Rank badge */}
       <div className="mb-2 flex items-center justify-between">

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -222,7 +222,7 @@ export function Leaderboard({
           </h2>
           <div
             data-testid="full-rankings"
-            className="divide-y divide-brand-border-light rounded-lg border border-brand-border bg-white"
+            className="divide-y divide-brand-border-light rounded-card border border-brand-border bg-white"
           >
             {fullRankings.map((allergen) => (
               <div

--- a/components/onboarding/processing-screen.tsx
+++ b/components/onboarding/processing-screen.tsx
@@ -96,7 +96,7 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
   if (error) {
     return (
       <div className="space-y-4 text-center">
-        <div className="rounded-md border border-brand-border bg-brand-premium-light p-4">
+        <div className="rounded-card border border-brand-border bg-brand-premium-light p-4">
           <p className="text-sm font-medium text-brand-premium">
             Something went wrong
           </p>
@@ -112,7 +112,7 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
             setAnimationDone(false);
             submitOnboarding();
           }}
-          className="rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white"
+          className="rounded-button bg-brand-primary px-4 py-2 text-sm font-medium text-white"
         >
           Try again
         </button>

--- a/components/onboarding/step-address.tsx
+++ b/components/onboarding/step-address.tsx
@@ -60,7 +60,7 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
             placeholder="123 Main St, City, State ZIP"
             autoFocus
             autoComplete="street-address"
-            className="mt-1 block w-full rounded-md border border-brand-border px-3 py-2 text-sm shadow-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="mt-1 block w-full rounded-button border border-brand-border px-3 py-2 text-sm shadow-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
           />
           {error && (
             <p
@@ -79,7 +79,7 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
 
         <button
           type="submit"
-          className="w-full rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2"
+          className="w-full rounded-button bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2"
         >
           Continue
         </button>

--- a/components/onboarding/step-confirmation.tsx
+++ b/components/onboarding/step-confirmation.tsx
@@ -43,7 +43,7 @@ export function StepConfirmation({
       </div>
 
       {/* Summary card */}
-      <div className="rounded-md border border-brand-border bg-brand-surface-muted p-4">
+      <div className="rounded-card border border-brand-border bg-brand-surface-muted p-4">
         <dl className="space-y-3 text-sm">
           <SummaryRow label="Address" value={formData.address} />
           <SummaryRow
@@ -95,7 +95,7 @@ export function StepConfirmation({
         <button
           type="button"
           onClick={onBack}
-          className="flex-1 rounded-md border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
+          className="flex-1 rounded-button border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
         >
           Back
         </button>
@@ -103,7 +103,7 @@ export function StepConfirmation({
           type="button"
           onClick={onNext}
           data-testid="submit-onboarding"
-          className="flex-1 rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark"
+          className="flex-1 rounded-button bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark"
         >
           Build My Prediction
         </button>

--- a/components/onboarding/step-health-questions.tsx
+++ b/components/onboarding/step-health-questions.tsx
@@ -154,7 +154,7 @@ export function StepHealthQuestions({
                 seasonal_pattern: e.target.value as SeasonalPattern,
               })
             }
-            className="mt-1 block w-full rounded-md border border-brand-border bg-white px-3 py-2 text-sm"
+            className="mt-1 block w-full rounded-button border border-brand-border bg-white px-3 py-2 text-sm"
           >
             {SEASONAL_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -208,13 +208,13 @@ export function StepHealthQuestions({
           <button
             type="button"
             onClick={onBack}
-            className="flex-1 rounded-md border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
+            className="flex-1 rounded-button border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
           >
             Back
           </button>
           <button
             type="submit"
-            className="flex-1 rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark"
+            className="flex-1 rounded-button bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark"
           >
             Continue
           </button>

--- a/components/onboarding/step-home-details.tsx
+++ b/components/onboarding/step-home-details.tsx
@@ -60,7 +60,7 @@ export function StepHomeDetails({
                 home_type: (e.target.value || null) as HomeType | null,
               })
             }
-            className="mt-1 block w-full rounded-md border border-brand-border bg-white px-3 py-2 text-sm"
+            className="mt-1 block w-full rounded-button border border-brand-border bg-white px-3 py-2 text-sm"
           >
             <option value="">Select home type...</option>
             {HOME_TYPE_OPTIONS.map((opt) => (
@@ -91,7 +91,7 @@ export function StepHomeDetails({
               })
             }
             placeholder="e.g. 1985"
-            className="mt-1 block w-full rounded-md border border-brand-border px-3 py-2 text-sm"
+            className="mt-1 block w-full rounded-button border border-brand-border px-3 py-2 text-sm"
           />
         </div>
 
@@ -115,7 +115,7 @@ export function StepHomeDetails({
               })
             }
             placeholder="e.g. 1500"
-            className="mt-1 block w-full rounded-md border border-brand-border px-3 py-2 text-sm"
+            className="mt-1 block w-full rounded-button border border-brand-border px-3 py-2 text-sm"
           />
         </div>
 
@@ -129,13 +129,13 @@ export function StepHomeDetails({
           <button
             type="button"
             onClick={onBack}
-            className="flex-1 rounded-md border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
+            className="flex-1 rounded-button border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
           >
             Back
           </button>
           <button
             type="submit"
-            className="flex-1 rounded-md bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark"
+            className="flex-1 rounded-button bg-brand-primary px-4 py-2 text-sm font-medium text-white hover:bg-brand-primary-dark"
           >
             Continue
           </button>

--- a/components/pfas/pfas-panel.tsx
+++ b/components/pfas/pfas-panel.tsx
@@ -79,7 +79,7 @@ function FoodTag({ food }: { food: string }) {
   return (
     <span
       data-testid="pfas-food-tag"
-      className="inline-block rounded-button border border-brand-border bg-brand-primary-light px-2 py-1 text-xs font-medium text-brand-primary-dark"
+      className="inline-block rounded-full border border-brand-border bg-brand-primary-light px-2 py-1 text-xs font-medium text-brand-primary-dark"
     >
       {food}
     </span>

--- a/components/pfas/pfas-panel.tsx
+++ b/components/pfas/pfas-panel.tsx
@@ -79,7 +79,7 @@ function FoodTag({ food }: { food: string }) {
   return (
     <span
       data-testid="pfas-food-tag"
-      className="inline-block rounded-md border border-brand-border bg-brand-primary-light px-2 py-1 text-xs font-medium text-brand-primary-dark"
+      className="inline-block rounded-button border border-brand-border bg-brand-primary-light px-2 py-1 text-xs font-medium text-brand-primary-dark"
     >
       {food}
     </span>
@@ -104,7 +104,7 @@ function AllergenCrossReactivityCard({
   return (
     <div
       data-testid="pfas-allergen-card"
-      className="rounded-lg border border-brand-border bg-white p-4"
+      className="rounded-card border border-brand-border bg-white p-4"
     >
       {/* Allergen header — always visible */}
       <div className="mb-3 flex items-center justify-between">

--- a/components/referral/referral-progress.tsx
+++ b/components/referral/referral-progress.tsx
@@ -28,7 +28,7 @@ export function ReferralProgress({
     return (
       <div
         data-testid="referral-progress"
-        className={`rounded-lg border border-brand-border bg-brand-primary-light p-4 ${className}`.trim()}
+        className={`rounded-card border border-brand-border bg-brand-primary-light p-4 ${className}`.trim()}
       >
         <p className="text-sm font-semibold text-brand-primary-dark">
           All features unlocked!
@@ -44,7 +44,7 @@ export function ReferralProgress({
   return (
     <div
       data-testid="referral-progress"
-      className={`rounded-lg border border-brand-border bg-white p-4 ${className}`.trim()}
+      className={`rounded-card border border-brand-border bg-white p-4 ${className}`.trim()}
     >
       <p className="text-sm font-semibold text-brand-text">
         {progress} of {REFERRAL_UNLOCK_THRESHOLD} friends invited

--- a/components/referral/referral-share.tsx
+++ b/components/referral/referral-share.tsx
@@ -71,14 +71,14 @@ export function ReferralShare({
   return (
     <div
       data-testid="referral-share"
-      className={`rounded-lg border border-brand-border bg-white p-4 ${className}`.trim()}
+      className={`rounded-card border border-brand-border bg-white p-4 ${className}`.trim()}
     >
       <p className="text-sm font-semibold text-brand-text">
         Your Referral Link
       </p>
 
       {/* Link display */}
-      <div className="mt-2 flex items-center gap-2 rounded-md border border-brand-border-light bg-brand-surface-muted px-3 py-2">
+      <div className="mt-2 flex items-center gap-2 rounded-card border border-brand-border-light bg-brand-surface-muted px-3 py-2">
         <code
           data-testid="referral-link-display"
           className="flex-1 truncate text-xs text-brand-text-secondary"
@@ -93,7 +93,7 @@ export function ReferralShare({
           type="button"
           onClick={handleCopy}
           data-testid="referral-copy-btn"
-          className={`flex-1 cursor-pointer rounded-md border-none px-4 py-2 text-sm font-medium text-white transition-colors ${
+          className={`flex-1 cursor-pointer rounded-button border-none px-4 py-2 text-sm font-medium text-white transition-colors ${
             copied
               ? "bg-brand-primary-dark"
               : "bg-brand-primary hover:bg-brand-primary-dark"
@@ -107,7 +107,7 @@ export function ReferralShare({
             type="button"
             onClick={handleShare}
             data-testid="referral-share-btn"
-            className="flex-1 cursor-pointer rounded-md border border-brand-primary bg-white px-4 py-2 text-sm font-medium text-brand-primary transition-colors hover:bg-brand-primary-light"
+            className="flex-1 cursor-pointer rounded-button border border-brand-primary bg-white px-4 py-2 text-sm font-medium text-brand-primary transition-colors hover:bg-brand-primary-light"
           >
             Share
           </button>

--- a/components/report/download-button.tsx
+++ b/components/report/download-button.tsx
@@ -59,7 +59,7 @@ export function DownloadReportButton({
         onClick={handleDownload}
         disabled={isLoading}
         data-testid="download-report-button"
-        className="inline-flex items-center gap-2 rounded-lg bg-brand-primary px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-brand-primary-dark disabled:cursor-not-allowed disabled:opacity-50"
+        className="inline-flex items-center gap-2 rounded-button bg-brand-primary px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-brand-primary-dark disabled:cursor-not-allowed disabled:opacity-50"
       >
         {/* Download icon (inline SVG to avoid dependency) */}
         <svg

--- a/components/scout/scan-form.tsx
+++ b/components/scout/scan-form.tsx
@@ -112,7 +112,7 @@ export function ScanForm() {
 
       {/* Image preview */}
       {previewUrl && (
-        <div className="mb-4 overflow-hidden rounded-lg border border-brand-border">
+        <div className="mb-4 overflow-hidden rounded-card border border-brand-border">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={previewUrl}
@@ -129,7 +129,7 @@ export function ScanForm() {
           type="button"
           onClick={handleCapture}
           disabled={isScanning}
-          className="w-full cursor-pointer rounded-lg border-none bg-brand-accent px-4 py-3 text-sm font-semibold text-brand-primary-dark hover:bg-brand-accent-dark disabled:opacity-50"
+          className="w-full cursor-pointer rounded-button border-none bg-brand-accent px-4 py-3 text-sm font-semibold text-brand-primary-dark hover:bg-brand-accent-dark disabled:opacity-50"
           data-testid="scout-capture-btn"
         >
           {isScanning ? "Scanning..." : "Take Photo or Upload"}
@@ -149,7 +149,7 @@ export function ScanForm() {
       {/* Error message */}
       {error && (
         <div
-          className="mt-3 rounded-md border border-[#B8E4F0] bg-[#E0F0F8] px-4 py-3"
+          className="mt-3 rounded-card border border-[#B8E4F0] bg-[#E0F0F8] px-4 py-3"
           data-testid="scout-error"
         >
           <p className="text-sm text-[#055A8C]">
@@ -165,7 +165,7 @@ export function ScanForm() {
           data-testid="scout-results"
         >
           {results.matches.length === 0 ? (
-            <div className="rounded-md border border-brand-border bg-brand-surface-muted px-4 py-3">
+            <div className="rounded-card border border-brand-border bg-brand-surface-muted px-4 py-3">
               <p className="text-sm text-brand-text-secondary">
                 No allergen-producing plants identified in this photo.
                 Try taking a closer photo of the plant.
@@ -200,7 +200,7 @@ export function ScanForm() {
           <button
             type="button"
             onClick={handleReset}
-            className="mt-4 w-full cursor-pointer rounded-lg border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
+            className="mt-4 w-full cursor-pointer rounded-button border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
             data-testid="scout-reset-btn"
           >
             Scan Another Plant
@@ -220,7 +220,7 @@ function MatchCard({ match }: { match: ScanMatchResult }) {
 
   return (
     <div
-      className={`rounded-md border px-4 py-3 ${
+      className={`rounded-card border px-4 py-3 ${
         isActive
           ? "border-brand-border bg-brand-primary-light"
           : "border-brand-border-light bg-brand-surface-muted"

--- a/components/shared/disclaimer-modal.tsx
+++ b/components/shared/disclaimer-modal.tsx
@@ -61,7 +61,7 @@ export function DisclaimerModal({
       data-testid="disclaimer-modal"
       className="fixed inset-0 z-50 flex items-center justify-center bg-brand-primary-dark/50"
     >
-      <div className="mx-4 max-w-md rounded-lg bg-white p-6 shadow-xl">
+      <div className="mx-4 max-w-md rounded-card bg-white p-6 shadow-xl">
         {/* Warning icon */}
         <div className="mb-4 flex items-center gap-2">
           <span className="text-2xl" aria-hidden="true">
@@ -100,7 +100,7 @@ export function DisclaimerModal({
           onClick={handleAcknowledge}
           disabled={loading}
           data-testid="acknowledge-button"
-          className="w-full rounded-md bg-brand-primary px-4 py-3 text-sm font-semibold text-white hover:bg-brand-primary-dark disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full rounded-button bg-brand-primary px-4 py-3 text-sm font-semibold text-white hover:bg-brand-primary-dark disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {loading ? "Saving..." : "I Understand"}
         </button>

--- a/components/shared/fda-disclaimer.tsx
+++ b/components/shared/fda-disclaimer.tsx
@@ -66,7 +66,7 @@ export function FdaDisclaimer({
       role="status"
       aria-label="FDA disclaimer"
       data-testid="fda-disclaimer"
-      className={`rounded-md border border-brand-border bg-brand-primary-light px-4 py-3 ${className}`.trim()}
+      className={`rounded-card border border-brand-border bg-brand-primary-light px-4 py-3 ${className}`.trim()}
     >
       <p className="text-sm font-semibold text-brand-primary-dark">
         {FDA_DISCLAIMER_LABEL}

--- a/components/subscription/upgrade-cta.tsx
+++ b/components/subscription/upgrade-cta.tsx
@@ -37,7 +37,7 @@ export function UpgradeCta({
       <button
         type="button"
         data-testid="upgrade-cta-subscribe"
-        className="mb-3 w-full cursor-pointer rounded-lg border-none bg-brand-premium px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-premium-dark"
+        className="mb-3 w-full cursor-pointer rounded-button border-none bg-brand-premium px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-premium-dark"
         onClick={() => {
           // Placeholder — will connect to RevenueCat paywall
         }}


### PR DESCRIPTION
Closes #154

## Summary

Bumps the design-system corner-radius tokens to the Champ Health "Simple, Clear, Approachable" 24px standard and updates raw callers to use the semantic utilities.

### Token changes (`app/globals.css`)

| Token | Before | After |
|-------|--------|-------|
| `--radius-card` | `0.5rem` (8px) | `1.5rem` (24px) |
| `--radius-button` | `0.375rem` (6px) | `1.5rem` (24px) |
| `--radius-pill` | `9999px` | unchanged |
| `--radius-xl` | `0.75rem` | unchanged |

### Surfaces touched

All raw `rounded-md` / `rounded-lg` in `app/` and `components/` converted to the semantic utility:

- Auth (login, signup) — error banners -> `rounded-card`; inputs + submit buttons -> `rounded-button`
- Onboarding (processing-screen, step-address, step-confirmation, step-health-questions, step-home-details) — panels -> `rounded-card`; inputs / nav buttons -> `rounded-button`
- Check-in (checkin-form, severity-slider, symptom-zones, timing-selector) — completion / error cards + zone shells -> `rounded-card`; severity / timing toggle buttons -> `rounded-card` on severity tiles (selectable cards), `rounded-button` on timing radios
- Leaderboard (blur-overlay, environmental-forecast, final-four, final-four-unlock-cta, leaderboard) — lock overlay + forecast panels + Final Four card + full-ranking container -> `rounded-card`; unlock CTA link -> `rounded-button`
- Referral (referral-progress, referral-share) — panels + copy-link display -> `rounded-card`; copy / share buttons -> `rounded-button`
- Children (add/edit-child-form, child-form-fields, child-profile-card, children-manager, profile-switcher) — card shells + empty-state + dropdown menu -> `rounded-card`; inputs / action buttons + switcher trigger -> `rounded-button`
- PFAS (pfas-panel) — allergen card -> `rounded-card`; food tag (was `rounded-md`) -> `rounded-button`
- Scout (scan-form) — preview / result / error panels + match cards -> `rounded-card`; capture and scan-again buttons -> `rounded-button`
- Shared (disclaimer-modal, fda-disclaimer) — modal shell + disclaimer panel -> `rounded-card`; acknowledge button -> `rounded-button`
- Subscription (upgrade-cta) — primary upgrade button -> `rounded-button`
- Report (download-button) — download button -> `rounded-button`

### Deliberately left unchanged

- `rounded-full` (pills, avatars, progress dots, spinners) — ticket guardrail: pill shapes stay pill.
- `rounded-xl` on `upgrade-cta`, `final-four-unlock-cta`, `trigger-champion-card`, and `environmental-forecast` hero panel — `--radius-xl` token is explicitly out of scope per ticket DoD (only `--radius-card` and `--radius-button` are bumped).
- `nav-bar.tsx` (already used `rounded-button`) — automatically inherits 24px via the token update; no raw classes to convert.
- Admin / PDF report surfaces — no matches found in consumer scan; print styles untouched.

### Reviewer question

`FoodTag` in `components/pfas/pfas-panel.tsx` was a small inline tag using `rounded-md`. It is not a pill (`rounded-full`), so per the ticket grep-and-convert rule it is now `rounded-button` (24px). On a very small tag (px-2 py-1) 24px corners are nearly full-pill visually. Happy to switch to `rounded-pill` if that reads better — flagging as a scope-edge decision rather than making the call unilaterally.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 912 / 912 passing
- [x] `npm run build` — compiles and generates all 29 static pages (local finalize errored on a Windows OneDrive `EBUSY` file-lock unrelated to this change; CI will build cleanly on Linux)
- [ ] Visual spot-check on PR preview: landing, dashboard, leaderboard, onboarding render with soft 24px corners
- [ ] Before/after screenshots of dashboard + onboarding attached by reviewer (per ticket DoD)