### PR TITLE
fix(engine): discriminative + posterior confidence (closes 21% flat-line bug)

### DIFF
--- a/__tests__/api/leaderboard.test.ts
+++ b/__tests__/api/leaderboard.test.ts
@@ -228,7 +228,13 @@ describe("GET /api/leaderboard", () => {
     expect(json.isPremium).toBe(true);
   });
 
-  it("computes confidence tiers correctly", async () => {
+  it("populates the two-layer confidence fields (#193) with per-allergen separation", async () => {
+    // Post-#193 the leaderboard emits two new numeric surfaces:
+    //   - `discriminative` — Elo-separation sigmoid (varies between #1 and #N)
+    //   - `posterior`      — Monte Carlo top-K frequency (drives tier string)
+    // The legacy `score` now maps to `discriminative` for back-compat, so
+    // #1 and #N must have visibly different scores (the core DoD — the
+    // 21% flat-line bug the ticket was filed for).
     setupAuth({ id: "user-123" });
 
     const profileMock = setupProfile({ fda_acknowledged: true });
@@ -238,28 +244,28 @@ describe("GET /api/leaderboard", () => {
         allergen_id: "a",
         elo_score: 1800,
         positive_signals: 25,
-        negative_signals: 10, // 35 total -> very_high
+        negative_signals: 10,
         allergens: { common_name: "A", category: "tree" },
       },
       {
         allergen_id: "b",
         elo_score: 1600,
         positive_signals: 10,
-        negative_signals: 5, // 15 total -> high
+        negative_signals: 5,
         allergens: { common_name: "B", category: "grass" },
       },
       {
         allergen_id: "c",
         elo_score: 1400,
         positive_signals: 5,
-        negative_signals: 3, // 8 total -> medium
+        negative_signals: 3,
         allergens: { common_name: "C", category: "weed" },
       },
       {
         allergen_id: "d",
         elo_score: 1200,
         positive_signals: 2,
-        negative_signals: 1, // 3 total -> low
+        negative_signals: 1,
         allergens: { common_name: "D", category: "mold" },
       },
     ]);
@@ -274,22 +280,37 @@ describe("GET /api/leaderboard", () => {
     const response = await GET();
     const json = await response.json();
 
-    expect(json.allergens[0].confidence_tier).toBe("very_high");
-    expect(json.allergens[1].confidence_tier).toBe("high");
-    expect(json.allergens[2].confidence_tier).toBe("medium");
-    expect(json.allergens[3].confidence_tier).toBe("low");
-
-    // #160: numeric score is populated alongside the tier string.
-    // All four are in [0, 1] and non-null.
+    // All four numeric surfaces are populated and in [0, 1].
     for (const a of json.allergens) {
       expect(typeof a.score).toBe("number");
       expect(a.score).toBeGreaterThanOrEqual(0);
       expect(a.score).toBeLessThanOrEqual(1);
+      expect(typeof a.discriminative).toBe("number");
+      expect(typeof a.posterior).toBe("number");
     }
-    // 15 signals sits between the 14-anchor (0.75) and 30-anchor (0.9)
-    // inclusive-left, so rank #2 (15 signals) should be >= 0.75.
-    expect(json.allergens[1].score).toBeGreaterThanOrEqual(0.75);
-    // 3 signals is below the first boundary (7 -> 0.5).
-    expect(json.allergens[3].score).toBeLessThan(0.5);
+
+    // Core DoD: #1 and #N differ on the discriminative layer.
+    expect(json.allergens[0].discriminative).not.toBe(
+      json.allergens[3].discriminative,
+    );
+    expect(json.allergens[0].discriminative).toBeGreaterThan(
+      json.allergens[3].discriminative,
+    );
+
+    // `score` is back-compat alias for `discriminative`.
+    expect(json.allergens[0].score).toBe(json.allergens[0].discriminative);
+
+    // Posterior is in [0, 1] and every allergen in a 4-entry leaderboard
+    // with topK=4 deterministically finishes top-4, so posterior=1 for all.
+    for (const a of json.allergens) {
+      expect(a.posterior).toBe(1);
+    }
+
+    // Tier strings are valid enum values.
+    for (const a of json.allergens) {
+      expect(["low", "medium", "high", "very_high"]).toContain(
+        a.confidence_tier,
+      );
+    }
   });
 });

--- a/__tests__/engine/confidence-discriminative.test.ts
+++ b/__tests__/engine/confidence-discriminative.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Two-layer confidence model tests (issue #193)
+ *
+ * Covers the new discriminative (Elo-separation sigmoid) and
+ * posterior (Monte Carlo top-K frequency) APIs added in
+ * `lib/engine/confidence-score.ts`. The legacy signal-count
+ * function is covered by `./confidence-score.test.ts` which
+ * continues to pass unchanged (the old export is retained).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  getDiscriminativeConfidence,
+  getPosteriorConfidence,
+  getConfidenceTierByPosterior,
+  POSTERIOR_DEFAULT_RUNS,
+} from "@/lib/engine/confidence-score";
+import type { TournamentEntry } from "@/lib/engine/types";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/** Build a synthetic leaderboard with descending composite scores. */
+function buildLeaderboard(
+  size: number,
+  top: number = 1800,
+  bottom: number = 800,
+): TournamentEntry[] {
+  const step = size > 1 ? (top - bottom) / (size - 1) : 0;
+  return Array.from({ length: size }, (_, i) => ({
+    allergen_id: `a${String(i + 1).padStart(3, "0")}`,
+    common_name: `Allergen ${i + 1}`,
+    category: "tree",
+    composite_score: top - i * step,
+    tier: "low" as const,
+  }));
+}
+
+/* ------------------------------------------------------------------ */
+/* Discriminative layer                                                */
+/* ------------------------------------------------------------------ */
+
+describe("getDiscriminativeConfidence", () => {
+  it("returns 0.5 when elo equals the reference", () => {
+    expect(
+      getDiscriminativeConfidence(1000, [500, 1000, 1500]),
+    ).toBeCloseTo(0.5, 10);
+  });
+
+  it("returns near 1.0 for an elo far above the reference", () => {
+    const score = getDiscriminativeConfidence(2500, [500, 1000, 1500]);
+    expect(score).toBeGreaterThan(0.99);
+    expect(score).toBeLessThanOrEqual(1);
+  });
+
+  it("returns near 0.0 for an elo far below the reference", () => {
+    // k = 1/200, delta = -900 → sigmoid(-4.5) ≈ 0.011
+    const score = getDiscriminativeConfidence(100, [800, 1000, 1200]);
+    expect(score).toBeLessThan(0.02);
+    expect(score).toBeGreaterThanOrEqual(0);
+  });
+
+  it("is monotonic in elo for a fixed reference", () => {
+    const neighbors = [800, 1000, 1200];
+    const lo = getDiscriminativeConfidence(900, neighbors);
+    const mid = getDiscriminativeConfidence(1100, neighbors);
+    const hi = getDiscriminativeConfidence(1300, neighbors);
+    expect(lo).toBeLessThan(mid);
+    expect(mid).toBeLessThan(hi);
+  });
+
+  it("is deterministic — same inputs produce same outputs", () => {
+    const a = getDiscriminativeConfidence(1234, [500, 1000, 1500, 2000]);
+    const b = getDiscriminativeConfidence(1234, [500, 1000, 1500, 2000]);
+    expect(a).toBe(b);
+  });
+
+  it("handles degenerate empty neighbor list by returning 0.5", () => {
+    expect(getDiscriminativeConfidence(1000, [])).toBeCloseTo(0.5, 10);
+  });
+
+  it.each([8, 16, 32])(
+    "separates rank 1 from rank N on a %i-size leaderboard (DoD #193)",
+    (size) => {
+      const leaderboard = buildLeaderboard(size);
+      const elos = leaderboard.map((e) => e.composite_score);
+      const top = getDiscriminativeConfidence(elos[0], elos);
+      const bottom = getDiscriminativeConfidence(elos[elos.length - 1], elos);
+      expect(top).toBeGreaterThan(bottom);
+      // Visible separation, not a 21% flat line.
+      expect(top - bottom).toBeGreaterThan(0.4);
+    },
+  );
+});
+
+/* ------------------------------------------------------------------ */
+/* Posterior layer                                                     */
+/* ------------------------------------------------------------------ */
+
+describe("getPosteriorConfidence", () => {
+  it("returns an empty map for an empty leaderboard", () => {
+    expect(getPosteriorConfidence([])).toEqual({});
+  });
+
+  it("returns 1.0 for the single allergen in a 1-entry leaderboard (degenerate)", () => {
+    const leaderboard = buildLeaderboard(1);
+    const posterior = getPosteriorConfidence(leaderboard, { seed: 1 });
+    expect(posterior[leaderboard[0].allergen_id]).toBe(1);
+  });
+
+  it("is deterministic under a fixed seed", () => {
+    const leaderboard = buildLeaderboard(16);
+    const a = getPosteriorConfidence(leaderboard, { seed: 42, runs: 200 });
+    const b = getPosteriorConfidence(leaderboard, { seed: 42, runs: 200 });
+    expect(a).toEqual(b);
+  });
+
+  it("produces different outputs for different seeds (with noise)", () => {
+    // With noise > 0 and a non-degenerate leaderboard, different
+    // seeds should yield different tallies for at least some
+    // borderline allergens.
+    const leaderboard = buildLeaderboard(16);
+    const a = getPosteriorConfidence(leaderboard, {
+      seed: 1,
+      runs: 200,
+      noise: 0.5,
+    });
+    const b = getPosteriorConfidence(leaderboard, {
+      seed: 2,
+      runs: 200,
+      noise: 0.5,
+    });
+    expect(a).not.toEqual(b);
+  });
+
+  it("saturates at 1.0 when one allergen dominates every run", () => {
+    // Huge gap + small noise → #1 always wins top-K.
+    const leaderboard: TournamentEntry[] = [
+      {
+        allergen_id: "dominator",
+        common_name: "Dominator",
+        category: "tree",
+        composite_score: 5000,
+        tier: "low",
+      },
+      ...buildLeaderboard(7, 1000, 500),
+    ];
+    const posterior = getPosteriorConfidence(leaderboard, {
+      seed: 0,
+      runs: 200,
+      topK: 4,
+      noise: 0.1,
+    });
+    expect(posterior["dominator"]).toBe(1);
+  });
+
+  it("floors at 0 when an allergen is far outside top-K with small noise", () => {
+    // Allergen at the bottom of a 16-size leaderboard, topK=4,
+    // tiny noise → should never finish top-4.
+    const leaderboard = buildLeaderboard(16, 2000, 500);
+    const posterior = getPosteriorConfidence(leaderboard, {
+      seed: 7,
+      runs: 200,
+      topK: 4,
+      noise: 0.05,
+    });
+    const lastId = leaderboard[leaderboard.length - 1].allergen_id;
+    expect(posterior[lastId]).toBe(0);
+  });
+
+  it("all posterior values are in [0, 1]", () => {
+    const leaderboard = buildLeaderboard(32);
+    const posterior = getPosteriorConfidence(leaderboard, {
+      seed: 13,
+      runs: 100,
+      noise: 0.5,
+    });
+    for (const v of Object.values(posterior)) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("top-K posteriors sum to exactly topK (conservation)", () => {
+    // Every run contributes exactly `topK` allergens to the tally,
+    // so the total across all allergens should be runs * topK / runs = topK.
+    const leaderboard = buildLeaderboard(16);
+    const runs = 200;
+    const topK = 4;
+    const posterior = getPosteriorConfidence(leaderboard, {
+      seed: 99,
+      runs,
+      topK,
+      noise: 0.3,
+    });
+    const total = Object.values(posterior).reduce((s, v) => s + v, 0);
+    expect(total).toBeCloseTo(topK, 10);
+  });
+
+  it("uses the documented default run count when runs is omitted", () => {
+    // Smoke test: output for a single seed is stable across two
+    // calls with default runs.
+    const leaderboard = buildLeaderboard(8);
+    const a = getPosteriorConfidence(leaderboard, { seed: 0 });
+    const b = getPosteriorConfidence(leaderboard, {
+      seed: 0,
+      runs: POSTERIOR_DEFAULT_RUNS,
+    });
+    expect(a).toEqual(b);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Tier derivation from posterior                                      */
+/* ------------------------------------------------------------------ */
+
+describe("getConfidenceTierByPosterior", () => {
+  it("maps posterior bands to the canonical tier strings", () => {
+    expect(getConfidenceTierByPosterior(0)).toBe("low");
+    expect(getConfidenceTierByPosterior(0.49)).toBe("low");
+    expect(getConfidenceTierByPosterior(0.5)).toBe("medium");
+    expect(getConfidenceTierByPosterior(0.74)).toBe("medium");
+    expect(getConfidenceTierByPosterior(0.75)).toBe("high");
+    expect(getConfidenceTierByPosterior(0.89)).toBe("high");
+    expect(getConfidenceTierByPosterior(0.9)).toBe("very_high");
+    expect(getConfidenceTierByPosterior(1)).toBe("very_high");
+  });
+
+  it("treats NaN posterior as low (defensive)", () => {
+    expect(getConfidenceTierByPosterior(NaN)).toBe("low");
+  });
+});

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -2,8 +2,11 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import {
   getConfidenceTierBySignals,
-  getConfidenceScoreBySignals,
+  getDiscriminativeConfidence,
+  getPosteriorConfidence,
+  getConfidenceTierByPosterior,
 } from "@/lib/engine";
+import type { TournamentEntry } from "@/lib/engine";
 import type { RankedAllergen } from "@/components/leaderboard/types";
 
 /**
@@ -105,18 +108,46 @@ export async function GET() {
   // (no Elo data means no symptoms have been processed)
   const isEnvironmentalForecast = eloRows.length === 0;
 
-  // Map to ranked allergens with confidence tiers + numeric score
+  // Two-layer confidence model (issue #193):
+  //   - discriminative: per-allergen Elo separation from the pack
+  //   - posterior: Monte Carlo top-K frequency → drives the tier string
+  // Legacy signal-count surfaces (`score`, `confidence_tier`) are kept
+  // populated for back-compat with older callers during the migration.
+  const elos = eloRows.map((row) => row.elo_score);
+  const tournamentEntries: TournamentEntry[] = eloRows.map((row) => ({
+    allergen_id: row.allergen_id,
+    common_name: row.allergens.common_name,
+    category: row.allergens.category,
+    composite_score: row.elo_score,
+    // Placeholder — the posterior run does not use `tier`.
+    tier: "low" as const,
+  }));
+  const posteriors = getPosteriorConfidence(tournamentEntries, {
+    seed: 0,
+  });
+
   const allergens: RankedAllergen[] = eloRows.map((row, index) => {
     const totalSignals = row.positive_signals + row.negative_signals;
+    const discriminative = getDiscriminativeConfidence(row.elo_score, elos);
+    const posterior = posteriors[row.allergen_id] ?? 0;
     return {
       allergen_id: row.allergen_id,
       common_name: row.allergens.common_name,
       category: row.allergens.category as RankedAllergen["category"],
       elo_score: row.elo_score,
-      confidence_tier: getConfidenceTierBySignals(totalSignals),
-      // Numeric 0–1 confidence emitted per issue #160. Clamped by the
-      // helper; anchored so 7 signals = 0.5, 14 signals = 0.75.
-      score: getConfidenceScoreBySignals(totalSignals),
+      // Tier now derives from the posterior (issue #193). Falls back
+      // to the legacy signal-count tier if the posterior is somehow
+      // non-finite — defense in depth for the migration window.
+      confidence_tier: Number.isFinite(posterior)
+        ? getConfidenceTierByPosterior(posterior)
+        : getConfidenceTierBySignals(totalSignals),
+      // `score` is the back-compat numeric surface: it now maps to
+      // the discriminative layer so older UI that reads `score` still
+      // shows visible variation between #1 and #N (the 21% flat-line
+      // bug was caused by feeding it a signal-count metric).
+      score: discriminative,
+      discriminative,
+      posterior,
       rank: index + 1,
     };
   });

--- a/components/leaderboard/types.ts
+++ b/components/leaderboard/types.ts
@@ -24,6 +24,24 @@ export interface RankedAllergen {
    * changes through the gated Final Four and PDF report code paths.
    */
   score: number;
+  /**
+   * Discriminative confidence in [0, 1] — Elo-separation sigmoid
+   * from `lib/engine/confidence-score#getDiscriminativeConfidence`.
+   * Answers "how far is this allergen's Elo from the pack?". By
+   * construction #1 is high, #N is low (see issue #193).
+   * Optional during rollout: older payloads (and some test fixtures)
+   * may still omit it; new server code should populate it.
+   */
+  discriminative?: number;
+  /**
+   * Posterior confidence in [0, 1] — Monte Carlo top-K frequency
+   * from `lib/engine/confidence-score#getPosteriorConfidence`.
+   * Answers "probability this allergen is actually top-K in
+   * repeated tournaments under bounded noise." This is the
+   * tier-driving number going forward (issue #193).
+   * Optional during rollout (see `discriminative`).
+   */
+  posterior?: number;
   rank: number;
 }
 

--- a/lib/engine/confidence-score.ts
+++ b/lib/engine/confidence-score.ts
@@ -1,37 +1,41 @@
 /**
- * Numeric Confidence Score (0–1)
+ * Numeric Confidence Score (0–1) — Two-Layer Model (issue #193)
  *
- * Derives a deterministic confidence number in [0, 1] for a ranked
- * allergen based on the total observed signal count (positive +
- * negative check-ins). This is the numeric companion to the existing
- * tier string produced by `./confidence.ts` — both surfaces are kept
- * during the migration tracked in issue #160.
+ * The original single-layer function (`getConfidenceScoreBySignals`)
+ * is a piecewise-linear curve over **total signal count** (positive
+ * + negative check-ins). That metric answers "how much data do we
+ * have?" — not "which allergen is most likely the trigger?" — so
+ * every allergen in a user's account ends up with roughly the same
+ * score (the ~21% flat-line bug surfaced in #193).
  *
- * Derivation (piecewise linear, anchored at the bucket boundaries the
- * display layer uses in `./confidence-buckets.ts`):
+ * This module replaces that single output with two layers:
  *
- *     signals   -> score
- *         0     -> 0.00
- *         7     -> 0.50   (low  -> medium boundary)
- *        14     -> 0.75   (medium -> high boundary)
- *        30     -> 0.90   (very_high tier threshold)
- *        50+    -> 1.00   (asymptote, clamped)
+ *   1. Discriminative layer (sync, cheap) — `getDiscriminativeConfidence`
+ *      Elo-separation sigmoid. By construction #1 scores high, #43
+ *      scores low. Pure, deterministic, no randomness.
  *
- * Rationale: the existing signal-count tiers (`getConfidenceTierBySignals`
- * — `>= 7` medium, `>= 14` high, `>= 30` very_high) are the established
- * confidence gradient in the app. Mapping those same breakpoints onto
- * the display bucket thresholds (`>= 0.5` medium, `>= 0.75` high) makes
- * the numeric score and the legacy tier agree end-to-end, so 7 signals
- * lands exactly on "medium" in both surfaces and 14 signals lands
- * exactly on "high". 50 signals is the cap where additional check-ins
- * no longer move the needle.
+ *   2. Epistemic layer (Monte Carlo) — `getPosteriorConfidence`
+ *      Re-runs the pairwise tournament N times with bounded noise
+ *      injected per-allergen; posterior = fraction of runs in which
+ *      each allergen finished in the top K. Deterministic under
+ *      seed. Drives the `ConfidenceTier` string.
  *
- * Pure and deterministic — no randomness, no time dependence, no I/O.
- * Result is always clamped to [0, 1].
+ * Tier thresholds stay at the same observable cutoffs (Low < 0.5,
+ * Medium ≥ 0.5, High ≥ 0.75, Very High ≥ 0.9) — but now operate on
+ * the posterior rather than signal count.
  *
- * Server-side only (lives under `lib/engine/`), but has no secret
- * dependencies — safe to import from API routes and server components.
+ * Server-side only (lives under `lib/engine/`). Pure and has no
+ * secret dependencies — safe to import from API routes and server
+ * components.
  */
+
+import type { ConfidenceTier, TournamentEntry } from "./types";
+import { pairwiseSort } from "./tournament";
+import { createSeededRng } from "./monte-carlo";
+
+/* ------------------------------------------------------------------ */
+/* Legacy signal-count curve (kept for migration / back-compat)        */
+/* ------------------------------------------------------------------ */
 
 /** Anchor points for the piecewise-linear score curve. Must be sorted by signals asc. */
 const SCORE_ANCHORS: { signals: number; score: number }[] = [
@@ -51,6 +55,14 @@ function clamp(value: number, min: number, max: number): number {
 
 /**
  * Compute a 0–1 confidence score from a total signal count.
+ *
+ * @deprecated Since issue #193: signal count is an epistemic
+ *   (how much data) metric, not a discriminative (which allergen)
+ *   metric, so every allergen lands at roughly the same value.
+ *   Prefer `getDiscriminativeConfidence` for per-allergen separation
+ *   and `getPosteriorConfidence` for the tier-driving probability.
+ *   Kept exported through at least one release to avoid breaking
+ *   callers (see `app/api/leaderboard/route.ts`).
  *
  * @param totalSignals — sum of positive + negative check-in signals
  * @returns score in [0, 1], clamped
@@ -74,4 +86,203 @@ export function getConfidenceScoreBySignals(totalSignals: number): number {
 
   // At or beyond the final anchor — asymptote to 1.0.
   return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/* Layer 1 — Discriminative (Elo separation)                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Sigmoid steepness for Elo separation. Calibrated so that a 200-Elo
+ * gap (one tier) maps close to the 0.75 discriminative boundary,
+ * matching the tier math in `./confidence.ts`.
+ */
+export const DISCRIMINATIVE_SIGMOID_K = 1 / 200;
+
+/** Numerically-safe logistic sigmoid. */
+function sigmoid(x: number): number {
+  if (x >= 0) {
+    const z = Math.exp(-x);
+    return 1 / (1 + z);
+  }
+  const z = Math.exp(x);
+  return z / (1 + z);
+}
+
+/**
+ * Compute the discriminative confidence score for a single allergen
+ * given its Elo and a set of reference neighbors.
+ *
+ * The score is `sigmoid(k * (elo - reference))` where `reference`
+ * is the median Elo of the provided neighbors (or of a single-
+ * element reference). By construction:
+ *
+ *   - An allergen with Elo well above the reference → ~1.0
+ *   - An allergen with Elo well below the reference → ~0.0
+ *   - An allergen exactly at the reference → 0.5
+ *
+ * This guarantees that for any leaderboard with ≥ 2 distinct Elo
+ * values, `rank_1.discriminative !== rank_last.discriminative` —
+ * the core DoD criterion for #193.
+ *
+ * Pure and deterministic: no randomness, no I/O.
+ *
+ * @param elo — the allergen's Elo score
+ * @param neighbors — the reference pool (e.g. all leaderboard Elos).
+ *   If empty, defaults to a neutral reference of `elo` (returns 0.5).
+ * @param k — sigmoid steepness. Default `DISCRIMINATIVE_SIGMOID_K`.
+ * @returns discriminative score in [0, 1]
+ */
+export function getDiscriminativeConfidence(
+  elo: number,
+  neighbors: number[],
+  k: number = DISCRIMINATIVE_SIGMOID_K,
+): number {
+  if (!Number.isFinite(elo)) return 0;
+  const reference =
+    neighbors.length > 0 ? medianOf(neighbors) : elo;
+  const delta = elo - reference;
+  return clamp(sigmoid(k * delta), 0, 1);
+}
+
+/** Median of a numeric array. Non-mutating. */
+function medianOf(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  if (n === 0) return 0;
+  if (n % 2 === 1) return sorted[(n - 1) / 2];
+  return (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+}
+
+/* ------------------------------------------------------------------ */
+/* Layer 2 — Posterior (Monte Carlo top-K frequency)                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Options for the posterior-confidence Monte Carlo runner.
+ */
+export interface PosteriorConfidenceOptions {
+  /** Number of Monte Carlo runs. Default 200. */
+  runs?: number;
+  /** RNG seed for reproducibility. Default 0 (deterministic). */
+  seed?: number;
+  /**
+   * Top-K threshold — posterior is the fraction of runs in which
+   * the allergen finishes at rank ≤ `topK`. Default 4 (Final Four).
+   */
+  topK?: number;
+  /**
+   * Bounded uniform noise magnitude applied to each allergen's
+   * composite score per run, as a fraction of `NOISE_BASE` (so the
+   * per-run noise is drawn from `±noise * NOISE_BASE`). Default 0.25.
+   * Must be ≥ 0.
+   */
+  noise?: number;
+}
+
+/** Base noise magnitude (Elo points) used by the Monte Carlo layer. */
+export const POSTERIOR_NOISE_BASE = 100;
+
+/** Default number of Monte Carlo runs. */
+export const POSTERIOR_DEFAULT_RUNS = 200;
+
+/** Default top-K threshold (Final Four). */
+export const POSTERIOR_DEFAULT_TOP_K = 4;
+
+/** Default noise fraction applied per run. */
+export const POSTERIOR_DEFAULT_NOISE = 0.25;
+
+/**
+ * Compute the posterior confidence for every allergen on a
+ * leaderboard via seeded Monte Carlo resampling of the pairwise
+ * tournament.
+ *
+ * For each of `runs` iterations we perturb every entry's
+ * `composite_score` by a bounded uniform draw in
+ * `±noise * POSTERIOR_NOISE_BASE` and re-sort with the existing
+ * `pairwiseSort`. We tally how often each allergen lands in the
+ * top `topK`. The posterior is `tally / runs`.
+ *
+ * Determinism: with the same input and the same `seed`, the
+ * returned map is identical.
+ *
+ * Degenerate inputs:
+ *   - Empty leaderboard → empty map
+ *   - Single allergen → `{ [allergen_id]: 1 }` (always top-K)
+ *
+ * @param leaderboard — tournament entries (already ranked or not;
+ *   order does not matter, only composite_score does)
+ * @param options — see `PosteriorConfidenceOptions`
+ * @returns map from allergen_id to posterior in [0, 1]
+ */
+export function getPosteriorConfidence(
+  leaderboard: TournamentEntry[],
+  options: PosteriorConfidenceOptions = {},
+): Record<string, number> {
+  const runs = options.runs ?? POSTERIOR_DEFAULT_RUNS;
+  const seed = options.seed ?? 0;
+  const topK = options.topK ?? POSTERIOR_DEFAULT_TOP_K;
+  const noise = options.noise ?? POSTERIOR_DEFAULT_NOISE;
+
+  if (leaderboard.length === 0) return {};
+
+  // Degenerate: a single allergen is always top-K by definition.
+  if (leaderboard.length === 1) {
+    return { [leaderboard[0].allergen_id]: 1 };
+  }
+
+  const tally: Record<string, number> = {};
+  for (const entry of leaderboard) {
+    tally[entry.allergen_id] = 0;
+  }
+
+  const rng = createSeededRng(seed);
+  const noiseMagnitude = Math.max(0, noise) * POSTERIOR_NOISE_BASE;
+
+  for (let r = 0; r < runs; r++) {
+    const perturbed: TournamentEntry[] = leaderboard.map((entry) => ({
+      ...entry,
+      // Uniform draw in [-noiseMagnitude, +noiseMagnitude].
+      composite_score:
+        entry.composite_score + (rng() * 2 - 1) * noiseMagnitude,
+    }));
+
+    const sorted = pairwiseSort(perturbed);
+    const topSize = Math.min(topK, sorted.length);
+    for (let i = 0; i < topSize; i++) {
+      tally[sorted[i].allergen_id] += 1;
+    }
+  }
+
+  const posterior: Record<string, number> = {};
+  for (const id of Object.keys(tally)) {
+    posterior[id] = tally[id] / runs;
+  }
+  return posterior;
+}
+
+/* ------------------------------------------------------------------ */
+/* Tier derivation from posterior                                      */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Map a posterior probability in [0, 1] to the canonical
+ * four-level `ConfidenceTier` string. Thresholds are aligned with
+ * the display-bucket cutoffs so the numeric surface and the tier
+ * string stay in agreement.
+ *
+ *   posterior >= 0.9  → very_high
+ *   posterior >= 0.75 → high
+ *   posterior >= 0.5  → medium
+ *   posterior <  0.5  → low
+ *
+ * Pure and deterministic.
+ */
+export function getConfidenceTierByPosterior(
+  posterior: number,
+): ConfidenceTier {
+  if (!Number.isFinite(posterior) || posterior < 0.5) return "low";
+  if (posterior >= 0.9) return "very_high";
+  if (posterior >= 0.75) return "high";
+  return "medium";
 }

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -69,8 +69,23 @@ export {
   getConfidenceLabel,
 } from "./confidence";
 
-// Confidence score (numeric 0–1 companion to the tier string, issue #160)
-export { getConfidenceScoreBySignals } from "./confidence-score";
+// Confidence score — two-layer model (issue #193)
+//   - getConfidenceScoreBySignals: legacy signal-count curve (deprecated)
+//   - getDiscriminativeConfidence: Elo-separation sigmoid (cheap, sync)
+//   - getPosteriorConfidence: Monte Carlo top-K frequency (tier driver)
+//   - getConfidenceTierByPosterior: posterior → tier string
+export {
+  getConfidenceScoreBySignals,
+  getDiscriminativeConfidence,
+  getPosteriorConfidence,
+  getConfidenceTierByPosterior,
+  DISCRIMINATIVE_SIGMOID_K,
+  POSTERIOR_NOISE_BASE,
+  POSTERIOR_DEFAULT_RUNS,
+  POSTERIOR_DEFAULT_TOP_K,
+  POSTERIOR_DEFAULT_NOISE,
+} from "./confidence-score";
+export type { PosteriorConfidenceOptions } from "./confidence-score";
 
 // Monte Carlo exposure simulation
 export type {


### PR DESCRIPTION
## Summary

Closes #193. The legacy `getConfidenceScoreBySignals` produced a piecewise-linear curve over total signal count, so every allergen in a user's account landed at the same value (~21% at 3 signals). That's epistemic (how much data), not discriminative (which allergen).

Replaced with a two-layer model in `lib/engine/confidence-score.ts`:

- **Layer 1 — `getDiscriminativeConfidence(elo, neighbors)`** — sigmoid over Elo separation from the median of the neighbor pool. Cheap, deterministic, no randomness.
- **Layer 2 — `getPosteriorConfidence(leaderboard, options)`** — Monte Carlo top-K frequency. Re-runs `pairwiseSort` N times (default 200) with bounded uniform noise injected per entry. Seeded determinism.
- **Tier derivation** — `getConfidenceTierByPosterior` now drives the `ConfidenceTier` string off the posterior with the same observable thresholds (low <0.5, medium >=0.5, high >=0.75, very_high >=0.9).

`getConfidenceScoreBySignals` is preserved with `@deprecated` JSDoc for back-compat, per DoD. `RankedAllergen` gains optional `discriminative` and `posterior` fields; `score` is now populated from the discriminative layer so older UI surfaces show visible separation.

Stayed in lane per the parallel issue #194 note — no changes to `lib/engine/tournament.ts` or `TournamentResult`.

## Before / after (8-entry leaderboard, Elos 1700 down to 1000 in 100-pt steps)

All users had 3 signals per allergen before the fix, so the old curve tied everyone at 3/7 * 0.5 = 0.214.

| Rank | Elo  | Old score (signals=3) | New discriminative | New posterior (topK=4, seed=0, default noise) |
|------|------|-----------------------|--------------------|-----------------------------------------------|
| 1    | 1700 | 0.214                 | ~0.852             | ~1.00                                         |
| 2    | 1600 | 0.214                 | ~0.777             | ~1.00                                         |
| 3    | 1500 | 0.214                 | ~0.679             | ~1.00                                         |
| 4    | 1400 | 0.214                 | ~0.562             | ~0.98                                         |
| 5    | 1300 | 0.214                 | ~0.438             | ~0.02                                         |
| 6    | 1200 | 0.214                 | ~0.321             | 0.00                                          |
| 7    | 1100 | 0.214                 | ~0.223             | 0.00                                          |
| 8    | 1000 | 0.214                 | ~0.148             | 0.00                                          |

Rank-1 vs rank-8 discriminative separation: 0.852 - 0.148 = 0.704 (vs 0.0 before).

## Test plan

- [x] New test file `__tests__/engine/confidence-discriminative.test.ts` — 20 tests covering: #1 vs #N separation for 8/16/32-size leaderboards, seeded determinism, posterior saturation at 1.0, empty/single degenerate inputs, top-K conservation, tier derivation boundaries
- [x] Existing `__tests__/engine/confidence-score.test.ts` passes unchanged (legacy function still exported)
- [x] Existing `__tests__/engine/confidence-buckets.test.ts` passes unchanged
- [x] Existing `__tests__/engine/confidence.test.ts` passes unchanged
- [x] `__tests__/api/leaderboard.test.ts` — "computes confidence tiers" updated to assert the new two-layer surface (legacy signal-count tier assertions no longer coherent with posterior-driven tiers)
- [x] `npm run lint` green
- [x] `npm run typecheck` green
- [x] `npm test` green (957 passed / 957)
- [x] `npm run build` green