### PR TITLE
feat(bracket): BracketNode + Bracket container with confidence-UI pattern

### DIFF
--- a/__tests__/bracket/bracket-node.test.tsx
+++ b/__tests__/bracket/bracket-node.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * BracketNode — component tests (ticket #179)
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BracketNode } from "@/components/bracket/bracket-node";
+import type { BracketNodeVM } from "@/components/bracket/types";
+
+function makeNode(overrides: Partial<BracketNodeVM> = {}): BracketNodeVM {
+  return {
+    round: 0,
+    matchId: 0,
+    left: {
+      allergenId: "ragweed",
+      name: "Ragweed",
+      thumbnail: { src: "/allergens/generic-plant.svg", alt: "Ragweed icon" },
+      discriminative: 0.8,
+      posterior: 0.8,
+    },
+    right: {
+      allergenId: "oak-pollen",
+      name: "Oak Pollen",
+      thumbnail: {
+        src: "/allergens/generic-plant.svg",
+        alt: "Oak pollen icon",
+      },
+      discriminative: 0.4,
+      posterior: 0.4,
+    },
+    winnerSide: "left",
+    leftScore: 1000,
+    rightScore: 600,
+    ...overrides,
+  };
+}
+
+describe("BracketNode", () => {
+  it("renders both side names", () => {
+    render(<BracketNode node={makeNode()} />);
+    expect(screen.getByTestId("bracket-side-left-name").textContent).toBe(
+      "Ragweed",
+    );
+    expect(screen.getByTestId("bracket-side-right-name").textContent).toBe(
+      "Oak Pollen",
+    );
+  });
+
+  it("renders thumbnails for both sides", () => {
+    render(<BracketNode node={makeNode()} />);
+    const imgs = screen.getAllByRole("img");
+    expect(imgs.length).toBeGreaterThanOrEqual(2);
+    expect(imgs[0].getAttribute("src")).toBe("/allergens/generic-plant.svg");
+  });
+
+  it("marks the loser side with reduced opacity and strikethrough", () => {
+    render(<BracketNode node={makeNode()} />);
+    const loser = screen.getByTestId("bracket-side-right");
+    expect(loser.getAttribute("data-winner")).toBe("false");
+    expect(loser.className).toContain("opacity-60");
+    const loserName = screen.getByTestId("bracket-side-right-name");
+    expect(loserName.className).toContain("line-through");
+  });
+
+  it("marks the winner side without the strikethrough", () => {
+    render(<BracketNode node={makeNode()} />);
+    const winner = screen.getByTestId("bracket-side-left");
+    expect(winner.getAttribute("data-winner")).toBe("true");
+    const winnerName = screen.getByTestId("bracket-side-left-name");
+    expect(winnerName.className).not.toContain("line-through");
+  });
+
+  it("shows the Nature Pop champion badge on the final match winner with posterior >= 0.75", () => {
+    render(<BracketNode node={makeNode()} isFinal />);
+    const badge = screen.getByTestId("bracket-champion-badge");
+    expect(badge.textContent).toContain("Most likely trigger");
+    expect(badge.className).toContain("bg-brand-accent");
+  });
+
+  it("does NOT show the champion badge when posterior < 0.75 even if final", () => {
+    const node = makeNode({
+      left: {
+        ...makeNode().left,
+        posterior: 0.6,
+        discriminative: 0.6,
+      },
+    });
+    render(<BracketNode node={node} isFinal />);
+    expect(screen.queryByTestId("bracket-champion-badge")).toBeNull();
+    // But the advancing side still gets the muted "Advances" badge.
+    expect(screen.getByTestId("bracket-winner-badge")).toBeDefined();
+  });
+
+  it("uses the muted 'Advances' badge for non-final winners", () => {
+    render(<BracketNode node={makeNode()} isFinal={false} />);
+    expect(screen.queryByTestId("bracket-champion-badge")).toBeNull();
+    const badge = screen.getByTestId("bracket-winner-badge");
+    expect(badge).toBeDefined();
+    expect(badge.className).toContain("border-brand-primary");
+  });
+
+  it("has an accessible name combining both sides", () => {
+    render(<BracketNode node={makeNode()} />);
+    const card = screen.getByTestId("bracket-node");
+    expect(card.getAttribute("aria-label")).toBe(
+      "Match: Ragweed vs Oak Pollen, winner Ragweed",
+    );
+  });
+
+  it("renders confidence bars (not a raw percentage label) for each side", () => {
+    render(<BracketNode node={makeNode()} />);
+    const leftBar = screen.getByTestId("bracket-side-left-bar");
+    const rightBar = screen.getByTestId("bracket-side-right-bar");
+    expect(leftBar.getAttribute("data-tier")).toBe("high"); // posterior 0.8
+    expect(rightBar.getAttribute("data-tier")).toBe("low"); // posterior 0.4
+    // No visible "80%" / "40%" label on the card.
+    expect(screen.queryByText("80%")).toBeNull();
+    expect(screen.queryByText("40%")).toBeNull();
+  });
+});

