### PR TITLE
feat(leaderboard): render allergen thumbnails on leaderboard rows

### DIFF
--- a/__tests__/components/leaderboard/final-four.test.tsx
+++ b/__tests__/components/leaderboard/final-four.test.tsx
@@ -109,6 +109,19 @@ describe("FinalFour", () => {
       );
       expect(screen.queryByTestId("final-four-unlock-cta")).toBeNull();
     });
+
+    it("renders allergen thumbnails for unlocked cards", () => {
+      render(
+        <FinalFour allergens={mockUnlockedAllergens} isUnlocked={true} />,
+      );
+      const thumbs = screen.getAllByAltText("Pollen allergen thumbnail");
+      expect(thumbs.length).toBe(3);
+      thumbs.forEach((img) => {
+        expect(img.getAttribute("src")).toBe("/allergens/generic-plant.svg");
+        expect(img.getAttribute("width")).toBe("48");
+        expect(img.getAttribute("height")).toBe("48");
+      });
+    });
   });
 
   describe("locked (free tier, < 3 referral credits)", () => {
@@ -198,6 +211,13 @@ describe("FinalFour", () => {
       );
       expect(screen.getByTestId("final-four-unlock-invite")).toBeDefined();
       expect(screen.getByTestId("final-four-unlock-upgrade")).toBeDefined();
+    });
+
+    it("does NOT render thumbnails for locked/redacted cards", () => {
+      render(
+        <FinalFour allergens={mockLockedAllergens} isUnlocked={false} />,
+      );
+      expect(screen.queryByAltText("Pollen allergen thumbnail")).toBeNull();
     });
   });
 

--- a/__tests__/components/leaderboard/leaderboard.test.tsx
+++ b/__tests__/components/leaderboard/leaderboard.test.tsx
@@ -140,6 +140,17 @@ describe("Leaderboard", () => {
       render(<Leaderboard {...defaultProps} />);
       expect(screen.getByText("Dust Mites")).toBeDefined();
     });
+
+    it("renders allergen thumbnails in the champion card and full rankings rows", () => {
+      render(<Leaderboard {...defaultProps} isPremium={true} />);
+      // Champion (1) + Full Rankings rows (2) = 3 thumbnails minimum
+      // (Final Four thumbnails are in their own sub-component)
+      const thumbs = screen.getAllByAltText("Pollen allergen thumbnail");
+      expect(thumbs.length).toBeGreaterThanOrEqual(3);
+      thumbs.forEach((img) => {
+        expect(img.getAttribute("src")).toBe("/allergens/generic-plant.svg");
+      });
+    });
   });
 
   describe("free-tier user (blurred Final Four)", () => {

--- a/__tests__/components/leaderboard/trigger-champion-card.test.tsx
+++ b/__tests__/components/leaderboard/trigger-champion-card.test.tsx
@@ -54,4 +54,13 @@ describe("TriggerChampionCard", () => {
     render(<TriggerChampionCard allergen={mockChampion} />);
     expect(screen.getByTestId("trigger-champion-card")).toBeDefined();
   });
+
+  it("renders an allergen thumbnail with alt text", () => {
+    render(<TriggerChampionCard allergen={mockChampion} />);
+    const img = screen.getByAltText("Pollen allergen thumbnail");
+    expect(img).toBeDefined();
+    expect(img.getAttribute("src")).toBe("/allergens/generic-plant.svg");
+    expect(img.getAttribute("width")).toBe("48");
+    expect(img.getAttribute("height")).toBe("48");
+  });
 });

--- a/components/leaderboard/final-four.tsx
+++ b/components/leaderboard/final-four.tsx
@@ -18,6 +18,7 @@ import { ConfidenceBadge } from "@/components/shared/confidence-badge";
 import { CategoryIcon } from "./category-icon";
 import { BlurOverlay } from "./blur-overlay";
 import { FinalFourUnlockCta } from "./final-four-unlock-cta";
