### PR TITLE
chore(allergens): enumerate allergen taxonomy + manifest

### DIFF
--- a/__tests__/allergens/taxonomy-coverage.test.ts
+++ b/__tests__/allergens/taxonomy-coverage.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import allergensSeed from "@/lib/data/allergens-seed.json";
+import { ALLERGEN_IDS } from "@/lib/allergens/taxonomy";
+
+/**
+ * Regression guard: every allergen ID that the engine can emit — i.e.
+ * every ID seeded into the Supabase `allergens` reference table — must
+ * also appear in the canonical taxonomy manifest. If this test fails,
+ * an allergen was added to the seed data without a corresponding
+ * taxonomy entry (parent epic #152, ticket #201).
+ */
+
+interface SeedRow {
+  id: string;
+}
+
+describe("taxonomy coverage vs. allergens-seed.json", () => {
+  const seedIds = new Set((allergensSeed as SeedRow[]).map((r) => r.id));
+  const taxonomyIds = new Set(ALLERGEN_IDS);
+
+  it("seed data is non-empty (sanity)", () => {
+    expect(seedIds.size).toBeGreaterThan(0);
+  });
+
+  it("every seed allergen ID is present in ALLERGEN_TAXONOMY", () => {
+    const missing = [...seedIds].filter((id) => !taxonomyIds.has(id));
+    expect(
+      missing,
+      `Seed IDs missing from taxonomy manifest: ${JSON.stringify(missing)}`,
+    ).toEqual([]);
+  });
+
+  it("taxonomy does not contain IDs absent from the seed (no phantom entries)", () => {
+    const extra = [...taxonomyIds].filter((id) => !seedIds.has(id));
+    expect(
+      extra,
+      `Taxonomy IDs with no matching seed row: ${JSON.stringify(extra)}`,
+    ).toEqual([]);
+  });
+
+  it("taxonomy and seed have the same cardinality", () => {
+    expect(taxonomyIds.size).toBe(seedIds.size);
+  });
+});

