### PR TITLE
polish(engine): PDF migration + final-four narrowing + confidence docs

### DIFF
--- a/__tests__/api/report-pdf.test.ts
+++ b/__tests__/api/report-pdf.test.ts
@@ -256,7 +256,10 @@ describe("GET /api/report/pdf", () => {
     expect(callArg.region).toBeNull();
   });
 
-  it("computes confidence tiers correctly", async () => {
+  it("computes confidence tiers via posterior model (issue #193)", async () => {
+    // With 6 allergens and topK=4 (default), the Monte Carlo posterior
+    // assigns ~1.0 to the top 4 (very_high) and ~0.0 to the bottom 2
+    // (low) when the Elo gaps are large enough that noise cannot reorder.
     mockCreateClient.mockResolvedValue(
       createMockSupabaseClient({
         eloRows: [
@@ -288,6 +291,20 @@ describe("GET /api/report/pdf", () => {
             negative_signals: 1,
             allergens: { common_name: "Dust", category: "indoor" },
           },
+          {
+            allergen_id: "a5",
+            elo_score: 1100,
+            positive_signals: 1,
+            negative_signals: 0,
+            allergens: { common_name: "Cat", category: "animal" },
+          },
+          {
+            allergen_id: "a6",
+            elo_score: 1000,
+            positive_signals: 0,
+            negative_signals: 0,
+            allergens: { common_name: "Dog", category: "animal" },
+          },
         ],
       }) as unknown as Awaited<ReturnType<typeof createClient>>
     );
@@ -295,13 +312,13 @@ describe("GET /api/report/pdf", () => {
     await GET();
 
     const callArg = mockGenerateReportPdf.mock.calls[0][0];
-    // 35 signals = very_high
+    // Top 4 by Elo → posterior ≈ 1.0 → very_high
     expect(callArg.allergens[0].confidence_tier).toBe("very_high");
-    // 15 signals = high
-    expect(callArg.allergens[1].confidence_tier).toBe("high");
-    // 8 signals = medium
-    expect(callArg.allergens[2].confidence_tier).toBe("medium");
-    // 3 signals = low
-    expect(callArg.allergens[3].confidence_tier).toBe("low");
+    expect(callArg.allergens[1].confidence_tier).toBe("very_high");
+    expect(callArg.allergens[2].confidence_tier).toBe("very_high");
+    expect(callArg.allergens[3].confidence_tier).toBe("very_high");
+    // Bottom 2 → posterior ≈ 0.0 → low
+    expect(callArg.allergens[4].confidence_tier).toBe("low");
+    expect(callArg.allergens[5].confidence_tier).toBe("low");
   });
 });

--- a/app/api/report/pdf/route.ts
+++ b/app/api/report/pdf/route.ts
@@ -14,7 +14,12 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { generateReportPdf } from "@/lib/pdf";
 import type { PdfAllergenEntry } from "@/lib/pdf";
-import { getConfidenceTierBySignals } from "@/lib/engine";
+import {
+  getConfidenceTierBySignals,
+  getPosteriorConfidence,
+  getConfidenceTierByPosterior,
+} from "@/lib/engine";
+import type { TournamentEntry } from "@/lib/engine";
 
 /** Shape returned by the Supabase join query */
 interface EloRowWithAllergen {
@@ -95,16 +100,34 @@ export async function GET() {
     );
   }
 
-  // Map to PDF allergen entries
-  const allergens: PdfAllergenEntry[] = eloRows.map((row, index) => ({
-    rank: index + 1,
+  // Two-layer confidence model (issue #193) — mirrors the logic in
+  // `app/api/leaderboard/route.ts` so the PDF report's tier string
+  // matches the leaderboard byte-for-byte.
+  const tournamentEntries: TournamentEntry[] = eloRows.map((row) => ({
+    allergen_id: row.allergen_id,
     common_name: row.allergens.common_name,
-    category: row.allergens.category as PdfAllergenEntry["category"],
-    elo_score: row.elo_score,
-    confidence_tier: getConfidenceTierBySignals(
-      row.positive_signals + row.negative_signals
-    ),
+    category: row.allergens.category,
+    composite_score: row.elo_score,
+    tier: "low" as const,
   }));
+  const posteriors = getPosteriorConfidence(tournamentEntries, { seed: 0 });
+
+  // Map to PDF allergen entries
+  const allergens: PdfAllergenEntry[] = eloRows.map((row, index) => {
+    const totalSignals = row.positive_signals + row.negative_signals;
+    const posterior = posteriors[row.allergen_id] ?? 0;
+    return {
+      rank: index + 1,
+      common_name: row.allergens.common_name,
+      category: row.allergens.category as PdfAllergenEntry["category"],
+      elo_score: row.elo_score,
+      // Tier derives from the posterior (issue #193). Falls back to the
+      // legacy signal-count tier if the posterior is non-finite.
+      confidence_tier: Number.isFinite(posterior)
+        ? getConfidenceTierByPosterior(posterior)
+        : getConfidenceTierBySignals(totalSignals),
+    };
+  });
 
   // Generate PDF
   const pdfBuffer = generateReportPdf({

--- a/components/leaderboard/final-four.tsx
+++ b/components/leaderboard/final-four.tsx
@@ -19,6 +19,13 @@ import { CategoryIcon } from "./category-icon";
 import { BlurOverlay } from "./blur-overlay";
 import { FinalFourUnlockCta } from "./final-four-unlock-cta";
 
+/** Type guard that narrows `score` from `number | null` to `number`. */
+function hasNumericScore(
+  allergen: GatedRankedAllergen,
+): allergen is GatedRankedAllergen & { score: number } {
+  return allergen.score !== null;
+}
+
 function FinalFourCard({ allergen }: { allergen: GatedRankedAllergen }) {
   const locked = allergen.locked;
 
@@ -36,7 +43,7 @@ function FinalFourCard({ allergen }: { allergen: GatedRankedAllergen }) {
         >
           #{allergen.rank}
         </span>
-        {!locked && allergen.score !== null && (
+        {!locked && hasNumericScore(allergen) && (
           <ConfidenceBadge score={allergen.score} variant="compact" />
         )}
       </div>

--- a/lib/engine/confidence-score.ts
+++ b/lib/engine/confidence-score.ts
@@ -37,7 +37,11 @@ import { createSeededRng } from "./monte-carlo";
 /* Legacy signal-count curve (kept for migration / back-compat)        */
 /* ------------------------------------------------------------------ */
 
-/** Anchor points for the piecewise-linear score curve. Must be sorted by signals asc. */
+/**
+ * Anchor points for the piecewise-linear score curve. Must be sorted by signals asc.
+ * Monotonic non-decreasing across the domain [0, Infinity); returns 0 for non-positive
+ * inputs and <=1 for any finite positive input.
+ */
 const SCORE_ANCHORS: { signals: number; score: number }[] = [
   { signals: 0, score: 0 },
   { signals: 7, score: 0.5 },


### PR DESCRIPTION
Closes #188. Three non-blocking suggestions from PR #187 review, consolidated.

## Summary

- PDF report now uses posterior-based tiers matching the leaderboard
- Final-four badge prop narrowed from `number | null` to `number`
- Confidence-score anchor table documents the monotonic invariant

## Changes

### 1. PDF report migration (`app/api/report/pdf/route.ts`)

The PDF route was using `getConfidenceTierBySignals(totalSignals)` to compute tier strings. The leaderboard migrated to `getConfidenceTierByPosterior` in PR #196, so the PDF could show different tiers than the leaderboard for the same allergen.

Fix: builds `TournamentEntry[]` from Elo rows, runs `getPosteriorConfidence({ seed: 0 })` (identical to the leaderboard route), and derives tiers from `getConfidenceTierByPosterior(posterior)`. Defense-in-depth fallback to `getConfidenceTierBySignals(totalSignals)` if posterior is non-finite.

PDF and leaderboard now produce byte-identical tier strings.

### 2. Final-four type narrowing (`components/leaderboard/final-four.tsx`)

Added a `hasNumericScore()` type guard function that narrows `GatedRankedAllergen` so `allergen.score` is typed `number` (not `number | null`) after the guard. No `as number` casts needed.

### 3. Confidence-score docs (`lib/engine/confidence-score.ts`)

Added monotonic-non-decreasing invariant comment on `SCORE_ANCHORS`: *"Monotonic non-decreasing across the domain [0, ∞); returns 0 for non-positive inputs and ≤1 for any finite positive input."*

## `getConfidenceTierBySignals` retention

Still used as a defense-in-depth fallback in `pdf/route.ts`, `leaderboard/route.ts`, and `dashboard/page.tsx`, plus tested directly. Not safe to delete yet — will be addressed when all three routes share a single `buildRankedFromEloRows` helper (#200).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1012/1012 passing
- [x] `npm run build` — clean
- [x] Boundary tests at 0.499/0.5/0.749/0.75 — unchanged and passing
- [x] PDF confidence test updated to assert posterior-based tiers (6-allergen fixture for topK=4 variation)

## Files modified
- `app/api/report/pdf/route.ts`
- `components/leaderboard/final-four.tsx`
- `lib/engine/confidence-score.ts`
- `__tests__/api/report-pdf.test.ts`