--- a/__tests__/bracket/bracket.test.tsx
+++ b/__tests__/bracket/bracket.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Bracket — container tests (ticket #179)
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Bracket } from "@/components/bracket/bracket";
+import { buildBracketTrace } from "@/lib/engine/tournament";
+import type { TournamentEntry } from "@/lib/engine/types";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+function makeEntries(n: number): TournamentEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    allergen_id: `a-${i + 1}`,
+    common_name: `Allergen ${i + 1}`,
+    category: "pollen",
+    composite_score: 1000 - i * 10,
+    tier: "low" as const,
+  }));
+}
+
+function makeRanked(
+  n: number,
+  opts: { championPosterior?: number } = {},
+): RankedAllergen[] {
+  return Array.from({ length: n }, (_, i) => ({
+    allergen_id: `a-${i + 1}`,
+    common_name: `Allergen ${i + 1}`,
+    category: "pollen" as RankedAllergen["category"],
+    elo_score: 1000 - i * 10,
+    confidence_tier: "medium",
+    score: 0.6,
+    discriminative: 0.5,
+    posterior: i === 0 ? opts.championPosterior ?? 0.8 : 0.5,
+    rank: i + 1,
+  }));
+}
+
+describe("Bracket", () => {
+  it.each([
+    [8, 3],
+    [16, 4],
+    [32, 5],
+  ])("renders %i columns for an %i-entry bracket", (size, totalRounds) => {
+    const trace = buildBracketTrace(makeEntries(size));
+    render(<Bracket nodes={trace} ranked={makeRanked(size)} />);
+    for (let r = 0; r < totalRounds; r++) {
+      expect(screen.getByTestId(`bracket-column-${r}`)).toBeDefined();
+    }
+    expect(
+      screen.queryByTestId(`bracket-column-${totalRounds}`),
+    ).toBeNull();
+  });
+
+  it("labels the final round 'Final'", () => {
+    const trace = buildBracketTrace(makeEntries(8));
+    render(<Bracket nodes={trace} ranked={makeRanked(8)} />);
+    // Final round is index 2 for 8-entry bracket
+    expect(
+      screen.getByTestId("bracket-round-label-2").textContent,
+    ).toBe("Final");
+  });
+
+  it("labels a 16-entry bracket with Round of 16 / QF / SF / Final", () => {
+    const trace = buildBracketTrace(makeEntries(16));
+    render(<Bracket nodes={trace} ranked={makeRanked(16)} />);
+    expect(screen.getByTestId("bracket-round-label-0").textContent).toBe(
+      "Round of 16",
+    );
+    expect(screen.getByTestId("bracket-round-label-1").textContent).toBe(
+      "Quarter-finals",
+    );
+    expect(screen.getByTestId("bracket-round-label-2").textContent).toBe(
+      "Semi-finals",
+    );
+    expect(screen.getByTestId("bracket-round-label-3").textContent).toBe(
+      "Final",
+    );
+  });
+
+  it("renders the FDA disclaimer", () => {
+    const trace = buildBracketTrace(makeEntries(8));
+    render(<Bracket nodes={trace} ranked={makeRanked(8)} />);
+    const disclaimer = screen.getByTestId("bracket-fda-disclaimer");
+    expect(disclaimer.textContent).toContain("Predicted Triggers");
+    expect(disclaimer.textContent).toContain("Not a Diagnosis");
+  });
+
+  it("renders the 'keep tracking' affordance when the champion posterior is below 0.5", () => {
+    const trace = buildBracketTrace(makeEntries(8));
+    render(
+      <Bracket
+        nodes={trace}
+        ranked={makeRanked(8, { championPosterior: 0.3 })}
+      />,
+    );
+    const banner = screen.getByTestId("bracket-low-confidence");
+    expect(banner.textContent?.toLowerCase()).toContain("low confidence");
+    expect(banner.textContent?.toLowerCase()).toContain("keep tracking");
+  });
+
+  it("does NOT render the low-confidence banner when the champion posterior is high", () => {
+    const trace = buildBracketTrace(makeEntries(8));
+    render(
+      <Bracket
+        nodes={trace}
+        ranked={makeRanked(8, { championPosterior: 0.9 })}
+      />,
+    );
+    expect(screen.queryByTestId("bracket-low-confidence")).toBeNull();
+  });
+
+  it("renders an empty state and does not crash when nodes is empty", () => {
+    render(<Bracket nodes={[]} ranked={[]} />);
+    expect(screen.getByTestId("bracket-empty")).toBeDefined();
+    expect(screen.queryByTestId("bracket")).toBeNull();
+  });
+});

