### PR TITLE
fix(subscription): honor expires_at on dashboard via getCachedAccessStatus

### DIFF
--- a/__tests__/components/leaderboard/leaderboard.test.tsx
+++ b/__tests__/components/leaderboard/leaderboard.test.tsx
@@ -368,6 +368,25 @@ describe("Leaderboard", () => {
       expect(screen.getByText("1350")).toBeDefined();
       expect(screen.queryByTestId("ranking-score-locked")).toBeNull();
     });
+
+    it("falls back to isPremium=false when hasFullRankings is undefined (locks ranks #5+)", () => {
+      // Pins the lock-fallback direction. If a future refactor accidentally
+      // defaults `hasFullRankings` to `true` (e.g., `?? true`), this test
+      // fails — preventing a silent paywall bypass for free / expired-sub
+      // users on the dashboard surface.
+      render(
+        <Leaderboard
+          {...defaultProps}
+          isPremium={false}
+        />
+      );
+      // Scores hidden, lock icons + upgrade CTA shown
+      expect(screen.queryByText("1350")).toBeNull();
+      expect(screen.queryByText("1300")).toBeNull();
+      const lockedElements = screen.getAllByTestId("ranking-score-locked");
+      expect(lockedElements.length).toBe(2);
+      expect(screen.getByTestId("rankings-upgrade-cta")).toBeDefined();
+    });
   });
 
   describe("with only champion (no Final Four)", () => {

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -10,10 +10,9 @@ import type {
   CheckinSeverityQuery,
 } from "@/components/leaderboard/types";
 import { gateFinalFour } from "@/lib/leaderboard/gate-final-four";
-import { hasFeatureAccess } from "@/lib/subscription";
-import type {
-  AccessStatus,
-  SubscriptionTier,
+import {
+  getCachedAccessStatus,
+  hasFeatureAccess,
 } from "@/lib/subscription";
 import { DashboardLeaderboard } from "./dashboard-leaderboard";
 import { PageContainer } from "@/components/layout";
@@ -54,44 +53,34 @@ export default async function DashboardPage() {
   const profile = profileData as { fda_acknowledged: boolean } | null;
   const fdaAcknowledged = profile?.fda_acknowledged ?? false;
 
-  // Fetch subscription tier
-  const { data: subscriptionData } = await supabase
-    .from("user_subscriptions")
-    .select("tier")
-    .eq("user_id", user.id)
-    .single();
+  // Resolve subscription + referral access via the canonical helper.
+  // `getCachedAccessStatus` honors `expires_at` against `now()` so an
+  // expired subscriber (whose tier hasn't been flipped yet) is correctly
+  // treated as inactive. React `cache()` makes this free to call across
+  // the request — no duplicate DB round-trips.
+  const accessStatus = await getCachedAccessStatus(supabase, user.id);
+  const isPremium = accessStatus.subscriptionActive;
 
-  const subscription = subscriptionData as { tier: string } | null;
-  const tier = (subscription?.tier ?? "free") as SubscriptionTier;
-  const isPremium = tier === "madness_plus" || tier === "madness_family";
-
-  // Fetch referral status — drives the Final Four gated reveal (#157).
-  // The user_profiles row carries both the referral count and a
-  // permanent `features_unlocked` flag that the record_referral RPC
-  // flips once the threshold (3) is crossed.
+  // Fetch referral count for the Final Four gated reveal (#157).
+  // `referralUnlocked` (the permanent `features_unlocked` flag) is
+  // already carried inside `accessStatus`; only the live count needs
+  // a separate read.
   const { data: referralProfile } = await supabase
     .from("user_profiles")
-    .select("referral_count, features_unlocked")
+    .select("referral_count")
     .eq("id", user.id)
     .single();
 
   const referralRow = referralProfile as {
     referral_count: number | null;
-    features_unlocked: boolean | null;
   } | null;
 
   const referralCount = referralRow?.referral_count ?? 0;
-  const referralUnlocked = referralRow?.features_unlocked ?? false;
+  const referralUnlocked = accessStatus.referralUnlocked;
 
   // Granular feature check for the Full Rankings section (ranks #5+).
   // Uses the centralized `hasFeatureAccess` helper so the gate can
   // evolve independently of other premium features in the future.
-  const accessStatus: AccessStatus = {
-    tier,
-    subscriptionActive: isPremium,
-    referralUnlocked,
-    isPremium: isPremium || referralUnlocked,
-  };
   const hasFullRankings = hasFeatureAccess(accessStatus, "full_rankings");
 
   // Fetch allergen Elo rankings


### PR DESCRIPTION
Closes #169
Refs #168, #82

## Severity

**Bug — P2 (correctness / paywall bypass).** Not polish.

## The bug

`app/(app)/dashboard/page.tsx` built an `AccessStatus` inline from the raw `tier` column only:

```ts
const tier = (subscription?.tier ?? "free") as SubscriptionTier;
const isPremium = tier === "madness_plus" || tier === "madness_family";
const accessStatus: AccessStatus = {
  tier,
  subscriptionActive: isPremium,    // ignores expires_at
  referralUnlocked,
  isPremium: isPremium || referralUnlocked,
};
```

A subscriber whose `expires_at` had passed — but whose `tier` column hadn't been flipped back to `free` yet (typical billing-webhook lag / cancellation grace) — was treated as fully active. They saw the unblurred Final Four and full rankings on the dashboard. That's the same gating that `gateFinalFour` (#157) and the granular `hasFullRankings` prop (#82) enforce downstream — once the producer is wrong, the consumers can't recover.

## The fix

Replace the inline struct with the canonical `getCachedAccessStatus(supabase, userId)` helper from `lib/subscription/check.ts`. It:

- Honors `expires_at` via `isSubscriptionActive()` against `now()`
- Is wrapped in React `cache()` (request-scoped Map), so per-render cost is one DB round-trip even with multiple callers — no perf regression
- Returns the same `AccessStatus` shape the consumers already expect

Downstream wiring is unchanged: `isPremium` now sources from `accessStatus.subscriptionActive` (expiry-aware); `referralUnlocked` sources from `accessStatus.referralUnlocked` (already covered by the helper via `user_profiles.features_unlocked`). The separate `referral_count` read is preserved — `getCachedAccessStatus` doesn't carry the live count, only the permanent flag, and the count drives the Final Four progress UI.

## Cache safety note

Cache is per-request via React `cache()` — never shared across users or requests. Expiry is re-evaluated on every request because `getRequestCache()` returns a fresh `Map` per server invocation. No stale-across-expiry trap.

## Test coverage

Added one regression test in `__tests__/components/leaderboard/leaderboard.test.tsx`:

> `falls back to isPremium=false when hasFullRankings is undefined (locks ranks #5+)`

This pins the lock direction. If a future refactor accidentally defaults `hasFullRankings ?? true`, the test fails — preventing a silent paywall bypass for free / expired-sub users. Pairs with the existing positive-fallback test (`isPremium=true → unlocked`).

The expired-subscription path itself is exercised by the `subscriptionActive` branch in `lib/subscription/check.ts` (already covered in `__tests__/subscription/constants.test.ts` and the helper's own `isSubscriptionActive` logic). The dashboard now consumes that single source of truth.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 937 passed (was 936; +1 for the new fallback test)
- [x] `npm run build` — production build green
- [x] No changes to `Leaderboard` component or its props
- [x] No changes to `gateFinalFour` signature
- [x] FDA disclaimer still rendered (no UI changes)
- [x] No new black/gray tokens introduced

## Out of scope

- Refactoring `getCachedAccessStatus` internals
- Other dashboard surfaces beyond the access-status producer
- Subscription lifecycle / webhook handling (the expiry logic already works — we just weren't using it here)