### PR TITLE
feat(allergens): getAllergenThumbnail helper with generic fallback

### DIFF
--- a/__tests__/allergens/thumbnails.test.ts
+++ b/__tests__/allergens/thumbnails.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getAllergenThumbnail } from "@/lib/allergens/thumbnails";
+
+describe("getAllergenThumbnail", () => {
+  const FALLBACK_SRC = "/allergens/generic-plant.svg";
+  const FALLBACK_ALT = "Pollen allergen thumbnail";
+
+  it("returns the generic fallback for an unknown allergen ID", () => {
+    const result = getAllergenThumbnail("not-a-real-allergen");
+    expect(result.src).toBe(FALLBACK_SRC);
+    expect(result.alt).toBe(FALLBACK_ALT);
+  });
+
+  it("returns the generic fallback for an empty string ID", () => {
+    const result = getAllergenThumbnail("");
+    expect(result.src).toBe(FALLBACK_SRC);
+    expect(result.alt).toBe(FALLBACK_ALT);
+  });
+
+  it("returns the generic fallback for any ID while THUMBNAIL_MAP is empty", () => {
+    // Ticket #176 intentionally ships with no bespoke entries — every
+    // plausible allergen ID must resolve to the fallback until the
+    // sibling asset-procurement ticket lands.
+    const ids = ["ragweed", "oak-pollen", "timothy-grass", "birch"];
+    for (const id of ids) {
+      const result = getAllergenThumbnail(id);
+      expect(result.src).toBe(FALLBACK_SRC);
+      expect(result.alt).toBe(FALLBACK_ALT);
+    }
+  });
+
+  it("always returns non-empty alt text (accessibility invariant)", () => {
+    const result = getAllergenThumbnail("anything");
+    expect(result.alt.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/allergens/thumbnails.ts
+++ b/lib/allergens/thumbnails.ts
@@ -1,0 +1,40 @@
+/**
+ * Allergen thumbnail resolver.
+ *
+ * Pure, deterministic helper used by both Server Components and client UI
+ * (notably the bracket view landing in epic #152). No React / UI-library
+ * imports — safe to call from anywhere.
+ *
+ * This ticket (#176) intentionally ships only the generic fallback icon.
+ * Per-allergen bespoke imagery is delivered by the sibling asset-procurement
+ * ticket in epic #152; when those assets land, add entries to THUMBNAIL_MAP
+ * below keyed by the allergen ID.
+ */
+
+export interface AllergenThumbnail {
+  /** Public-relative path to the SVG asset. */
+  src: string;
+  /** Screen-reader-friendly alt text. Required on every return. */
+  alt: string;
+}
+
+const GENERIC_FALLBACK: AllergenThumbnail = {
+  src: "/allergens/generic-plant.svg",
+  alt: "Pollen allergen thumbnail",
+};
+
+/**
+ * Per-allergen thumbnail registry.
+ *
+ * Intentionally empty in ticket #176 — every lookup resolves to the generic
+ * fallback. Populate as bespoke assets are procured under epic #152.
+ */
+const THUMBNAIL_MAP: Record<string, AllergenThumbnail> = {};
+
+/**
+ * Resolve a thumbnail for an allergen ID. Always returns a valid thumbnail:
+ * unknown / empty / undefined IDs fall back to the generic plant silhouette.
+ */
+export function getAllergenThumbnail(id: string): AllergenThumbnail {
+  return THUMBNAIL_MAP[id] ?? GENERIC_FALLBACK;
+}

--- a/public/allergens/generic-plant.svg
+++ b/public/allergens/generic-plant.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Generic allergen thumbnail — leaf silhouette.
+  Source: Lucide icon "leaf" (https://lucide.dev/icons/leaf).
+  License: ISC (commercial use permitted). Adapted to Dusty Denim (#0682BB)
+  stroke to conform to the Champ Health design system (no-black / no-gray rule).
+  Used as the fallback thumbnail in lib/allergens/thumbnails.ts (ticket #176).
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  width="48"
+  height="48"
+  fill="none"
+  stroke="#0682BB"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  role="img"
+  aria-label="Pollen allergen thumbnail"
+>
+  <path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19.2 2.96a1 1 0 0 1 1.8.84v0C20.09 9.23 19.02 13 17 15.43A7 7 0 0 1 11 20z" />
+  <path d="M2 21c0-3 1.85-5.36 5.08-6" />
+</svg>


### PR DESCRIPTION
Closes #176.

## Summary
- Pure, deterministic thumbnail resolver at `lib/allergens/thumbnails.ts` — no React / UI-library imports, safe from Server Components or client UI.
- Generic fallback SVG at `public/allergens/generic-plant.svg` (Lucide "leaf" icon, ISC license, recolored to Dusty Denim `#0682BB` to respect the no-black / no-gray design system rule).
- `THUMBNAIL_MAP` ships empty; every lookup resolves to the fallback until the sibling asset-procurement ticket under epic #152 populates it.
- 4 tests: unknown ID, empty string, any-plausible-ID-while-map-empty, non-empty-alt-text invariant.

## Asset license
`public/allergens/generic-plant.svg` is adapted from [Lucide's "leaf" icon](https://lucide.dev/icons/leaf) — ISC license, commercial use permitted. Stroke recolored to `#0682BB` (Dusty Denim).

## Non-goals
Per the ticket: no bespoke per-allergen imagery, no bracket-UI integration, no `<AllergenThumbnail>` React wrapper. Those land in sibling tickets under #152.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 941/941 pass
- [x] `getAllergenThumbnail("")` returns fallback
- [x] `getAllergenThumbnail("unknown")` returns fallback
- [x] Every return has non-empty `alt`