--- a/__tests__/bracket/build-vms.test.ts
+++ b/__tests__/bracket/build-vms.test.ts
@@ -1,0 +1,117 @@
+/**
+ * buildBracketVMs — unit tests (ticket #179)
+ *
+ * Covers the pure join helper that merges a raw `BracketMatch[]`
+ * trace with a ranked leaderboard into the VM shape the UI consumes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildBracketVMs } from "@/components/bracket/types";
+import { buildBracketTrace } from "@/lib/engine/tournament";
+import type { TournamentEntry, BracketMatch } from "@/lib/engine/types";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+/** Helper: make N entries with strictly descending composite scores. */
+function makeEntries(n: number): TournamentEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    allergen_id: `a-${i + 1}`,
+    common_name: `Allergen ${i + 1}`,
+    category: "pollen",
+    composite_score: 1000 - i * 10,
+    tier: "low" as const,
+  }));
+}
+
+/** Helper: build a ranked leaderboard matching the entries. */
+function makeRanked(n: number): RankedAllergen[] {
+  return Array.from({ length: n }, (_, i) => ({
+    allergen_id: `a-${i + 1}`,
+    common_name: `Allergen ${i + 1}`,
+    category: "pollen" as RankedAllergen["category"],
+    elo_score: 1000 - i * 10,
+    confidence_tier: "medium",
+    score: 0.6,
+    discriminative: 0.5 + i * 0.01,
+    posterior: 0.5 + i * 0.01,
+    rank: i + 1,
+  }));
+}
+
+describe("buildBracketVMs", () => {
+  it("produces 7 matches across 3 rounds for an 8-entry bracket", () => {
+    const entries = makeEntries(8);
+    const trace = buildBracketTrace(entries);
+    const ranked = makeRanked(8);
+    const vms = buildBracketVMs(trace, ranked);
+
+    expect(vms).toHaveLength(7);
+    const rounds = new Set(vms.map((v) => v.round));
+    expect(rounds.size).toBe(3); // 8 -> 4 -> 2 -> 1, so rounds 0, 1, 2
+    expect(vms.filter((v) => v.round === 0)).toHaveLength(4);
+    expect(vms.filter((v) => v.round === 1)).toHaveLength(2);
+    expect(vms.filter((v) => v.round === 2)).toHaveLength(1);
+  });
+
+  it("produces 15 matches across 4 rounds for a 16-entry bracket", () => {
+    const entries = makeEntries(16);
+    const trace = buildBracketTrace(entries);
+    const vms = buildBracketVMs(trace, makeRanked(16));
+
+    expect(vms).toHaveLength(15);
+    const rounds = new Set(vms.map((v) => v.round));
+    expect(rounds.size).toBe(4);
+  });
+
+  it("correctly identifies winnerSide as 'left' or 'right'", () => {
+    const trace: BracketMatch[] = [
+      {
+        round: 0,
+        matchId: 0,
+        leftAllergenId: "a-1",
+        rightAllergenId: "a-2",
+        winnerId: "a-1",
+        leftScore: 1000,
+        rightScore: 500,
+      },
+      {
+        round: 0,
+        matchId: 1,
+        leftAllergenId: "a-3",
+        rightAllergenId: "a-4",
+        winnerId: "a-4",
+        leftScore: 300,
+        rightScore: 700,
+      },
+    ];
+    const vms = buildBracketVMs(trace, makeRanked(4));
+
+    expect(vms[0].winnerSide).toBe("left");
+    expect(vms[1].winnerSide).toBe("right");
+  });
+
+  it("falls back to generic thumbnail + id as name for unknown allergen ids", () => {
+    const trace: BracketMatch[] = [
+      {
+        round: 0,
+        matchId: 0,
+        leftAllergenId: "unknown-x",
+        rightAllergenId: "unknown-y",
+        winnerId: "unknown-x",
+        leftScore: 100,
+        rightScore: 50,
+      },
+    ];
+    const vms = buildBracketVMs(trace, []);
+
+    expect(vms[0].left.name).toBe("unknown-x");
+    expect(vms[0].right.name).toBe("unknown-y");
+    expect(vms[0].left.thumbnail.src).toBe("/allergens/generic-plant.svg");
+    expect(vms[0].right.thumbnail.src).toBe("/allergens/generic-plant.svg");
+    expect(vms[0].left.discriminative).toBe(0);
+    expect(vms[0].left.posterior).toBe(0);
+  });
+
+  it("returns an empty array for an empty trace", () => {
+    expect(buildBracketVMs([], makeRanked(4))).toEqual([]);
+  });
+});

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -3,7 +3,13 @@ import { createClient } from "@/lib/supabase/server";
 import {
   getConfidenceTierBySignals,
   getConfidenceScoreBySignals,
+  getDiscriminativeConfidence,
+  getPosteriorConfidence,
+  getConfidenceTierByPosterior,
 } from "@/lib/engine";
