### PR TITLE
feat(subscription): add telemetry for subscribe button clicks

### DIFF
--- a/__tests__/components/subscription/upgrade-cta.test.tsx
+++ b/__tests__/components/subscription/upgrade-cta.test.tsx
@@ -1,12 +1,17 @@
 /**
  * UpgradeCta Component Tests
  *
- * Tests the upgrade call-to-action component for free-tier users.
+ * Tests the upgrade call-to-action component for free-tier users,
+ * including telemetry + coming-soon feedback for the no-op subscribe
+ * button (ticket #75).
  */
 
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { UpgradeCta } from "@/components/subscription/upgrade-cta";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  SUBSCRIBE_INTENT_EVENT,
+  UpgradeCta,
+} from "@/components/subscription/upgrade-cta";
 
 describe("UpgradeCta", () => {
   it("renders with default props", () => {
@@ -66,5 +71,117 @@ describe("UpgradeCta", () => {
     expect(
       screen.getByText("Upgrade to Madness Family"),
     ).toBeTruthy();
+  });
+
+  describe("subscribe click telemetry (ticket #75)", () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it("does not render coming-soon feedback before click", () => {
+      render(<UpgradeCta />);
+      expect(screen.queryByTestId("upgrade-cta-coming-soon")).toBeNull();
+    });
+
+    it("reveals coming-soon feedback when subscribe is clicked", () => {
+      render(<UpgradeCta tierName="Madness+" />);
+
+      fireEvent.click(screen.getByTestId("upgrade-cta-subscribe"));
+
+      const feedback = screen.getByTestId("upgrade-cta-coming-soon");
+      expect(feedback).toBeTruthy();
+      expect(feedback.textContent).toMatch(/coming soon/i);
+      expect(feedback.textContent).toMatch(/Madness\+/);
+    });
+
+    it("uses an aria-live region for the feedback message", () => {
+      render(<UpgradeCta />);
+
+      fireEvent.click(screen.getByTestId("upgrade-cta-subscribe"));
+
+      const feedback = screen.getByTestId("upgrade-cta-coming-soon");
+      expect(feedback.getAttribute("role")).toBe("status");
+      expect(feedback.getAttribute("aria-live")).toBe("polite");
+    });
+
+    it("logs a structured telemetry event on subscribe click", () => {
+      render(
+        <UpgradeCta
+          feature="Final Four details"
+          tierName="Madness Family"
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("upgrade-cta-subscribe"));
+
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      const [tag, payload] = consoleSpy.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      expect(tag).toBe("[telemetry]");
+      expect(payload.event).toBe(SUBSCRIBE_INTENT_EVENT);
+      expect(payload.feature).toBe("Final Four details");
+      expect(payload.tierName).toBe("Madness Family");
+      expect(typeof payload.timestamp).toBe("string");
+      // ISO 8601 shape check
+      expect(payload.timestamp as string).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+      );
+    });
+
+    it("invokes onSubscribeClick with the same payload", () => {
+      const handler = vi.fn();
+      render(
+        <UpgradeCta
+          feature="premium features"
+          tierName="Madness+"
+          onSubscribeClick={handler}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("upgrade-cta-subscribe"));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const payload = handler.mock.calls[0][0];
+      expect(payload.event).toBe(SUBSCRIBE_INTENT_EVENT);
+      expect(payload.feature).toBe("premium features");
+      expect(payload.tierName).toBe("Madness+");
+    });
+
+    it("telemetry payload does not include PII or health data fields", () => {
+      const handler = vi.fn();
+      render(<UpgradeCta onSubscribeClick={handler} />);
+
+      fireEvent.click(screen.getByTestId("upgrade-cta-subscribe"));
+
+      const payload = handler.mock.calls[0][0] as Record<string, unknown>;
+      const forbidden = [
+        "email",
+        "userId",
+        "user_id",
+        "name",
+        "phone",
+        "address",
+        "ip",
+        "allergens",
+        "symptoms",
+        "diagnosis",
+        "healthData",
+      ];
+      for (const key of forbidden) {
+        expect(payload).not.toHaveProperty(key);
+      }
+      // Only the documented keys are present.
+      expect(Object.keys(payload).sort()).toEqual(
+        ["event", "feature", "tierName", "timestamp"].sort(),
+      );
+    });
   });
 });

--- a/components/subscription/index.ts
+++ b/components/subscription/index.ts
@@ -4,7 +4,7 @@
  * Re-exports for subscription-related UI components.
  */
 
-export { UpgradeCta } from "./upgrade-cta";
-export type { UpgradeCtaProps } from "./upgrade-cta";
+export { UpgradeCta, SUBSCRIBE_INTENT_EVENT } from "./upgrade-cta";
+export type { UpgradeCtaProps, SubscribeIntentEvent } from "./upgrade-cta";
 export { PremiumBadge } from "./premium-badge";
 export type { PremiumBadgeProps } from "./premium-badge";