+import { getAllergenThumbnail } from "@/lib/allergens/thumbnails";
 
 /** Type guard that narrows `score` from `number | null` to `number`. */
 function hasNumericScore(
@@ -28,6 +29,7 @@ function hasNumericScore(
 
 function FinalFourCard({ allergen }: { allergen: GatedRankedAllergen }) {
   const locked = allergen.locked;
+  const thumb = getAllergenThumbnail(allergen.allergen_id);
 
   return (
     <div
@@ -50,6 +52,17 @@ function FinalFourCard({ allergen }: { allergen: GatedRankedAllergen }) {
 
       {/* Allergen info (silhouette if locked) */}
       <div className="flex items-center gap-2">
+        {/* Thumbnail — skip for locked/redacted rows (generic icon next to "???" is meaningless) */}
+        {!locked && (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img
+            src={thumb.src}
+            alt={thumb.alt}
+            width={48}
+            height={48}
+            className="h-12 w-12 flex-shrink-0 rounded-xl"
+          />
+        )}
         <CategoryIcon category={allergen.category} />
         <div>
           <p

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -27,6 +27,7 @@ import { CategoryIcon } from "./category-icon";
 import { UpgradeCta } from "@/components/subscription/upgrade-cta";
 import { PfasPanel } from "@/components/pfas/pfas-panel";
 import type { PfasCrossReactivity } from "@/lib/pfas/types";
+import { getAllergenThumbnail } from "@/lib/allergens/thumbnails";
 import type { RankedAllergen, GatedRankedAllergen } from "./types";
 
 export interface LeaderboardClientProps {
@@ -224,7 +225,9 @@ export function Leaderboard({
             data-testid="full-rankings"
             className="divide-y divide-brand-border-light rounded-card border border-brand-border bg-white"
           >
-            {fullRankings.map((allergen) => (
+            {fullRankings.map((allergen) => {
+              const thumb = getAllergenThumbnail(allergen.allergen_id);
+              return (
               <div
                 key={allergen.allergen_id}
                 data-testid="ranked-allergen-row"
@@ -234,6 +237,15 @@ export function Leaderboard({
                   <span className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-surface-muted text-xs font-bold text-brand-text-muted">
                     #{allergen.rank}
                   </span>
+                  {/* Thumbnail — plain <img> for SVG compat, matches bracket-node pattern (#179) */}
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={thumb.src}
+                    alt={thumb.alt}
+                    width={48}
+                    height={48}
+                    className="h-12 w-12 flex-shrink-0 rounded-xl"
+                  />
                   <CategoryIcon category={allergen.category} />
                   <span className="text-sm font-medium text-brand-primary-dark">
                     {allergen.common_name}
@@ -272,7 +284,8 @@ export function Leaderboard({
                   </div>
                 )}
               </div>
-            ))}
+              );
+            })}
           </div>
 
           {/* Upgrade CTA for free users */}

--- a/components/leaderboard/trigger-champion-card.tsx
+++ b/components/leaderboard/trigger-champion-card.tsx
@@ -8,8 +8,11 @@
 import type { TriggerChampionCardProps } from "./types";
 import { ConfidenceBadge } from "@/components/shared/confidence-badge";
 import { CategoryIcon } from "./category-icon";
+import { getAllergenThumbnail } from "@/lib/allergens/thumbnails";
 
 export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
+  const thumb = getAllergenThumbnail(allergen.allergen_id);
+
   return (
     <div
       data-testid="trigger-champion-card"
@@ -30,8 +33,17 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
         </h2>
       </div>
 
-      {/* Allergen name + category */}
+      {/* Allergen name + thumbnail + category */}
       <div className="mb-3 flex items-center gap-3">
+        {/* Thumbnail — plain <img> for SVG compat, matches bracket-node pattern (#179) */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={thumb.src}
+          alt={thumb.alt}
+          width={48}
+          height={48}
+          className="h-12 w-12 flex-shrink-0 rounded-xl"
+        />
         <CategoryIcon category={allergen.category} />
         <h3
           data-testid="champion-name"


### PR DESCRIPTION
Closes #178. Parent epic: #152. Wires `getAllergenThumbnail` into every leaderboard component that renders an allergen name.

## Summary

Every leaderboard surface now renders a 48×48 thumbnail left of the allergen name using the generic Dusty Denim fallback. Bespoke per-allergen assets will appear automatically when #202 (asset procurement) and #203 (populate THUMBNAIL_MAP) land — no further component changes needed.

## Render sites audited

| Component | Surface | Thumbnail? | Locked handling |
|-----------|---------|------------|-----------------|
| `trigger-champion-card.tsx` | #1 champion card | Yes — left of name | N/A (champion always unlocked) |
| `final-four.tsx` → `FinalFourCard` | #2–#4 Final Four cards | Yes when unlocked, skip when locked | `{!locked && <img>}` — no generic icon next to "???" |
| `leaderboard.tsx` | Full rankings rows (#5+) | Yes — left of name | N/A (always visible) |

No other components in `components/leaderboard/` render `common_name` — remaining grep hits were type definitions and backward-compat mapping.

## Implementation details

- **Plain `<img>` (not `next/image`)** — matches the bracket-node pattern from PR #199. Local SVGs in `/public/` at 48×48 don't benefit from next/image optimization, and avoiding it sidesteps SVG domain config.
- **`getAllergenThumbnail(allergen.allergen_id)`** — types use `allergen_id` field (not `id`). All calls go through the helper; no inlined paths.
- **`rounded-xl`** on all thumbnails — consistent with bracket nodes.
- **`eslint-disable-next-line @next/next/no-img-element`** — same suppression pattern as bracket-node.tsx.

## Tests added (+4)

- `trigger-champion-card.test.tsx` — thumbnail renders with correct alt/src/dimensions
- `final-four.test.tsx` — thumbnails render for unlocked cards; thumbnails do NOT render for locked cards
- `leaderboard.test.tsx` — thumbnails render in champion + full rankings rows

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1025/1025 passing (95 files; +4 new tests)
- [x] `npm run build` — clean
- [x] No-black regression guard still passes
- [ ] Manual: visual QA on dashboard (free user: locked Final Four has no thumbnails; premium: all rows have thumbnails)

## Files modified
- `components/leaderboard/trigger-champion-card.tsx`
- `components/leaderboard/final-four.tsx`
- `components/leaderboard/leaderboard.tsx`
- `__tests__/components/leaderboard/trigger-champion-card.test.tsx`
- `__tests__/components/leaderboard/final-four.test.tsx`
- `__tests__/components/leaderboard/leaderboard.test.tsx`