+import type { TournamentEntry } from "@/lib/engine";
+import { buildBracketTrace } from "@/lib/engine/tournament";
+import type { BracketMatch } from "@/lib/engine/types";
 import type {
   RankedAllergen,
   GatedRankedAllergen,
@@ -14,6 +20,7 @@ import {
   getCachedAccessStatus,
   hasFeatureAccess,
 } from "@/lib/subscription";
+import { Bracket } from "@/components/bracket";
 import { DashboardLeaderboard } from "./dashboard-leaderboard";
 import { PageContainer } from "@/components/layout";
 
@@ -104,21 +111,53 @@ export default async function DashboardPage() {
 
   const eloRows = (rawEloRows ?? []) as unknown as EloRowWithAllergen[];
 
+  // Two-layer confidence model (issue #193) — mirrors the logic in
+  // `app/api/leaderboard/route.ts` so the dashboard's server-rendered
+  // payload carries `discriminative` + `posterior` into the bracket UI
+  // (issue #179).
+  const elos = eloRows.map((row) => row.elo_score);
+  const tournamentEntries: TournamentEntry[] = eloRows.map((row) => ({
+    allergen_id: row.allergen_id,
+    common_name: row.allergens.common_name,
+    category: row.allergens.category,
+    composite_score: row.elo_score,
+    tier: "low" as const,
+  }));
+  const posteriors = getPosteriorConfidence(tournamentEntries, { seed: 0 });
+
   // Map to ranked allergens with confidence tiers + numeric score
   // (server-side computation; score derivation lives in @/lib/engine).
   const allergens: RankedAllergen[] = eloRows.map((row, index) => {
     const totalSignals = row.positive_signals + row.negative_signals;
+    const discriminative = getDiscriminativeConfidence(row.elo_score, elos);
+    const posterior = posteriors[row.allergen_id] ?? 0;
     return {
       allergen_id: row.allergen_id,
       common_name: row.allergens.common_name,
       category: row.allergens.category as RankedAllergen["category"],
       elo_score: row.elo_score,
-      confidence_tier: getConfidenceTierBySignals(totalSignals),
-      // Numeric 0–1 confidence emitted per issue #160.
+      // Tier prefers the posterior (issue #193), falling back to legacy
+      // signal-count derivation if the posterior is non-finite.
+      confidence_tier: Number.isFinite(posterior)
+        ? getConfidenceTierByPosterior(posterior)
+        : getConfidenceTierBySignals(totalSignals),
+      // `score` stays as the legacy surface for components that haven't
+      // migrated yet; `discriminative` / `posterior` are the two-layer
+      // signals the bracket UI reads.
       score: getConfidenceScoreBySignals(totalSignals),
+      discriminative,
+      posterior,
       rank: index + 1,
     };
   });
+
+  // Bracket trace for the #179 bracket UI. `tournamentEntries` is
+  // already ordered by Elo descending (the Supabase query orders by
+  // elo_score desc), which matches `pairwiseSort`'s ordering for
+  // distinct composite scores. The engine helper handles byes for
+  // non-power-of-two counts and returns an empty trace for
+  // zero/one-entry inputs.
+  const bracketTrace: BracketMatch[] = buildBracketTrace(tournamentEntries);
 
   // Determine if we should show Environmental Forecast mode.
   // Forecast mode activates when the user's most recent check-in has severity = 0,
@@ -159,6 +198,16 @@ export default async function DashboardPage() {
           Signed in as {user.email}
         </p>
       </div>
+
+      {/* Tournament bracket (ticket #179). Rendered above the
+          leaderboard so users can see the path to their champion
+          before the ranked list. Hidden in Environmental Forecast
+          mode — no tournament has been played yet. */}
+      {!isEnvironmentalForecast && bracketTrace.length > 0 && (
+        <div className="mb-6">
+          <Bracket nodes={bracketTrace} ranked={allergens} />
+        </div>
+      )}
 
       <DashboardLeaderboard
         allergens={finalFourView.allergensForClient}

--- a/components/bracket/bracket-node.tsx
+++ b/components/bracket/bracket-node.tsx
@@ -1,0 +1,162 @@
+/**
+ * BracketNode — single match card (ticket #179)
+ *
+ * Renders a head-to-head matchup with thumbnails, names, and the
+ * Modexa Confidence UI pattern (bar length = discriminative, color
+ * intensity = posterior tier). Winner badge uses Nature Pop sparingly:
+ * only when the winner is the bracket champion AND posterior ≥ 0.75.
+ * All other winners get a muted Champ Blue badge.
+ *
+ * Strict design-system compliance — no black, no gray, no raw hex.
+ */
+
+import type { BracketNodeVM, BracketSideVM } from "./types";
+import { getConfidenceTierByPosterior } from "@/lib/engine/confidence-score";
+import type { ConfidenceTier } from "@/lib/engine/types";
+
+export interface BracketNodeProps {
+  node: BracketNodeVM;
+  /**
+   * Whether this node is the championship match (the final round's
+   * sole match). Only used to decide whether the winner is eligible
+   * for the Nature Pop "champion" badge.
+   */
+  isFinal?: boolean;
+}
+
+/**
+ * Map a posterior-derived tier to a Champ Blue bar color token.
+ * Nature Pop is reserved for the champion badge elsewhere.
+ */
+function barColorForTier(tier: ConfidenceTier): string {
+  switch (tier) {
+    case "very_high":
+      return "bg-brand-primary-dark";
+    case "high":
+      return "bg-brand-primary";
+    case "medium":
+      return "bg-brand-primary-light";
+    case "low":
+    default:
+      return "bg-brand-border";
+  }
+}
+
+function clampPct(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 100;
+  return Math.round(value * 100);
+}
+
+interface SideProps {
+  side: BracketSideVM;
+  isWinner: boolean;
+  isChampion: boolean;
+  label: string;
+}
+
+function Side({ side, isWinner, isChampion, label }: SideProps) {
+  const tier = getConfidenceTierByPosterior(side.posterior);
+  const barWidth = clampPct(side.discriminative);
+  const barColor = barColorForTier(tier);
+
+  return (
+    <div
+      data-testid={`bracket-side-${label}`}
+      data-winner={isWinner ? "true" : "false"}
+      className={[
+        "flex items-center gap-3 rounded-card border px-3 py-2",
+        isWinner
+          ? "border-brand-primary bg-brand-primary-light"
+          : "border-brand-border-light bg-brand-surface opacity-60",
+      ].join(" ")}
+    >
+      {/* Thumbnail — plain <img> to avoid next/image domain config */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={side.thumbnail.src}
+        alt={side.thumbnail.alt}
+        width={40}
+        height={40}
+        className="h-10 w-10 flex-shrink-0 rounded-pill border border-brand-border-light bg-brand-surface-muted"
+      />
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span
+            data-testid={`bracket-side-${label}-name`}
+            className={[
+              "truncate text-sm font-semibold text-brand-primary-dark",
+              isWinner ? "" : "line-through",
+            ].join(" ")}
+          >
+            {side.name}
+          </span>
+          {isWinner && isChampion && (
+            <span
+              data-testid="bracket-champion-badge"
+              className="inline-flex items-center rounded-pill bg-brand-accent px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brand-primary-dark"
+            >
+              Most likely trigger
+            </span>
+          )}
+          {isWinner && !isChampion && (
+            <span
+              data-testid="bracket-winner-badge"
+              className="inline-flex items-center rounded-pill border border-brand-primary bg-brand-surface px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-primary-dark"
+            >
+              Advances
+            </span>
+          )}
+        </div>
+
+        {/* Confidence bar — width encodes discriminative, color encodes tier.
+            Intentionally NO raw percentage label as the primary signal. */}
+        <div
+          data-testid={`bracket-side-${label}-bar`}
+          data-tier={tier}
+          className="mt-1 h-1.5 w-full overflow-hidden rounded-pill bg-brand-surface-muted"
+          role="presentation"
+        >
+          <div
+            className={["h-full rounded-pill", barColor].join(" ")}
+            style={{ width: `${barWidth}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function BracketNode({ node, isFinal = false }: BracketNodeProps) {
+  const { left, right, winnerSide } = node;
+  const winner = winnerSide === "left" ? left : right;
+  const championEligible = isFinal && winner.posterior >= 0.75;
+
+  const accessibleName =
+    `Match: ${left.name} vs ${right.name}, winner ${winner.name}`;
+
+  return (
+    <article
+      data-testid="bracket-node"
+      data-round={node.round}
+      data-match={node.matchId}
+      aria-label={accessibleName}
+      className="flex flex-col gap-2 rounded-card border border-brand-border bg-brand-surface p-2 shadow-sm"
+    >
+      <Side
+        side={left}
+        isWinner={winnerSide === "left"}
+        isChampion={championEligible && winnerSide === "left"}
+        label="left"
+      />
+      <Side
+        side={right}
+        isWinner={winnerSide === "right"}
+        isChampion={championEligible && winnerSide === "right"}
+        label="right"
+      />
+    </article>
+  );
+}

--- a/components/bracket/bracket.tsx
+++ b/components/bracket/bracket.tsx
@@ -1,0 +1,144 @@
+/**
+ * Bracket — grid container (ticket #179)
+ *
+ * Renders a single-elimination bracket as a horizontal grid of columns,
+ * one column per round (round 0 leftmost, Final rightmost). Each column
+ * shows a round label above the match cards.
+ *
+ * This is the bracket UI shell only:
+ *   - No connecting lines between matches (ticket #179-B)
+ *   - No animations / mobile-scroll polish (ticket #179-C)
+ *
+ * Confidence UI pattern (Modexa):
+ *   - Champion card uses "Most likely trigger" hedging — not a flat %
+ *   - Low-posterior (< 0.5) champion renders a "keep tracking" affordance
+ */
+
+import type { BracketMatch } from "@/lib/engine/types";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+import { FDA_DISCLAIMER_LABEL } from "@/components/shared/fda-disclaimer";
+import { BracketNode } from "./bracket-node";
+import {
+  buildBracketVMs,
+  roundLabel,
+  type BracketNodeVM,
+} from "./types";
+
+export interface BracketProps {
+  /** Raw trace from the tournament engine. */
+  nodes: readonly BracketMatch[];
+  /** Ranked leaderboard providing thumbnails + per-allergen confidence. */
+  ranked: readonly RankedAllergen[];
+}
+
+/** Group VMs by round, preserving per-round matchId order. */
+function groupByRound(vms: BracketNodeVM[]): BracketNodeVM[][] {
+  if (vms.length === 0) return [];
+  let maxRound = 0;
+  for (const vm of vms) if (vm.round > maxRound) maxRound = vm.round;
+  const columns: BracketNodeVM[][] = [];
+  for (let r = 0; r <= maxRound; r++) columns.push([]);
+  for (const vm of vms) columns[vm.round].push(vm);
+  // Sort each column by matchId (the trace is already ordered, but be defensive)
+  for (const col of columns) col.sort((a, b) => a.matchId - b.matchId);
+  return columns;
+}
+
+export function Bracket({ nodes, ranked }: BracketProps) {
+  const vms = buildBracketVMs(nodes, ranked);
+
+  if (vms.length === 0) {
+    return (
+      <section
+        data-testid="bracket-empty"
+        aria-label="Tournament bracket"
+        className="rounded-card border border-brand-border bg-brand-surface-muted p-6"
+      >
+        <p className="text-sm text-brand-text-secondary">
+          No matches yet — check in with your symptoms to run a tournament.
+        </p>
+      </section>
+    );
+  }
+
+  const columns = groupByRound(vms);
+  const totalRounds = columns.length;
+
+  // The champion is the winner of the final (last) round's single match.
+  const finalColumn = columns[columns.length - 1];
+  const finalMatch = finalColumn[0];
+  const championSide =
+    finalMatch.winnerSide === "left" ? finalMatch.left : finalMatch.right;
+  const championPosterior = championSide.posterior;
+  const isLowConfidence = championPosterior < 0.5;
+
+  return (
+    <section
+      data-testid="bracket"
+      aria-label="Tournament bracket"
+      className="rounded-card border border-brand-border bg-brand-surface p-4 shadow-sm"
+    >
+      <header className="mb-4">
+        <h2 className="text-lg font-bold text-brand-primary-dark">
+          Tournament Bracket
+        </h2>
+        <p className="mt-1 text-xs text-brand-text-secondary">
+          Head-to-head matchups that produced your most likely trigger.
+        </p>
+      </header>
+
+      {isLowConfidence && (
+        <p
+          data-testid="bracket-low-confidence"
+          className="mb-4 rounded-card border border-brand-border bg-brand-primary-light px-3 py-2 text-xs font-medium text-brand-primary-dark"
+        >
+          Low confidence — keep tracking your symptoms to sharpen these
+          results.
+        </p>
+      )}
+
+      <div
+        data-testid="bracket-grid"
+        className="flex gap-4 overflow-x-auto"
+        style={{ gridTemplateColumns: `repeat(${totalRounds}, minmax(0, 1fr))` }}
+      >
+        {columns.map((column, roundIdx) => {
+          const isFinal = roundIdx === totalRounds - 1;
+          return (
+            <div
+              key={`round-${roundIdx}`}
+              data-testid={`bracket-column-${roundIdx}`}
+              data-round={roundIdx}
+              className="flex min-w-[240px] flex-1 flex-col gap-3"
+            >
+              <h3
+                data-testid={`bracket-round-label-${roundIdx}`}
+                className="text-xs font-semibold uppercase tracking-wider text-brand-text-accent"
+              >
+                {roundLabel(roundIdx, totalRounds)}
+              </h3>
+              <div className="flex flex-col justify-around gap-3">
+                {column.map((vm) => (
+                  <BracketNode
+                    key={`${vm.round}-${vm.matchId}`}
+                    node={vm}
+                    isFinal={isFinal}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <footer className="mt-4 border-t border-brand-border-light pt-3">
+        <p
+          data-testid="bracket-fda-disclaimer"
+          className="text-xs font-medium text-brand-primary-dark"
+        >
+          {FDA_DISCLAIMER_LABEL}
+        </p>
+      </footer>
+    </section>
+  );
+}

--- a/components/bracket/index.ts
+++ b/components/bracket/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Bracket — public entry points (ticket #179).
+ */
+
+export { Bracket } from "./bracket";
+export type { BracketProps } from "./bracket";
+
+export { BracketNode } from "./bracket-node";
+export type { BracketNodeProps } from "./bracket-node";
+
+export {
+  buildBracketVMs,
+  roundLabel,
+} from "./types";
+export type {
+  BracketMatch,
+  BracketNode as BracketNodeTrace,
+  BracketNodeVM,
+  BracketSideVM,
+} from "./types";

--- a/components/bracket/types.ts
+++ b/components/bracket/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Bracket Component Types (ticket #179)
+ *
+ * Client-safe view-model types for the tournament bracket UI.
+ * The raw `BracketMatch` / `BracketNode` shapes are re-exported from
+ * the engine for convenience; the `*VM` types below join each match
+ * with per-side display data (thumbnail + confidence) pulled from the
+ * `RankedAllergen` leaderboard that already feeds the dashboard.
+ */
+
+import type { BracketMatch, BracketNode } from "@/lib/engine/types";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+import {
+  getAllergenThumbnail,
+  type AllergenThumbnail,
+} from "@/lib/allergens/thumbnails";
+
+export type { BracketMatch, BracketNode };
+
+/** One side (left or right) of a rendered bracket node. */
+export interface BracketSideVM {
+  allergenId: string;
+  /** Common name for display; falls back to `allergenId` when unknown. */
+  name: string;
+  thumbnail: AllergenThumbnail;
+  /** Discriminative confidence in [0, 1] — drives bar width. */
+  discriminative: number;
+  /** Posterior confidence in [0, 1] — drives color intensity / tier. */
+  posterior: number;
+}
+
+/** A single match card, joined with display metadata. */
+export interface BracketNodeVM {
+  round: number;
+  matchId: number;
+  left: BracketSideVM;
+  right: BracketSideVM;
+  /** Which side advanced, derived from `winnerId`. */
+  winnerSide: "left" | "right";
+  leftScore: number;
+  rightScore: number;
+}
+
+/**
+ * Build a per-side view model from a raw allergen id by joining against
+ * the ranked leaderboard. Unknown ids fall back to the generic plant
+ * thumbnail, the raw id as a name, and zeroed confidences — this keeps
+ * the component robust to drift between the bracket trace and the
+ * leaderboard slice (shouldn't happen in practice, but we never crash).
+ */
+function buildSide(
+  allergenId: string,
+  byId: Map<string, RankedAllergen>,
+): BracketSideVM {
+  const ranked = byId.get(allergenId);
+  return {
+    allergenId,
+    name: ranked?.common_name ?? allergenId,
+    thumbnail: getAllergenThumbnail(allergenId),
+    discriminative: ranked?.discriminative ?? 0,
+    posterior: ranked?.posterior ?? 0,
+  };
+}
+
+/**
+ * Join a bracket trace (from the engine) with a ranked leaderboard
+ * (from the API / server page) into the VM shape the bracket UI
+ * consumes. Pure: no I/O, deterministic under the same inputs.
+ *
+ * Empty traces return an empty array. Matches missing a `winnerId`
+ * from either side default `winnerSide` to `"left"` — the trace
+ * generator guarantees this won't happen in practice, but defensive.
+ */
+export function buildBracketVMs(
+  trace: readonly BracketMatch[],
+  ranked: readonly RankedAllergen[],
+): BracketNodeVM[] {
+  const byId = new Map<string, RankedAllergen>();
+  for (const r of ranked) byId.set(r.allergen_id, r);
+
+  return trace.map((match): BracketNodeVM => {
+    const left = buildSide(match.leftAllergenId, byId);
+    const right = buildSide(match.rightAllergenId, byId);
+    const winnerSide: "left" | "right" =
+      match.winnerId === match.rightAllergenId ? "right" : "left";
+    return {
+      round: match.round,
+      matchId: match.matchId,
+      left,
+      right,
+      winnerSide,
+      leftScore: match.leftScore,
+      rightScore: match.rightScore,
+    };
+  });
+}
+
+/**
+ * Human-readable label for a round given the total number of rounds
+ * in the bracket. Round 0 is the leftmost column (first matches); the
+ * final round is always labelled "Final".
+ */
+export function roundLabel(roundIndex: number, totalRounds: number): string {
+  // Number of matches in this round = 2^(totalRounds - 1 - roundIndex)
+  const fromEnd = totalRounds - 1 - roundIndex;
+  if (fromEnd <= 0) return "Final";
+  if (fromEnd === 1) return "Semi-finals";
+  if (fromEnd === 2) return "Quarter-finals";
+  const size = 2 ** (fromEnd + 1);
+  return `Round of ${size}`;
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,13 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   {
-    ignores: [".next/", "starters/", ".venv/", "node_modules/"],
+    ignores: [
+      ".next/",
+      "starters/",
+      ".venv/",
+      "node_modules/",
+      ".claude/worktrees/",
+    ],
   },
   ...compat.extends("next/core-web-vitals"),
 ];

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,5 +12,14 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
+    // Exclude agent-harness scratch worktrees — they contain duplicate
+    // copies of the test suite pinned to older branches and are not
+    // part of this checkout's test scope.
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.next/**",
+      "**/.claude/worktrees/**",
+    ],
   },
 });


### PR DESCRIPTION
Closes #179. Parent epic: #155.

## Summary

Ships the first shippable surface of the Allergy Madness bracket epic: a visual grid of match cards that renders `TournamentResult.bracket_trace` (from #194) with two-layer confidence (from #193) and generic allergen thumbnails (from #176). Leaderboard stays in place alongside — this is additive, not a replacement.

## What's in this PR

### New: `components/bracket/`
- **`types.ts`** — `BracketNodeVM` / `BracketSideVM` view-models, pure `buildBracketVMs(trace, ranked)` join helper, `roundLabel(roundIndex, totalRounds)`
- **`bracket-node.tsx`** — single-match card. Confidence bar width = \`discriminative\`; color intensity via \`getConfidenceTierByPosterior(posterior)\`. Loser side: `opacity-60` + line-through (no gray). Champion badge (\"Most likely trigger\") uses Nature Pop **only when `isFinal && posterior >= 0.75`** (respects the 2% rule); non-champion winners get a muted \"Advances\" badge.
- **`bracket.tsx`** — grid container with round-label header, FDA disclaimer footer, low-posterior champion banner (\"keep tracking your symptoms\"), empty-state guard.

### Dashboard wiring (`app/(app)/dashboard/page.tsx`)
Ports the same two-layer confidence logic that lives in `app/api/leaderboard/route.ts` and calls `buildBracketTrace` on the sorted tournament entries. Renders `<Bracket>` above `<DashboardLeaderboard>`. Hidden in Environmental Forecast mode and when the trace is empty. Leaderboard untouched.

### Tests (23 new, all passing)
- `__tests__/bracket/build-vms.test.ts` (5) — round counts, winnerSide resolution, unknown-id fallback
- `__tests__/bracket/bracket-node.test.tsx` (9) — thumbnail rendering, champion badge gating, loser styling, accessible name
- `__tests__/bracket/bracket.test.tsx` (9) — 8/16/32 column layout, FDA disclaimer, low-posterior banner, empty-state

### Incidental
- `eslint.config.mjs` + `vitest.config.ts` — ignore `.claude/worktrees/` (stale agent scratch trees were polluting lint/test runs). No `--no-verify` used.

## Confidence UI pattern (Modexa) — how the rules are enforced

| Rule | Enforcement |
|------|-------------|
| No flat percentage as primary signal | Confidence bar is the primary visual; no \"XX%\" label on the card |
| Hedging language for the champion | \"Most likely trigger\" on the final card; never \"100% confident\" |
| Visible uncertainty for low-confidence | Champion `posterior < 0.5` → muted banner with \"keep tracking\" affordance |
| Tier-aware color | Bar intensity tracks `getConfidenceTierByPosterior(posterior)` |

## Guardrails honored
- No black, no gray, no raw hex — brand tokens only. `__tests__/theme/no-black-consumer-ui.test.ts` still green.
- Nature Pop reserved for final-round high-confidence champion only.
- FDA disclaimer (\"Predicted Triggers — Not a Diagnosis\") rendered on the bracket surface.
- Leaderboard not regressed.

## Out of scope (follow-ups)
- **#179-B** — SVG progression lines between matched nodes
- **#179-C** — slide-in animations, mobile horizontal-scroll polish, keyboard navigation
- Product decision on whether the dashboard eventually replaces the ranked list with the bracket (currently both render)

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 995/995 passing (91 files, 23 new bracket tests)
- [x] `npm run build` — clean
- [ ] Manual: load `/dashboard` with a tournament result, verify bracket renders above leaderboard with expected round labels, confidence bars, and champion badge
- [ ] Manual: `prefers-reduced-motion` is not relevant to this PR (no animations) — animations land in #179-C

Design references (per ticket):
- [Brackets Ninja — image brackets](https://www.bracketsninja.com/types/images-bracket)
- [Flourish tournament chart](https://flourish.studio/visualisations/tournament-chart/)
- [The Confidence UI Pattern (Modexa)](https://medium.com/@Modexa/the-confidence-ui-pattern-that-users-actually-trust-ff27e1a8a956)