--- a/__tests__/allergens/taxonomy.test.ts
+++ b/__tests__/allergens/taxonomy.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  ALLERGEN_TAXONOMY,
+  ALLERGEN_IDS,
+  getAllergenEntry,
+  type AllergenCategory,
+} from "@/lib/allergens/taxonomy";
+
+const ALLOWED_CATEGORIES: readonly AllergenCategory[] = [
+  "pollen",
+  "mold",
+  "food",
+  "pet",
+  "dust",
+  "other",
+];
+
+const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+describe("ALLERGEN_TAXONOMY", () => {
+  it("is non-empty", () => {
+    expect(ALLERGEN_TAXONOMY.length).toBeGreaterThan(0);
+  });
+
+  it("every entry has non-empty id, name, slug, and category", () => {
+    for (const entry of ALLERGEN_TAXONOMY) {
+      expect(entry.id, `entry ${JSON.stringify(entry)} missing id`).toBeTruthy();
+      expect(entry.name, `entry ${entry.id} missing name`).toBeTruthy();
+      expect(entry.slug, `entry ${entry.id} missing slug`).toBeTruthy();
+      expect(entry.category, `entry ${entry.id} missing category`).toBeTruthy();
+    }
+  });
+
+  it("IDs are unique", () => {
+    const ids = ALLERGEN_TAXONOMY.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("slugs are unique", () => {
+    const slugs = ALLERGEN_TAXONOMY.map((e) => e.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("slugs are valid kebab-case", () => {
+    for (const entry of ALLERGEN_TAXONOMY) {
+      expect(
+        KEBAB_CASE.test(entry.slug),
+        `slug "${entry.slug}" (id=${entry.id}) is not kebab-case`,
+      ).toBe(true);
+    }
+  });
+
+  it("category is one of the allowed literal values", () => {
+    for (const entry of ALLERGEN_TAXONOMY) {
+      expect(
+        ALLOWED_CATEGORIES.includes(entry.category),
+        `entry ${entry.id} has invalid category "${entry.category}"`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("ALLERGEN_IDS", () => {
+  it("length equals ALLERGEN_TAXONOMY length", () => {
+    expect(ALLERGEN_IDS.length).toBe(ALLERGEN_TAXONOMY.length);
+  });
+
+  it("contains exactly the taxonomy entry IDs", () => {
+    expect([...ALLERGEN_IDS].sort()).toEqual(
+      ALLERGEN_TAXONOMY.map((e) => e.id).sort(),
+    );
+  });
+});
+
+describe("getAllergenEntry", () => {
+  it("returns the entry for a known ID", () => {
+    const first = ALLERGEN_TAXONOMY[0];
+    const found = getAllergenEntry(first.id);
+    expect(found).toBeDefined();
+    expect(found?.id).toBe(first.id);
+    expect(found?.name).toBe(first.name);
+  });
+
+  it("returns undefined for an unknown ID", () => {
+    expect(getAllergenEntry("definitely-not-a-real-allergen-id")).toBeUndefined();
+  });
+
+  it("returns undefined for the empty string", () => {
+    expect(getAllergenEntry("")).toBeUndefined();
+  });
+});

--- a/lib/allergens/taxonomy.ts
+++ b/lib/allergens/taxonomy.ts
@@ -1,0 +1,116 @@
+/**
+ * Allergen taxonomy — canonical enumeration of every allergen ID the
+ * engine can emit. Single source of truth; join key for thumbnails,
+ * confidence scoring, and bracket traces.
+ *
+ * Populated from `lib/data/allergens-seed.json` (the seed data loaded by
+ * `scripts/seed-allergens.ts` into the Supabase `allergens` reference
+ * table). Every ID below appears verbatim in that file; no IDs are
+ * invented here.
+ *
+ * The `category` field collapses the seed's engine-facing categories
+ * (`tree` / `grass` / `weed` / `mold` / `indoor`) into the consumer-facing
+ * taxonomy (pollen / mold / food / pet / dust / other) used for thumbnail
+ * grouping and UI copy:
+ *
+ *   seed tree  | seed grass | seed weed   -> pollen
+ *   seed mold                              -> mold
+ *   seed indoor (dust-mites)               -> dust
+ *   seed indoor (cat-dander, dog-dander)   -> pet
+ *   seed indoor (cockroach, mouse)         -> other
+ *
+ * Parent epic: #152
+ */
+
+export type AllergenCategory =
+  | "pollen"
+  | "mold"
+  | "food"
+  | "pet"
+  | "dust"
+  | "other";
+
+export interface AllergenTaxonomyEntry {
+  /** Canonical ID (engine join key). Kebab-case. */
+  readonly id: string;
+  /** Human-readable display name. */
+  readonly name: string;
+  /** High-level category for grouping and asset resolution. */
+  readonly category: AllergenCategory;
+  /** Kebab-case asset filename slug. Equal to `id` for current entries. */
+  readonly slug: string;
+}
+
+export const ALLERGEN_TAXONOMY: readonly AllergenTaxonomyEntry[] = [
+  // Tree pollens
+  { id: "oak", name: "Oak", category: "pollen", slug: "oak" },
+  { id: "birch", name: "Birch", category: "pollen", slug: "birch" },
+  { id: "cedar-juniper", name: "Cedar / Juniper", category: "pollen", slug: "cedar-juniper" },
+  { id: "elm", name: "Elm", category: "pollen", slug: "elm" },
+  { id: "maple", name: "Maple", category: "pollen", slug: "maple" },
+  { id: "pine", name: "Pine", category: "pollen", slug: "pine" },
+  { id: "ash", name: "Ash", category: "pollen", slug: "ash" },
+  { id: "cottonwood", name: "Cottonwood", category: "pollen", slug: "cottonwood" },
+  { id: "alder", name: "Alder", category: "pollen", slug: "alder" },
+  { id: "walnut", name: "Walnut", category: "pollen", slug: "walnut" },
+  { id: "pecan", name: "Pecan", category: "pollen", slug: "pecan" },
+  { id: "olive", name: "Olive", category: "pollen", slug: "olive" },
+  { id: "hickory", name: "Hickory", category: "pollen", slug: "hickory" },
+  { id: "mulberry", name: "Mulberry", category: "pollen", slug: "mulberry" },
+  { id: "privet", name: "Privet", category: "pollen", slug: "privet" },
+  { id: "cypress", name: "Cypress", category: "pollen", slug: "cypress" },
+  { id: "mesquite", name: "Mesquite", category: "pollen", slug: "mesquite" },
+
+  // Grass pollens
+  { id: "bermuda-grass", name: "Bermuda Grass", category: "pollen", slug: "bermuda-grass" },
+  { id: "timothy-grass", name: "Timothy Grass", category: "pollen", slug: "timothy-grass" },
+  { id: "rye-grass", name: "Rye Grass", category: "pollen", slug: "rye-grass" },
+  { id: "bahia-grass", name: "Bahia Grass", category: "pollen", slug: "bahia-grass" },
+  { id: "johnson-grass", name: "Johnson Grass", category: "pollen", slug: "johnson-grass" },
+  { id: "kentucky-bluegrass", name: "Kentucky Bluegrass", category: "pollen", slug: "kentucky-bluegrass" },
+  { id: "orchard-grass", name: "Orchard Grass", category: "pollen", slug: "orchard-grass" },
+  { id: "sweet-vernal-grass", name: "Sweet Vernal Grass", category: "pollen", slug: "sweet-vernal-grass" },
+
+  // Weed pollens
+  { id: "ragweed", name: "Ragweed", category: "pollen", slug: "ragweed" },
+  { id: "sagebrush", name: "Sagebrush", category: "pollen", slug: "sagebrush" },
+  { id: "lambs-quarters", name: "Lamb's Quarters", category: "pollen", slug: "lambs-quarters" },
+  { id: "pigweed", name: "Pigweed", category: "pollen", slug: "pigweed" },
+  { id: "plantain", name: "Plantain", category: "pollen", slug: "plantain" },
+  { id: "dock-sorrel", name: "Dock / Sorrel", category: "pollen", slug: "dock-sorrel" },
+  { id: "mugwort", name: "Mugwort", category: "pollen", slug: "mugwort" },
+  { id: "cocklebur", name: "Cocklebur", category: "pollen", slug: "cocklebur" },
+  { id: "marsh-elder", name: "Marsh Elder", category: "pollen", slug: "marsh-elder" },
+  { id: "russian-thistle", name: "Russian Thistle", category: "pollen", slug: "russian-thistle" },
+  { id: "nettle", name: "Nettle", category: "pollen", slug: "nettle" },
+
+  // Molds
+  { id: "alternaria", name: "Alternaria", category: "mold", slug: "alternaria" },
+  { id: "aspergillus", name: "Aspergillus", category: "mold", slug: "aspergillus" },
+  { id: "cladosporium", name: "Cladosporium", category: "mold", slug: "cladosporium" },
+  { id: "penicillium", name: "Penicillium", category: "mold", slug: "penicillium" },
+  { id: "stachybotrys", name: "Black Mold", category: "mold", slug: "stachybotrys" },
+  { id: "fusarium", name: "Fusarium", category: "mold", slug: "fusarium" },
+
+  // Indoor — dust
+  { id: "dust-mites", name: "Dust Mites", category: "dust", slug: "dust-mites" },
+
+  // Indoor — pets
+  { id: "cat-dander", name: "Cat Dander", category: "pet", slug: "cat-dander" },
+  { id: "dog-dander", name: "Dog Dander", category: "pet", slug: "dog-dander" },
+
+  // Indoor — other
+  { id: "cockroach", name: "Cockroach", category: "other", slug: "cockroach" },
+  { id: "mouse", name: "Mouse", category: "other", slug: "mouse" },
+] as const;
+
+export const ALLERGEN_IDS: readonly string[] = ALLERGEN_TAXONOMY.map(
+  (e) => e.id,
+);
+
+/** Lookup by ID. Returns undefined for unknown IDs. */
+export function getAllergenEntry(
+  id: string,
+): AllergenTaxonomyEntry | undefined {
+  return ALLERGEN_TAXONOMY.find((e) => e.id === id);
+}


### PR DESCRIPTION
Closes #201. Parent epic: #152. Child (a) of three — the agent-workable prerequisite for #202 (asset procurement, human task) and #203 (populate `THUMBNAIL_MAP` + leaderboard rendering).

## Summary

Introduces `lib/allergens/taxonomy.ts` as the canonical single source of truth for every allergen ID the engine can emit. Join key for thumbnails, confidence scoring, and bracket traces.

## What's in this PR

### New: `lib/allergens/taxonomy.ts`
- `AllergenCategory` union: `"pollen" | "mold" | "food" | "pet" | "dust" | "other"`
- `AllergenTaxonomyEntry` interface: `{ id, name, category, slug }` — all readonly
- `ALLERGEN_TAXONOMY` — 47 entries, populated from `lib/data/allergens-seed.json`
- `ALLERGEN_IDS` — derived ID array
- `getAllergenEntry(id)` — lookup helper, returns undefined for unknown

### Tests (+15 new, all passing)
- `__tests__/allergens/taxonomy.test.ts` (11) — entry shape, uniqueness, kebab-case slugs, category membership, lookup behavior
- `__tests__/allergens/taxonomy-coverage.test.ts` (4) — programmatic diff vs. seed JSON in both directions. This is the "fail loudly" regression guard: if anyone adds an allergen to `allergens-seed.json` without also updating the taxonomy (or vice versa), CI turns red with the missing/extra IDs listed.

## Sources audited

| Source | Role |
|--------|------|
| `lib/data/allergens-seed.json` | **Canonical** — 47 entries with `id`, `common_name`, `category`, Elo/region/LRT props |
| `scripts/seed-allergens.ts` | Runtime seed loader for Supabase |
| `supabase/migrations/20260101000000_base_schema.sql` | Schema only; no hardcoded INSERTs |
| `lib/engine/types.ts` | Types only |
| `__tests__/engine/*.test.ts` | Fixtures via `makeAllergen` helper |
| API routes (`allergens`, `checkin`, `onboarding`, `trigger-scout/scan`) | Import seed JSON directly |

The JSON file is the only enumerated source. All other references read from it.

## Taxonomy breakdown (47 allergens)

| Category | Count | Source `category` field |
|----------|-------|-------------------------|
| `pollen` | 36 | tree (17) + grass (8) + weed (11) |
| `mold` | 6 | mold (6) |
| `dust` | 1 | indoor → dust-mites |
| `pet` | 2 | indoor → cat-dander, dog-dander |
| `other` | 2 | indoor → cockroach, mouse |
| `food` | 0 | (none in current data; kept in union for forward-compat) |

## Design notes

- **Seed `category` is engine-physical, taxonomy `category` is UI-facing.** The seed's `tree/grass/weed/mold/indoor` drives pollen-source logic in the engine; the taxonomy's `pollen/mold/food/pet/dust/other` is the consumer grouping requested by the ticket. Kept separate deliberately so future UI refactors can't accidentally break engine behavior.
- **Slug rule:** kebab-case derived from ID. Seed IDs are already kebab-case, so `slug === id` for every current entry. Rule documented for future entries in case anyone adds a snake_case ID.
- **Readonly all the way down.** The manifest is declared `as const` with `readonly` fields so TS callers can't mutate it and the compiler preserves literal types.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1010/1010 passing (93 files; +15 new tests, +2 new files)
- [x] `npm run build` — clean

## Unblocks
- **#202** — asset procurement (human task). The manifest is the procurement worklist.
- **#203** — wire `THUMBNAIL_MAP` + leaderboard rendering (agent-workable once #202 lands).

## Non-goals
- No asset sourcing (that's #202)
- No `THUMBNAIL_MAP` changes (that's #203)
- No engine or seed modifications (read-only audit)