### PR TITLE
polish(allergens): taxonomy type safety + Map lookup

### DIFF
--- a/__tests__/allergens/taxonomy.test.ts
+++ b/__tests__/allergens/taxonomy.test.ts
@@ -88,4 +88,12 @@ describe("getAllergenEntry", () => {
   it("returns undefined for the empty string", () => {
     expect(getAllergenEntry("")).toBeUndefined();
   });
+
+  it("internal lookup map has no silent ID collisions", () => {
+    // If two taxonomy entries ever shared an id, the Map would silently
+    // drop one and its size would be less than the array length. This
+    // invariant guards the O(1) lookup path in getAllergenEntry().
+    const lookup = new Map(ALLERGEN_TAXONOMY.map((e) => [e.id, e]));
+    expect(lookup.size).toBe(ALLERGEN_TAXONOMY.length);
+  });
 });

--- a/lib/allergens/taxonomy.ts
+++ b/lib/allergens/taxonomy.ts
@@ -41,7 +41,7 @@ export interface AllergenTaxonomyEntry {
   readonly slug: string;
 }
 
-export const ALLERGEN_TAXONOMY: readonly AllergenTaxonomyEntry[] = [
+export const ALLERGEN_TAXONOMY = [
   // Tree pollens
   { id: "oak", name: "Oak", category: "pollen", slug: "oak" },
   { id: "birch", name: "Birch", category: "pollen", slug: "birch" },
@@ -102,15 +102,35 @@ export const ALLERGEN_TAXONOMY: readonly AllergenTaxonomyEntry[] = [
   // Indoor — other
   { id: "cockroach", name: "Cockroach", category: "other", slug: "cockroach" },
   { id: "mouse", name: "Mouse", category: "other", slug: "mouse" },
-] as const;
+] as const satisfies readonly AllergenTaxonomyEntry[];
+
+/**
+ * String literal union of every canonical allergen ID in the taxonomy.
+ * Derived from {@link ALLERGEN_TAXONOMY} so adding or removing an entry
+ * automatically updates every consumer that accepts `AllergenId`.
+ */
+export type AllergenId = (typeof ALLERGEN_TAXONOMY)[number]["id"];
 
 export const ALLERGEN_IDS: readonly string[] = ALLERGEN_TAXONOMY.map(
   (e) => e.id,
 );
 
-/** Lookup by ID. Returns undefined for unknown IDs. */
+/**
+ * Module-level index built once at import time. Replaces a linear
+ * `Array.find()` scan (O(n)) with an O(1) `Map.get()` lookup.
+ */
+const ALLERGEN_BY_ID: ReadonlyMap<string, AllergenTaxonomyEntry> = new Map(
+  ALLERGEN_TAXONOMY.map((entry) => [entry.id, entry]),
+);
+
+/** Lookup by known `AllergenId` — entry is guaranteed to exist. */
+export function getAllergenEntry(id: AllergenId): AllergenTaxonomyEntry;
+/** Lookup by arbitrary string — returns undefined for unknown IDs. */
+export function getAllergenEntry(
+  id: string,
+): AllergenTaxonomyEntry | undefined;
 export function getAllergenEntry(
   id: string,
 ): AllergenTaxonomyEntry | undefined {
-  return ALLERGEN_TAXONOMY.find((e) => e.id === id);
+  return ALLERGEN_BY_ID.get(id);
 }


### PR DESCRIPTION
## Summary

Addresses the PR #204 review feedback for `lib/allergens/taxonomy.ts`:

- Export `AllergenId` as a string literal union derived from `typeof ALLERGEN_TAXONOMY[number]["id"]` so every consumer that accepts `AllergenId` narrows to the exact set of canonical IDs.
- Overload `getAllergenEntry` — known `AllergenId` returns `AllergenTaxonomyEntry` (non-optional), arbitrary `string` returns `AllergenTaxonomyEntry | undefined`.
- Replace the O(n) `Array.find()` scan with an O(1) module-level `ReadonlyMap<string, AllergenTaxonomyEntry>` built once at import time.
- Add a regression test asserting the Map size equals the taxonomy length so any silent ID collision fails loudly.

No taxonomy data, seed data, or engine files were touched. All existing taxonomy tests pass unchanged.

## Test plan

- [x] `npm run lint` (clean)
- [x] `npm run typecheck` (clean)
- [x] `npm test` — 1055 tests pass across 97 files, including the new Map-size invariant
- [x] `npm run build` (clean)

Closes #205
Refs #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)