### PR TITLE
feat(engine): emit BracketNode[] match trace from pairwise tournament

### DIFF
--- a/__tests__/engine/tournament.test.ts
+++ b/__tests__/engine/tournament.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  buildBracketTrace,
   createTournamentEntry,
   pairwiseCompare,
   pairwiseSort,
@@ -190,5 +191,144 @@ describe("runTournament", () => {
     const result = runTournament(entries);
     expect(result.leaderboard[0].tier).toBe("very_high");
     expect(result.leaderboard[1].tier).toBe("low");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* bracket_trace                                                       */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Build N tournament entries with distinct, strictly-decreasing scores
+ * so that the top seed always wins and ordering is unambiguous.
+ */
+const makeEntries = (n: number): TournamentEntry[] =>
+  Array.from({ length: n }, (_, i) =>
+    makeEntry({
+      allergen_id: `a${String(i).padStart(3, "0")}`,
+      common_name: `Allergen ${i}`,
+      composite_score: 2000 - i * 10,
+    }),
+  );
+
+describe("bracket_trace", () => {
+  it("emits exactly 7 matches for an 8-entry tournament (8→4→2→1)", () => {
+    const result = runTournament(makeEntries(8));
+    expect(result.bracket_trace).toHaveLength(7);
+
+    // 4 first-round, 2 semifinal, 1 final
+    const byRound = result.bracket_trace.reduce<Record<number, number>>(
+      (acc, m) => {
+        acc[m.round] = (acc[m.round] ?? 0) + 1;
+        return acc;
+      },
+      {},
+    );
+    expect(byRound[0]).toBe(4);
+    expect(byRound[1]).toBe(2);
+    expect(byRound[2]).toBe(1);
+  });
+
+  it("emits exactly 15 matches for a 16-entry tournament", () => {
+    const result = runTournament(makeEntries(16));
+    expect(result.bracket_trace).toHaveLength(15);
+
+    const rounds = new Set(result.bracket_trace.map((m) => m.round));
+    expect(rounds.size).toBe(4); // 16→8→4→2→1 = 4 rounds
+  });
+
+  it("emits exactly 31 matches for a 32-entry tournament", () => {
+    const result = runTournament(makeEntries(32));
+    expect(result.bracket_trace).toHaveLength(31);
+
+    const rounds = new Set(result.bracket_trace.map((m) => m.round));
+    expect(rounds.size).toBe(5); // 32→16→8→4→2→1 = 5 rounds
+  });
+
+  it("final-round winnerId matches trigger_champion.allergen_id", () => {
+    for (const n of [8, 16, 32]) {
+      const result = runTournament(makeEntries(n));
+      const finalRound = Math.max(
+        ...result.bracket_trace.map((m) => m.round),
+      );
+      const finalMatches = result.bracket_trace.filter(
+        (m) => m.round === finalRound,
+      );
+      expect(finalMatches).toHaveLength(1);
+      expect(finalMatches[0].winnerId).toBe(
+        result.trigger_champion?.allergen_id,
+      );
+    }
+  });
+
+  it("produces a byte-identical trace across repeated runs (determinism)", () => {
+    const entries = makeEntries(16);
+    const a = runTournament(entries).bracket_trace;
+    const b = runTournament([...entries].reverse()).bracket_trace;
+    // Same input (set-wise) and same comparator => identical trace
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("is ordered by (round asc, matchId asc)", () => {
+    const trace = runTournament(makeEntries(16)).bracket_trace;
+    for (let i = 1; i < trace.length; i++) {
+      const prev = trace[i - 1];
+      const curr = trace[i];
+      const prevKey = prev.round * 10_000 + prev.matchId;
+      const currKey = curr.round * 10_000 + curr.matchId;
+      expect(currKey).toBeGreaterThan(prevKey);
+    }
+  });
+
+  it("records left/right scores and a winnerId equal to left or right", () => {
+    const trace = runTournament(makeEntries(8)).bracket_trace;
+    for (const m of trace) {
+      expect(typeof m.leftScore).toBe("number");
+      expect(typeof m.rightScore).toBe("number");
+      expect([m.leftAllergenId, m.rightAllergenId]).toContain(m.winnerId);
+    }
+  });
+
+  it("returns empty bracket_trace for 0 and 1 entries", () => {
+    expect(runTournament([]).bracket_trace).toEqual([]);
+    expect(
+      runTournament([makeEntry({ allergen_id: "only" })]).bracket_trace,
+    ).toEqual([]);
+  });
+
+  it("does not change leaderboard/final_four/trigger_champion shape", () => {
+    // Regression guard: adding bracket_trace must not perturb legacy fields.
+    const entries = makeEntries(8);
+    const result = runTournament(entries);
+    const sortedIds = [...entries]
+      .sort(pairwiseCompare)
+      .map((e) => e.allergen_id);
+    expect(result.leaderboard.map((e) => e.allergen_id)).toEqual(sortedIds);
+    expect(result.final_four.map((e) => e.allergen_id)).toEqual(
+      sortedIds.slice(0, 4),
+    );
+    expect(result.trigger_champion?.allergen_id).toBe(sortedIds[0]);
+  });
+
+  it("buildBracketTrace is callable directly and matches runTournament output", () => {
+    const entries = makeEntries(16);
+    const sorted = pairwiseSort(entries);
+    const direct = buildBracketTrace(sorted);
+    const viaRun = runTournament(entries).bracket_trace;
+    expect(direct).toEqual(viaRun);
+  });
+
+  it("handles non-power-of-two entry counts by awarding byes to top seeds", () => {
+    // 6 entries: bracket size 4, 2 byes → 6-1=5 head-to-head matches total.
+    const result = runTournament(makeEntries(6));
+    expect(result.bracket_trace).toHaveLength(5);
+    // Top seed still wins because scores are strictly decreasing.
+    const finalRound = Math.max(
+      ...result.bracket_trace.map((m) => m.round),
+    );
+    const finalMatch = result.bracket_trace.find(
+      (m) => m.round === finalRound,
+    );
+    expect(finalMatch?.winnerId).toBe(result.trigger_champion?.allergen_id);
   });
 });

--- a/lib/engine/tournament.ts
+++ b/lib/engine/tournament.ts
@@ -12,6 +12,7 @@
  */
 
 import type {
+  BracketMatch,
   ConfidenceTier,
   TournamentEntry,
   TournamentResult,
@@ -89,6 +90,101 @@ export function pairwiseSort(entries: TournamentEntry[]): TournamentEntry[] {
 }
 
 /* ------------------------------------------------------------------ */
+/* Bracket trace                                                       */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Build a round-by-round bracket trace from a sorted leaderboard.
+ *
+ * The bracket is a single-elimination tournament seeded directly from
+ * the leaderboard: highest seed meets lowest seed, etc. Winners are
+ * determined by {@link pairwiseCompare}, which is the same comparator
+ * used by {@link pairwiseSort} — so the trace is consistent with the
+ * leaderboard and fully deterministic under the same input.
+ *
+ * For a power-of-two count N, this emits exactly N - 1 matches
+ * (8 → 7, 16 → 15, 32 → 31). For non-power-of-two counts, the top
+ * seeds receive first-round byes so the round-one field is reduced to
+ * the next lower power of two; byes are *not* recorded as matches —
+ * only real head-to-heads are. Zero- and one-entry inputs yield an
+ * empty trace.
+ *
+ * Pure and deterministic — no I/O, no randomness.
+ *
+ * @param sorted — entries already sorted by {@link pairwiseSort}
+ * @returns bracket trace ordered by (round asc, matchId asc)
+ */
+export function buildBracketTrace(
+  sorted: readonly TournamentEntry[],
+): BracketMatch[] {
+  const trace: BracketMatch[] = [];
+  if (sorted.length < 2) return trace;
+
+  // Largest power of two that is <= sorted.length.
+  // Everything above it gets a first-round bye.
+  let bracketSize = 1;
+  while (bracketSize * 2 <= sorted.length) bracketSize *= 2;
+
+  const byeCount = sorted.length - bracketSize;
+  // Top `byeCount` seeds get byes; remaining seeds form round 0.
+  const byes: TournamentEntry[] = sorted.slice(0, byeCount);
+  const roundZeroField: TournamentEntry[] = sorted.slice(byeCount);
+
+  // Round 0: pair seeds 1-vs-N, 2-vs-(N-1), ...
+  let currentRound: TournamentEntry[] = [];
+  const fieldSize = roundZeroField.length;
+  if (fieldSize >= 2) {
+    for (let i = 0; i < fieldSize / 2; i++) {
+      const left = roundZeroField[i];
+      const right = roundZeroField[fieldSize - 1 - i];
+      const winner = pairwiseCompare(left, right) <= 0 ? left : right;
+      trace.push({
+        round: 0,
+        matchId: i,
+        leftAllergenId: left.allergen_id,
+        rightAllergenId: right.allergen_id,
+        winnerId: winner.allergen_id,
+        leftScore: left.composite_score,
+        rightScore: right.composite_score,
+      });
+      currentRound.push(winner);
+    }
+  } else {
+    currentRound = [...roundZeroField];
+  }
+
+  // Reinsert byes at the top of the field for subsequent rounds,
+  // preserving seed order (top seed plays lowest surviving seed).
+  currentRound = [...byes, ...currentRound];
+
+  // Subsequent rounds: top vs bottom of survivors list each round.
+  let roundIndex = 1;
+  while (currentRound.length > 1) {
+    const nextRound: TournamentEntry[] = [];
+    const size = currentRound.length;
+    for (let i = 0; i < size / 2; i++) {
+      const left = currentRound[i];
+      const right = currentRound[size - 1 - i];
+      const winner = pairwiseCompare(left, right) <= 0 ? left : right;
+      trace.push({
+        round: roundIndex,
+        matchId: i,
+        leftAllergenId: left.allergen_id,
+        rightAllergenId: right.allergen_id,
+        winnerId: winner.allergen_id,
+        leftScore: left.composite_score,
+        rightScore: right.composite_score,
+      });
+      nextRound.push(winner);
+    }
+    currentRound = nextRound;
+    roundIndex++;
+  }
+
+  return trace;
+}
+
+/* ------------------------------------------------------------------ */
 /* Final Four + Trigger Champion                                       */
 /* ------------------------------------------------------------------ */
 
@@ -96,17 +192,20 @@ export function pairwiseSort(entries: TournamentEntry[]): TournamentEntry[] {
  * Run the full pairwise tournament: sort, extract Final Four and Trigger Champion.
  *
  * @param entries — tournament entries (will be sorted)
- * @returns TournamentResult with leaderboard, final_four, and trigger_champion
+ * @returns TournamentResult with leaderboard, final_four, trigger_champion,
+ *          and a bracket_trace of every head-to-head match played
  */
 export function runTournament(entries: TournamentEntry[]): TournamentResult {
   const leaderboard = pairwiseSort(entries);
 
   const final_four = leaderboard.slice(0, FINAL_FOUR_SIZE);
   const trigger_champion = leaderboard.length > 0 ? leaderboard[0] : null;
+  const bracket_trace = buildBracketTrace(leaderboard);
 
   return {
     leaderboard,
     final_four,
     trigger_champion,
+    bracket_trace,
   };
 }

--- a/lib/engine/types.ts
+++ b/lib/engine/types.ts
@@ -170,6 +170,34 @@ export interface TournamentEntry {
   tier: ConfidenceTier;
 }
 
+/**
+ * A single pairwise match in the bracket trace.
+ *
+ * One `BracketMatch` is emitted for every head-to-head comparison
+ * performed during the tournament. They are ordered by
+ * `(round asc, matchId asc)` within `TournamentResult.bracket_trace`.
+ */
+export interface BracketMatch {
+  /** Zero-indexed round number; 0 = first round, last round = finals */
+  round: number;
+  /** Stable match identifier within the round, zero-indexed */
+  matchId: number;
+  leftAllergenId: string;
+  rightAllergenId: string;
+  /** Allergen ID of the advancing side */
+  winnerId: string;
+  /** Raw composite score of the left side at time of match */
+  leftScore: number;
+  /** Raw composite score of the right side at time of match */
+  rightScore: number;
+}
+
+/**
+ * Alias used by bracket UI consumers.
+ * Equivalent to {@link BracketMatch} for now.
+ */
+export type BracketNode = BracketMatch;
+
 /** Result of the pairwise tournament sort */
 export interface TournamentResult {
   /** Full ranked leaderboard (highest score first) */
@@ -178,6 +206,18 @@ export interface TournamentResult {
   final_four: TournamentEntry[];
   /** Top 1 allergen (Trigger Champion) */
   trigger_champion: TournamentEntry | null;
+  /**
+   * Round-by-round match trace, ordered by `(round asc, matchId asc)`.
+   *
+   * For a power-of-two entry count N, contains exactly `N - 1` matches
+   * (8 → 7, 16 → 15, 32 → 31). For non-power-of-two counts, the bracket
+   * is still well-defined: byes are awarded to the top seeds so the
+   * first-round size is reduced to the next power of two, and only
+   * real head-to-head matches are recorded.
+   *
+   * Empty for zero- or one-entry tournaments (no matches are played).
+   */
+  bracket_trace: BracketMatch[];
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Closes #194.

## What

Capture the round-by-round head-to-head matches that the pairwise tournament plays so the bracket UI (#179) can render the path to the Trigger Champion.

## Shape

```ts
export interface BracketMatch {
  round: number;          // 0-indexed; 0 = first round
  matchId: number;        // 0-indexed stable within round
  leftAllergenId: string;
  rightAllergenId: string;
  winnerId: string;
  leftScore: number;
  rightScore: number;
}
export type BracketNode = BracketMatch;

export interface TournamentResult {
  leaderboard: TournamentEntry[];       // unchanged
  final_four: TournamentEntry[];        // unchanged
  trigger_champion: TournamentEntry | null; // unchanged
  bracket_trace: BracketMatch[];        // NEW (round asc, matchId asc)
}
```

## How

- `buildBracketTrace()` in `lib/engine/tournament.ts` walks a single-elimination bracket seeded directly from `pairwiseSort` output (top seed vs bottom seed). Uses `pairwiseCompare` for match winners so the trace is consistent with the leaderboard and fully deterministic.
- `runTournament` now returns `bracket_trace` alongside the existing fields. `run.ts` requires no change (it forwards the result as-is).
- Non-power-of-two entry counts: top seeds receive first-round byes; only real head-to-heads are recorded. Documented in the type's JSDoc.

## Guardrails honored

- `leaderboard` / `final_four` / `trigger_champion` shape and ordering unchanged; regression test added.
- Pure / deterministic; no new async; no new I/O.
- Server-only module (same as before); no client imports added.
- All existing `tournament.test.ts` tests still pass.

## Match counts (verified by test)

| N  | Matches | Rounds |
|----|---------|--------|
| 8  | 7       | 3      |
| 16 | 15      | 4      |
| 32 | 31      | 5      |

## Tests added (10 in `bracket_trace` describe block)

- 8 / 16 / 32-entry match count and per-round distribution
- Final-round `winnerId` equals `trigger_champion.allergen_id`
- Determinism across reordered input (byte-identical trace)
- `(round asc, matchId asc)` ordering invariant
- `winnerId` must equal `leftAllergenId` or `rightAllergenId`; scores present
- Empty bracket for 0- and 1-entry inputs
- Legacy fields unchanged regression guard
- `buildBracketTrace` direct call equals `runTournament` output
- Non-power-of-two (6 entries) bye handling

## Verification

- `npm run lint` passes
- `npm run typecheck` passes
- `npm test` — 948 / 948 pass
- `npm run build` passes