--- a/components/subscription/upgrade-cta.tsx
+++ b/components/subscription/upgrade-cta.tsx
@@ -3,9 +3,31 @@
  *
  * Prompts free-tier users to upgrade or unlock via referrals.
  * Shown alongside the blur overlay on gated content.
+ *
+ * Telemetry: the subscribe button is a no-op placeholder until the
+ * payment integration (RevenueCat) lands. Clicks emit a structured
+ * intent event so we can size demand and show the user "Coming soon!"
+ * feedback. Event payloads never include PII or health data.
  */
 
 "use client";
+
+import { useCallback, useState } from "react";
+
+/** Structured event name for the subscribe-intent signal. */
+export const SUBSCRIBE_INTENT_EVENT = "subscribe_cta_clicked";
+
+/** Shape of the subscribe-intent event payload (no PII, no health data). */
+export interface SubscribeIntentEvent {
+  /** Event discriminator. */
+  event: typeof SUBSCRIBE_INTENT_EVENT;
+  /** Which feature the user was gated on when they clicked. */
+  feature: string;
+  /** Tier name shown in the CTA copy. */
+  tierName: string;
+  /** ISO timestamp of the click. */
+  timestamp: string;
+}
 
 export interface UpgradeCtaProps {
   /** The feature being gated (for contextual messaging) */
@@ -14,13 +36,37 @@ export interface UpgradeCtaProps {
   tierName?: string;
   /** Number of referrals still needed to unlock (0 if already unlocked) */
   referralsNeeded?: number;
+  /**
+   * Fires when the subscribe button is clicked with a sanitized,
+   * PII-free payload. Use for parent-level analytics hooks.
+   */
+  onSubscribeClick?: (event: SubscribeIntentEvent) => void;
 }
 
 export function UpgradeCta({
   feature = "premium features",
   tierName = "Madness+",
   referralsNeeded = 3,
+  onSubscribeClick,
 }: UpgradeCtaProps) {
+  const [showComingSoon, setShowComingSoon] = useState(false);
+
+  const handleSubscribeClick = useCallback(() => {
+    const payload: SubscribeIntentEvent = {
+      event: SUBSCRIBE_INTENT_EVENT,
+      feature,
+      tierName,
+      timestamp: new Date().toISOString(),
+    };
+
+    // Structured console log — picked up by browser-side telemetry
+    // collectors in prod, visible in dev. No PII or health data.
+    console.info("[telemetry]", payload);
+
+    onSubscribeClick?.(payload);
+    setShowComingSoon(true);
+  }, [feature, tierName, onSubscribeClick]);
+
   return (
     <div
       data-testid="upgrade-cta"
@@ -38,12 +84,24 @@ export function UpgradeCta({
         type="button"
         data-testid="upgrade-cta-subscribe"
         className="mb-3 w-full cursor-pointer rounded-button border-none bg-brand-premium px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-premium-dark"
-        onClick={() => {
-          // Placeholder — will connect to RevenueCat paywall
-        }}
+        onClick={handleSubscribeClick}
       >
         Upgrade to {tierName}
       </button>
+
+      {/* Coming-soon feedback — replaces the silent no-op click */}
+      {showComingSoon && (
+        <p
+          role="status"
+          aria-live="polite"
+          data-testid="upgrade-cta-coming-soon"
+          className="mb-3 text-sm font-medium text-brand-premium-dark"
+        >
+          Subscriptions coming soon! We&apos;ll let you know when
+          {" "}
+          {tierName} opens up.
+        </p>
+      )}
 
       {/* Secondary CTA — Referral unlock */}
       {referralsNeeded > 0 && (


### PR DESCRIPTION
## Summary

Closes #75.

The subscribe/upgrade button in `components/subscription/upgrade-cta.tsx` was a silent no-op with no way to size demand for Madness+. This PR wires up a structured intent signal and gives the user visible feedback so the click stops feeling broken — without shipping any payment code.

## Changes

- Subscribe button click emits `subscribe_cta_clicked` via `console.info("[telemetry]", payload)` — picked up by browser-side collectors in prod, visible in dev.
- Payload schema is `{ event, feature, tierName, timestamp }` — no PII, no health data, no user/session identifiers.
- New `onSubscribeClick(event)` callback prop so parent pages can wire their own analytics hooks (matches the pattern in `final-four-unlock-cta.tsx`).
- Accessible "Subscriptions coming soon!" message appears after click (`role="status"`, `aria-live="polite"`).
- `SUBSCRIBE_INTENT_EVENT` constant + `SubscribeIntentEvent` type exported from the subscription barrel.

## Definition of Done

- [x] Subscribe button click produces user-visible feedback
- [x] Click intent is logged/trackable (structured event + callback)
- [x] No PII or health data in telemetry (dedicated test asserts this)
- [x] All existing tests pass (1044 tests, 96 files, green)
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean

## Test plan

- [x] Unit tests cover: payload shape, telemetry tag, ISO timestamp, callback invocation, feedback visibility, aria-live, PII absence
- [ ] Manual smoke: click the Upgrade button on a gated surface in dev, confirm `[telemetry] { event: "subscribe_cta_clicked", ... }` logs and the "Coming soon!" message appears