### PR TITLE
feat(a11y): NavBar aria-label + aria-current + authState JSDoc

### DIFF
--- a/__tests__/components/layout/nav-bar.test.tsx
+++ b/__tests__/components/layout/nav-bar.test.tsx
@@ -87,6 +87,22 @@ describe("NavBar", () => {
       }
     });
 
+    it("sets aria-current='page' on the active link", () => {
+      mockPathname = "/checkin";
+      render(<NavBar authState="authenticated" />);
+
+      const checkinLinks = screen.getAllByText("Check-in");
+      for (const link of checkinLinks) {
+        expect(link.getAttribute("aria-current")).toBe("page");
+      }
+
+      // Inactive links should NOT have aria-current
+      const dashboardLinks = screen.getAllByText("Dashboard");
+      for (const link of dashboardLinks) {
+        expect(link.getAttribute("aria-current")).toBeNull();
+      }
+    });
+
     it("renders sign-out buttons (desktop + mobile after open)", () => {
       render(<NavBar authState="authenticated" />);
 
@@ -112,6 +128,12 @@ describe("NavBar", () => {
       render(<NavBar authState="authenticated" />);
       const header = screen.getByTestId("nav-bar");
       expect(header.getAttribute("data-auth-state")).toBe("authenticated");
+    });
+
+    it("renders the nav landmark with aria-label='Primary'", () => {
+      render(<NavBar authState="authenticated" />);
+      const nav = screen.getByRole("navigation", { name: "Primary" });
+      expect(nav).toBeDefined();
     });
   });
 

--- a/components/layout/nav-bar.tsx
+++ b/components/layout/nav-bar.tsx
@@ -33,6 +33,12 @@ const AUTHENTICATED_LINKS: NavLink[] = [
 ];
 
 export interface NavBarProps {
+  /**
+   * Server-derived auth state passed from the layout.
+   * - "unauthenticated" — landing page nav (Sign In / Get Started)
+   * - "authenticated" — app nav (Dashboard / Check-in / Children / Scout / Sign Out)
+   * Always resolved server-side to avoid FOUC and hydration mismatch.
+   */
   authState: NavBarAuthState;
 }
 
@@ -62,7 +68,7 @@ export function NavBar({ authState }: NavBarProps) {
       data-testid="nav-bar"
       data-auth-state={authState}
     >
-      <nav className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3 sm:px-6 sm:py-4">
+      <nav aria-label="Primary" className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3 sm:px-6 sm:py-4">
         {/* Logo */}
         <Link href={logoHref} className="flex items-center">
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -81,6 +87,7 @@ export function NavBar({ authState }: NavBarProps) {
                 <Link
                   key={link.href}
                   href={link.href}
+                  aria-current={isActive(link.href) ? "page" : undefined}
                   className={`rounded-button px-3 py-2 text-sm font-medium transition-colors ${
                     isActive(link.href)
                       ? "bg-white/20 text-white"
@@ -172,6 +179,7 @@ export function NavBar({ authState }: NavBarProps) {
                   key={link.href}
                   href={link.href}
                   onClick={() => setMobileMenuOpen(false)}
+                  aria-current={isActive(link.href) ? "page" : undefined}
                   className={`block rounded-button px-3 py-2 text-sm font-medium transition-colors ${
                     isActive(link.href)
                       ? "bg-white/20 text-white"


### PR DESCRIPTION
## Summary

Follow-up from #172 review ([comment](https://github.com/eddie452/workshop/pull/172#issuecomment-4246684632)). Hardens screen-reader experience on the unified `NavBar` without changing any visual or routing behavior.

- Add `aria-label="Primary"` on the outer `<nav>` landmark for screen-reader discoverability
- Add `aria-current="page"` on active links (both desktop and mobile menus)
- Add JSDoc comment on the `authState` prop documenting both states and server-side resolution rationale

Closes #173
Related: #172, #106

## Acceptance Criteria

- [x] Outer `<nav>` has `aria-label="Primary"`
- [x] Active link emits `aria-current="page"` when its href matches the current pathname
- [x] `authState` prop has a JSDoc comment documenting both states and the server-side resolution rationale
- [x] New unit test asserts the active link's `aria-current="page"` attribute
- [x] New unit test asserts the nav landmark's `aria-label="Primary"`
- [x] `npm run lint`, `npm run typecheck`, `npm test` all pass (1040/1040 tests green)

## Test plan

- [ ] Verify `aria-label="Primary"` on nav landmark in Render preview
- [ ] Verify `aria-current="page"` on active link via browser DevTools
- [ ] Confirm no visual regression on landing + dashboard nav
- [ ] Run screen reader (VoiceOver/NVDA) to confirm landmark announcement