### PR TITLE
feat(bracket): BracketLines CSS progression connectors in Champ Blue

### DIFF
--- a/__tests__/bracket/bracket-lines.test.tsx
+++ b/__tests__/bracket/bracket-lines.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * BracketConnector / bracket lines — tests (ticket #180)
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Bracket } from "@/components/bracket/bracket";
+import { BracketConnector } from "@/components/bracket/bracket-lines";
+import { buildBracketTrace } from "@/lib/engine/tournament";
+import type { TournamentEntry } from "@/lib/engine/types";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+function makeEntries(n: number): TournamentEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    allergen_id: `a-${i + 1}`,
+    common_name: `Allergen ${i + 1}`,
+    category: "pollen",
+    composite_score: 1000 - i * 10,
+    tier: "low" as const,
+  }));
+}
+
+function makeRanked(n: number): RankedAllergen[] {
+  return Array.from({ length: n }, (_, i) => ({
+    allergen_id: `a-${i + 1}`,
+    common_name: `Allergen ${i + 1}`,
+    category: "pollen" as RankedAllergen["category"],
+    elo_score: 1000 - i * 10,
+    confidence_tier: "medium",
+    score: 0.6,
+    discriminative: 0.5,
+    posterior: 0.8,
+    rank: i + 1,
+  }));
+}
+
+describe("BracketConnector (unit)", () => {
+  it("renders nothing when sourceMatchCount is 0", () => {
+    const { container } = render(<BracketConnector sourceMatchCount={0} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when sourceMatchCount is 1 (no pairs)", () => {
+    const { container } = render(<BracketConnector sourceMatchCount={1} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders 1 pair for sourceMatchCount=2", () => {
+    render(<BracketConnector sourceMatchCount={2} />);
+    expect(screen.getByTestId("bracket-connector")).toBeDefined();
+    expect(screen.getByTestId("bracket-connector-pair-0")).toBeDefined();
+    expect(screen.queryByTestId("bracket-connector-pair-1")).toBeNull();
+  });
+
+  it("renders 2 pairs for sourceMatchCount=4", () => {
+    render(<BracketConnector sourceMatchCount={4} />);
+    expect(screen.getByTestId("bracket-connector-pair-0")).toBeDefined();
+    expect(screen.getByTestId("bracket-connector-pair-1")).toBeDefined();
+    expect(screen.queryByTestId("bracket-connector-pair-2")).toBeNull();
+  });
+
+  it("is aria-hidden for screen readers", () => {
+    render(<BracketConnector sourceMatchCount={2} />);
+    const connector = screen.getByTestId("bracket-connector");
+    expect(connector.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("Bracket with lines (integration)", () => {
+  it.each([
+    // [bracketSize, totalRounds, connectorCount]
+    // 8 entries: 3 rounds, connectors between r0-r1 (4 matches) and r1-r2 (2 matches) = 2 connectors
+    [8, 2],
+    // 16 entries: 4 rounds, connectors between r0-r1, r1-r2, r2-r3 = 3 connectors
+    [16, 3],
+    // 32 entries: 5 rounds, connectors between r0-r1, r1-r2, r2-r3, r3-r4 = 4 connectors
+    [32, 4],
+  ])(
+    "renders %i-entry bracket with %i connector columns",
+    (size, expectedConnectors) => {
+      const trace = buildBracketTrace(makeEntries(size));
+      render(<Bracket nodes={trace} ranked={makeRanked(size)} />);
+      const connectors = screen.getAllByTestId("bracket-connector");
+      expect(connectors).toHaveLength(expectedConnectors);
+    },
+  );
+
+  it("8-entry bracket: connector pair counts are [2, 1]", () => {
+    // Round 0 has 4 matches -> 2 pairs, Round 1 has 2 matches -> 1 pair
+    const trace = buildBracketTrace(makeEntries(8));
+    render(<Bracket nodes={trace} ranked={makeRanked(8)} />);
+    const connectors = screen.getAllByTestId("bracket-connector");
+    // First connector (round 0 -> 1): 4 source matches = 2 pairs
+    expect(
+      connectors[0].querySelectorAll("[data-testid^='bracket-connector-pair-']")
+        .length,
+    ).toBe(2);
+    // Second connector (round 1 -> 2): 2 source matches = 1 pair
+    expect(
+      connectors[1].querySelectorAll("[data-testid^='bracket-connector-pair-']")
+        .length,
+    ).toBe(1);
+  });
+
+  it("16-entry bracket: connector pair counts are [4, 2, 1]", () => {
+    const trace = buildBracketTrace(makeEntries(16));
+    render(<Bracket nodes={trace} ranked={makeRanked(16)} />);
+    const connectors = screen.getAllByTestId("bracket-connector");
+    expect(
+      connectors[0].querySelectorAll("[data-testid^='bracket-connector-pair-']")
+        .length,
+    ).toBe(4);
+    expect(
+      connectors[1].querySelectorAll("[data-testid^='bracket-connector-pair-']")
+        .length,
+    ).toBe(2);
+    expect(
+      connectors[2].querySelectorAll("[data-testid^='bracket-connector-pair-']")
+        .length,
+    ).toBe(1);
+  });
+
+  it("does not render connectors when showLines is false", () => {
+    const trace = buildBracketTrace(makeEntries(8));
+    render(
+      <Bracket nodes={trace} ranked={makeRanked(8)} showLines={false} />,
+    );
+    expect(screen.queryByTestId("bracket-connector")).toBeNull();
+  });
+
+  it("does not render connectors for empty bracket", () => {
+    render(<Bracket nodes={[]} ranked={[]} />);
+    expect(screen.queryByTestId("bracket-connector")).toBeNull();
+  });
+
+  it("connector elements use brand-primary border color", () => {
+    render(<BracketConnector sourceMatchCount={2} />);
+    const pair = screen.getByTestId("bracket-connector-pair-0");
+    const divs = pair.querySelectorAll("div");
+    // Each elbow div should have the border-brand-primary class
+    for (const div of divs) {
+      expect(div.className).toContain("border-brand-primary");
+    }
+  });
+});

--- a/components/bracket/bracket-lines.tsx
+++ b/components/bracket/bracket-lines.tsx
@@ -1,0 +1,56 @@
+/**
+ * BracketConnector — CSS-based connecting lines between bracket rounds
+ * (ticket #180)
+ *
+ * Renders between two adjacent round columns in the bracket flex layout.
+ * For each pair of feeder matches (2K, 2K+1) in round N, draws an
+ * elbow connector that merges into the corresponding match K in round N+1.
+ *
+ * Layout: three sub-columns per connector gap:
+ *   1. Right stubs — short horizontal lines exiting each match in round N
+ *   2. Vertical merge — a vertical bar spanning each feeder pair, with a
+ *      midpoint horizontal stub entering the next round
+ *   3. Left stubs — short horizontal lines entering each match in round N+1
+ *
+ * All strokes use brand-primary (Champ Blue) via border color tokens.
+ * No raw hex, no black, no gray.
+ */
+
+export interface BracketConnectorProps {
+  /** Number of matches in the source (left) round. */
+  sourceMatchCount: number;
+}
+
+/**
+ * A single connector column placed between two adjacent bracket rounds.
+ *
+ * The source round has `sourceMatchCount` matches; the target round has
+ * `sourceMatchCount / 2` matches. Each pair of source matches merges
+ * into one target match.
+ */
+export function BracketConnector({ sourceMatchCount }: BracketConnectorProps) {
+  const pairCount = Math.floor(sourceMatchCount / 2);
+
+  if (pairCount === 0) return null;
+
+  return (
+    <div
+      data-testid="bracket-connector"
+      className="flex flex-col justify-around"
+      aria-hidden="true"
+    >
+      {Array.from({ length: pairCount }, (_, pairIdx) => (
+        <div
+          key={pairIdx}
+          data-testid={`bracket-connector-pair-${pairIdx}`}
+          className="flex flex-col"
+        >
+          {/* Top half — upper feeder match elbow */}
+          <div className="h-8 w-6 border-r-2 border-t-2 border-brand-primary rounded-tr-lg" />
+          {/* Bottom half — lower feeder match elbow */}
+          <div className="h-8 w-6 border-r-2 border-b-2 border-brand-primary rounded-br-lg" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/bracket/bracket.tsx
+++ b/components/bracket/bracket.tsx
@@ -18,6 +18,7 @@ import type { BracketMatch } from "@/lib/engine/types";
 import type { RankedAllergen } from "@/components/leaderboard/types";
 import { FDA_DISCLAIMER_LABEL } from "@/components/shared/fda-disclaimer";
 import { BracketNode } from "./bracket-node";
+import { BracketConnector } from "./bracket-lines";
 import {
   buildBracketVMs,
   roundLabel,
@@ -29,6 +30,8 @@ export interface BracketProps {
   nodes: readonly BracketMatch[];
   /** Ranked leaderboard providing thumbnails + per-allergen confidence. */
   ranked: readonly RankedAllergen[];
+  /** Whether to render connecting lines between rounds. Defaults to true. */
+  showLines?: boolean;
 }
 
 /** Group VMs by round, preserving per-round matchId order. */
@@ -44,7 +47,7 @@ function groupByRound(vms: BracketNodeVM[]): BracketNodeVM[][] {
   return columns;
 }
 
-export function Bracket({ nodes, ranked }: BracketProps) {
+export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
   const vms = buildBracketVMs(nodes, ranked);
 
   if (vms.length === 0) {
@@ -105,27 +108,31 @@ export function Bracket({ nodes, ranked }: BracketProps) {
         {columns.map((column, roundIdx) => {
           const isFinal = roundIdx === totalRounds - 1;
           return (
-            <div
-              key={`round-${roundIdx}`}
-              data-testid={`bracket-column-${roundIdx}`}
-              data-round={roundIdx}
-              className="flex min-w-[240px] flex-1 flex-col gap-3"
-            >
-              <h3
-                data-testid={`bracket-round-label-${roundIdx}`}
-                className="text-xs font-semibold uppercase tracking-wider text-brand-text-accent"
+            <div key={`round-group-${roundIdx}`} className="flex">
+              <div
+                data-testid={`bracket-column-${roundIdx}`}
+                data-round={roundIdx}
+                className="flex min-w-[240px] flex-1 flex-col gap-3"
               >
-                {roundLabel(roundIdx, totalRounds)}
-              </h3>
-              <div className="flex flex-col justify-around gap-3">
-                {column.map((vm) => (
-                  <BracketNode
-                    key={`${vm.round}-${vm.matchId}`}
-                    node={vm}
-                    isFinal={isFinal}
-                  />
-                ))}
+                <h3
+                  data-testid={`bracket-round-label-${roundIdx}`}
+                  className="text-xs font-semibold uppercase tracking-wider text-brand-text-accent"
+                >
+                  {roundLabel(roundIdx, totalRounds)}
+                </h3>
+                <div className="flex flex-col justify-around gap-3">
+                  {column.map((vm) => (
+                    <BracketNode
+                      key={`${vm.round}-${vm.matchId}`}
+                      node={vm}
+                      isFinal={isFinal}
+                    />
+                  ))}
+                </div>
               </div>
+              {showLines && !isFinal && (
+                <BracketConnector sourceMatchCount={column.length} />
+              )}
             </div>
           );
         })}

--- a/components/bracket/index.ts
+++ b/components/bracket/index.ts
@@ -8,6 +8,9 @@ export type { BracketProps } from "./bracket";
 export { BracketNode } from "./bracket-node";
 export type { BracketNodeProps } from "./bracket-node";
 
+export { BracketConnector } from "./bracket-lines";
+export type { BracketConnectorProps } from "./bracket-lines";
+
 export {
   buildBracketVMs,
   roundLabel,


### PR DESCRIPTION
Closes #180. Parent epic: #155. Adds visual connecting lines between bracket nodes showing the winner's progression path through each round.

## Summary

Renders Champ Blue (brand-primary) CSS border-based connectors between matched bracket nodes. Each pair of feeder matches in round N merges into their shared parent match in round N+1 via elbow-shaped connector lines.

## Approach: CSS borders (not SVG overlay)

Chose CSS `border-r-2 border-t-2 border-b-2 border-brand-primary` with rounded corners over an SVG overlay because:
- Integrates cleanly with the existing flex layout — no DOM rect measurement
- No resize/repositioning complexity — borders flow with the grid naturally
- Simpler to maintain and test
- Matches the semantic structure (connectors live between round columns)

## How it works

The bracket's flex row now interleaves `BracketConnector` components between round columns:

```
[Round 1 column] [Connector] [Round 2 column] [Connector] [Round 3 column] ... [Final]
```

Each connector renders elbow pairs — one per two feeder matches — that visually merge adjacent matches into their shared target in the next round.

## Connector counts

| Bracket size | Rounds | Connector columns | Total elbow pairs |
|-------------|--------|-------------------|-------------------|
| 8 nodes | 3 | 2 | 3 (2+1) |
| 16 nodes | 4 | 3 | 7 (4+2+1) |
| 32 nodes | 5 | 4 | 15 (8+4+2+1) |

## Files

**New:**
- `components/bracket/bracket-lines.tsx` — `BracketConnector` component
- `__tests__/bracket/bracket-lines.test.tsx` — 13 tests (unit + integration)

**Modified:**
- `components/bracket/bracket.tsx` — `showLines` prop (default `true`), interleaved connectors
- `components/bracket/index.ts` — exports `BracketConnector`, `BracketConnectorProps`

## Design system

- Stroke color: `border-brand-primary` (Champ Blue) — no raw hex
- Line width: `border-2` (2px)
- Rounded corners on elbows: `rounded-tr-lg rounded-br-lg`
- No black, no gray — regression guard passes

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1038/1038 passing (97 files; +13 new tests)
- [x] `npm run build` — clean
- [x] No-black regression guard passes
- [x] Existing bracket tests unchanged and passing

## Non-goals (deferred to #181)
- Mobile-specific line styling
- Slide-in animations
- Keyboard navigation