### PR TITLE
feat(engine): NOAA HYSPLIT LRT detection

### DIFF
--- a/__tests__/engine/lrt.test.ts
+++ b/__tests__/engine/lrt.test.ts
@@ -3,6 +3,8 @@ import {
   isWindFromRegion,
   detectLRT,
   detectLRTForAll,
+  regionDistanceMiles,
+  distanceDecayMultiplier,
 } from "@/lib/engine/lrt";
 import type { LRTAllergenInput } from "@/lib/engine/types";
 
@@ -127,5 +129,277 @@ describe("detectLRTForAll", () => {
 
   it("returns empty array for empty input", () => {
     expect(detectLRTForAll([], "Southwest", 45)).toHaveLength(0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* regionDistanceMiles                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("regionDistanceMiles", () => {
+  it("returns 0 for same region", () => {
+    expect(regionDistanceMiles("Southwest", "Southwest")).toBe(0);
+  });
+
+  it("is symmetric across region pairs", () => {
+    expect(regionDistanceMiles("South Central", "Southeast")).toBe(
+      regionDistanceMiles("Southeast", "South Central"),
+    );
+    expect(regionDistanceMiles("Northeast", "Northwest")).toBe(
+      regionDistanceMiles("Northwest", "Northeast"),
+    );
+  });
+
+  it("returns a positive distance for distinct regions", () => {
+    const d = regionDistanceMiles("South Central", "Midwest");
+    expect(d).not.toBeNull();
+    expect(d!).toBeGreaterThan(0);
+  });
+
+  it("returns null for unknown regions", () => {
+    expect(regionDistanceMiles("Atlantis", "Southwest")).toBeNull();
+    expect(regionDistanceMiles("Southwest", "Atlantis")).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* distanceDecayMultiplier                                             */
+/* ------------------------------------------------------------------ */
+
+describe("distanceDecayMultiplier", () => {
+  it("returns full 1.5 boost at zero distance", () => {
+    expect(distanceDecayMultiplier(0, 1000)).toBeCloseTo(1.5, 5);
+  });
+
+  it("decays to ~1.1 minimum at max distance", () => {
+    expect(distanceDecayMultiplier(1000, 1000)).toBeCloseTo(1.1, 5);
+  });
+
+  it("interpolates linearly in the middle", () => {
+    // At halfway point, midway between 1.5 and 1.1 → 1.3
+    expect(distanceDecayMultiplier(500, 1000)).toBeCloseTo(1.3, 5);
+  });
+
+  it("returns 1.0 (no boost) when distance exceeds max", () => {
+    expect(distanceDecayMultiplier(1500, 1000)).toBe(1.0);
+  });
+
+  it("returns 1.0 for non-positive max distance", () => {
+    expect(distanceDecayMultiplier(100, 0)).toBe(1.0);
+  });
+
+  it("produces higher boost for a closer source than a farther one (same max)", () => {
+    const close = distanceDecayMultiplier(200, 1000);
+    const far = distanceDecayMultiplier(800, 1000);
+    expect(close).toBeGreaterThan(far);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* detectLRT — bloom gate                                              */
+/* ------------------------------------------------------------------ */
+
+describe("detectLRT with bloom gate", () => {
+  const cedarAllergen = (): LRTAllergenInput => ({
+    allergen_id: "cedar-juniper",
+    lrt_capable: true,
+    lrt_max_miles: 1000,
+    lrt_source_regions: ["South Central"],
+  });
+
+  it("detects cedar LRT when source in bloom, wind from south, within range", () => {
+    // User in Southwest (or Midwest), source South Central bearing 180.
+    // Wind from 180 → from South Central.
+    const result = detectLRT(cedarAllergen(), "Midwest", 180, {
+      isSourceInBloom: () => true,
+    });
+    expect(result.lrt_detected).toBe(true);
+    expect(result.multiplier).toBeGreaterThan(1.0);
+  });
+
+  it("does NOT detect LRT when source region is not in bloom", () => {
+    const result = detectLRT(cedarAllergen(), "Midwest", 180, {
+      isSourceInBloom: () => false,
+    });
+    expect(result.lrt_detected).toBe(false);
+    expect(result.multiplier).toBe(1.0);
+  });
+
+  it("does NOT detect LRT when wind direction is unfavorable", () => {
+    // Wind from 0 (N) — not from South Central (180)
+    const result = detectLRT(cedarAllergen(), "Midwest", 0, {
+      isSourceInBloom: () => true,
+    });
+    expect(result.lrt_detected).toBe(false);
+    expect(result.multiplier).toBe(1.0);
+  });
+
+  it("passes allergen_id and source region to the bloom predicate", () => {
+    const seen: Array<[string, string]> = [];
+    detectLRT(cedarAllergen(), "Midwest", 180, {
+      isSourceInBloom: (id, region) => {
+        seen.push([id, region]);
+        return true;
+      },
+    });
+    expect(seen).toContainEqual(["cedar-juniper", "South Central"]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* detectLRT — distance decay                                          */
+/* ------------------------------------------------------------------ */
+
+describe("detectLRT with distance decay", () => {
+  it("applies decayed multiplier (not flat 1.5) when applyDistanceDecay is true", () => {
+    // Cedar from South Central, user in Midwest → distance 700 mi, max 1000.
+    // Wind from 180 (South Central).
+    const result = detectLRT(
+      {
+        allergen_id: "cedar-juniper",
+        lrt_capable: true,
+        lrt_max_miles: 1000,
+        lrt_source_regions: ["South Central"],
+      },
+      "Midwest",
+      180,
+      { applyDistanceDecay: true },
+    );
+    expect(result.lrt_detected).toBe(true);
+    // 700/1000 of the way from 1.5 down to 1.1 → 1.5 - 0.7*0.4 = 1.22
+    expect(result.multiplier).toBeCloseTo(1.22, 2);
+  });
+
+  it("reduces boost for farther sources than closer ones", () => {
+    // Ragweed (400 mi max) from South Central.
+    // User in Southeast → ~700 mi → out of range.
+    const farResult = detectLRT(
+      {
+        allergen_id: "ragweed",
+        lrt_capable: true,
+        lrt_max_miles: 400,
+        lrt_source_regions: ["South Central"],
+      },
+      "Southeast",
+      180,
+      { applyDistanceDecay: true },
+    );
+    // Out of range → no LRT
+    expect(farResult.lrt_detected).toBe(false);
+
+    // Same allergen, user in Midwest → 700 mi — still out of 400 max
+    const midResult = detectLRT(
+      {
+        allergen_id: "ragweed",
+        lrt_capable: true,
+        lrt_max_miles: 400,
+        lrt_source_regions: ["South Central"],
+      },
+      "Midwest",
+      180,
+      { applyDistanceDecay: true },
+    );
+    expect(midResult.lrt_detected).toBe(false);
+
+    // Now with a bigger lrt_max_miles — closer user gets a higher boost
+    const a: LRTAllergenInput = {
+      allergen_id: "cedar-juniper",
+      lrt_capable: true,
+      lrt_max_miles: 1500,
+      lrt_source_regions: ["South Central"],
+    };
+    const closerUserResult = detectLRT(a, "Midwest", 180, {
+      applyDistanceDecay: true,
+    });
+    const fartherUserResult = detectLRT(a, "Northeast", 180, {
+      applyDistanceDecay: true,
+    });
+    // Both should detect, but closer user should have larger multiplier.
+    // Northeast bearing is 45, but we query wind from 180 (South Central source).
+    // Both have source "South Central", so both eligible.
+    expect(closerUserResult.lrt_detected).toBe(true);
+    // Northeast is 1400 mi from South Central → still in 1500 range
+    expect(fartherUserResult.lrt_detected).toBe(true);
+    expect(closerUserResult.multiplier).toBeGreaterThan(
+      fartherUserResult.multiplier,
+    );
+  });
+
+  it("produces no boost when source exceeds lrt_max_miles", () => {
+    // Bermuda max 100 mi, source South Central → any inter-region distance >100.
+    const result = detectLRT(
+      {
+        allergen_id: "bermuda",
+        lrt_capable: true,
+        lrt_max_miles: 100,
+        lrt_source_regions: ["South Central"],
+      },
+      "Midwest",
+      180,
+      { applyDistanceDecay: true },
+    );
+    expect(result.lrt_detected).toBe(false);
+    expect(result.multiplier).toBe(1.0);
+  });
+
+  it("does NOT affect non-LRT allergens", () => {
+    const result = detectLRT(
+      {
+        allergen_id: "dust-mite",
+        lrt_capable: false,
+        lrt_max_miles: null,
+        lrt_source_regions: [],
+      },
+      "Midwest",
+      180,
+      { applyDistanceDecay: true, isSourceInBloom: () => true },
+    );
+    expect(result.lrt_detected).toBe(false);
+    expect(result.multiplier).toBe(1.0);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* detectLRT — combined (bloom + distance decay)                       */
+/* ------------------------------------------------------------------ */
+
+describe("detectLRT combined scenarios", () => {
+  it("Cedar Fever: user in Midwest, source in bloom in South Central, south wind, within range", () => {
+    const result = detectLRT(
+      {
+        allergen_id: "cedar-juniper",
+        lrt_capable: true,
+        lrt_max_miles: 1000,
+        lrt_source_regions: ["South Central"],
+      },
+      "Midwest",
+      180, // wind from South
+      {
+        isSourceInBloom: (id, region) =>
+          id === "cedar-juniper" && region === "South Central",
+        applyDistanceDecay: true,
+      },
+    );
+    expect(result.lrt_detected).toBe(true);
+    expect(result.multiplier).toBeGreaterThan(1.0);
+    expect(result.multiplier).toBeLessThanOrEqual(1.5);
+  });
+
+  it("rejects when all upstream checks pass but bloom is off-season", () => {
+    const result = detectLRT(
+      {
+        allergen_id: "cedar-juniper",
+        lrt_capable: true,
+        lrt_max_miles: 1000,
+        lrt_source_regions: ["South Central"],
+      },
+      "Midwest",
+      180,
+      {
+        isSourceInBloom: () => false, // e.g., August — cedar off-season
+        applyDistanceDecay: true,
+      },
+    );
+    expect(result.lrt_detected).toBe(false);
   });
 });

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -128,7 +128,10 @@ export {
   isWindFromRegion,
   detectLRT,
   detectLRTForAll,
+  regionDistanceMiles,
+  distanceDecayMultiplier,
 } from "./lrt";
+export type { BloomPredicate, DetectLRTOptions } from "./lrt";
 
 // Tournament sort
 export {

--- a/lib/engine/lrt.ts
+++ b/lib/engine/lrt.ts
@@ -2,14 +2,26 @@
  * Long-Range Transport (LRT) Detection
  *
  * Detects whether an allergen could be arriving via long-range
- * atmospheric transport based on wind direction and source regions.
- * LRT-capable allergens (e.g., birch, cedar) can travel hundreds
- * of miles on prevailing winds.
+ * atmospheric transport based on:
+ *   1. Source region currently in bloom (seasonal calendar)
+ *   2. Wind trajectory confirms transport toward user
+ *   3. Distance within lrt_max_miles (with decay for farther sources)
+ *
+ * This is a simplified surrogate for NOAA HYSPLIT trajectory modeling —
+ * no external API call. Wind direction + inter-region distance is
+ * sufficient for workshop-grade LRT detection.
  *
  * Server-side only — never import from client components.
  *
  * Wind direction convention: meteorological (degrees, 0=N, 90=E, 180=S, 270=W).
  * Wind "from" 180 means wind blows from the south.
+ *
+ * LRT species (from seed data):
+ *   - cedar/juniper: 1000+ mi
+ *   - ragweed:       400 mi
+ *   - pine:          300 mi
+ *   - bermuda:       100 mi
+ *   - olive:         100 mi
  */
 
 import type { Region } from "@/lib/supabase/types";
@@ -20,10 +32,18 @@ import type { LRTAllergenInput, LRTResult } from "./types";
 /* ------------------------------------------------------------------ */
 
 /**
- * LRT multiplier when transport is detected.
- * Boosts allergen score to reflect distant-source arrival.
+ * Maximum LRT multiplier when transport is detected at zero distance
+ * from the source. Multiplier decays linearly to `LRT_MIN_BOOST` as
+ * distance approaches `lrt_max_miles`.
  */
 const LRT_BOOST_MULTIPLIER = 1.5;
+
+/**
+ * Minimum boost applied when LRT is detected but the source is at the
+ * edge of its transport range. Keeps LRT distinguishable from
+ * no-LRT (1.0) even at max distance.
+ */
+const LRT_MIN_BOOST = 1.1;
 
 /** No LRT effect — neutral multiplier */
 const LRT_NEUTRAL_MULTIPLIER = 1.0;
@@ -48,8 +68,117 @@ const REGION_BEARING: Record<string, number> = {
   Southwest: 225,
 };
 
+/**
+ * Approximate centroid distances between US regions (miles).
+ * Used for distance-decay when a source region is distant.
+ * Symmetric: distance(A, B) === distance(B, A). Diagonal is 0.
+ *
+ * Values are rough great-circle estimates between region centroids,
+ * adequate for the simplified LRT model. Same-region sources resolve
+ * to zero distance and are filtered out upstream (LRT is about
+ * _distant_ transport).
+ */
+const REGION_DISTANCE_MI: Record<string, Record<string, number>> = {
+  Northeast: {
+    Northeast: 0,
+    Midwest: 700,
+    Northwest: 2200,
+    "South Central": 1400,
+    Southeast: 900,
+    Southwest: 1900,
+  },
+  Midwest: {
+    Northeast: 700,
+    Midwest: 0,
+    Northwest: 1500,
+    "South Central": 700,
+    Southeast: 800,
+    Southwest: 1200,
+  },
+  Northwest: {
+    Northeast: 2200,
+    Midwest: 1500,
+    Northwest: 0,
+    "South Central": 1700,
+    Southeast: 2300,
+    Southwest: 900,
+  },
+  "South Central": {
+    Northeast: 1400,
+    Midwest: 700,
+    Northwest: 1700,
+    "South Central": 0,
+    Southeast: 700,
+    Southwest: 900,
+  },
+  Southeast: {
+    Northeast: 900,
+    Midwest: 800,
+    Northwest: 2300,
+    "South Central": 700,
+    Southeast: 0,
+    Southwest: 1800,
+  },
+  Southwest: {
+    Northeast: 1900,
+    Midwest: 1200,
+    Northwest: 900,
+    "South Central": 900,
+    Southeast: 1800,
+    Southwest: 0,
+  },
+};
+
 /* ------------------------------------------------------------------ */
-/* Detection                                                           */
+/* Distance                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Approximate distance in miles between two US regions.
+ *
+ * @param from — source region
+ * @param to   — destination region (user location)
+ * @returns distance in miles, or `null` if either region is unknown
+ */
+export function regionDistanceMiles(
+  from: string,
+  to: string,
+): number | null {
+  const row = REGION_DISTANCE_MI[from];
+  if (!row) return null;
+  const d = row[to];
+  return d === undefined ? null : d;
+}
+
+/**
+ * Compute a linear distance-decay factor in [LRT_MIN_BOOST, LRT_BOOST_MULTIPLIER].
+ *
+ *   distance 0            → LRT_BOOST_MULTIPLIER (full boost)
+ *   distance lrt_max_miles → LRT_MIN_BOOST       (edge of range)
+ *   distance > lrt_max_miles → 1.0               (out of range, no boost)
+ *
+ * @param distanceMi — distance from source to user (miles)
+ * @param maxMi      — lrt_max_miles for this allergen
+ * @returns multiplier to apply
+ */
+export function distanceDecayMultiplier(
+  distanceMi: number,
+  maxMi: number,
+): number {
+  if (maxMi <= 0) return LRT_NEUTRAL_MULTIPLIER;
+  if (distanceMi < 0) return LRT_BOOST_MULTIPLIER;
+  if (distanceMi > maxMi) return LRT_NEUTRAL_MULTIPLIER;
+
+  const ratio = distanceMi / maxMi; // 0..1
+  // Linear interpolation from LRT_BOOST_MULTIPLIER down to LRT_MIN_BOOST
+  return (
+    LRT_BOOST_MULTIPLIER -
+    ratio * (LRT_BOOST_MULTIPLIER - LRT_MIN_BOOST)
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Wind                                                                */
 /* ------------------------------------------------------------------ */
 
 /**
@@ -76,41 +205,85 @@ export function isWindFromRegion(
   return diff <= WIND_DIRECTION_TOLERANCE;
 }
 
+/* ------------------------------------------------------------------ */
+/* Detection                                                           */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Predicate for checking whether a source region is currently in bloom
+ * for a given allergen. Injected as a callback so `lrt.ts` doesn't pull
+ * in the seasonal calendar directly (keeps this module a leaf).
+ *
+ * Callers in the run orchestrator should pass a closure that consults
+ * `getSeasonalSeverity(...)` from `./seasonal`.
+ */
+export type BloomPredicate = (
+  allergenId: string,
+  sourceRegion: Region,
+) => boolean;
+
+/**
+ * Options for {@link detectLRT}.
+ *
+ * All fields are optional; omitting them preserves legacy behavior
+ * (wind-only LRT with a flat 1.5 multiplier).
+ */
+export interface DetectLRTOptions {
+  /**
+   * Predicate returning `true` when `sourceRegion` is currently in bloom
+   * for `allergenId`. When provided, LRT is only detected for sources
+   * confirmed to be in bloom.
+   */
+  isSourceInBloom?: BloomPredicate;
+  /**
+   * When `true`, apply linear distance decay between full boost
+   * ({@link LRT_BOOST_MULTIPLIER}) at zero distance and {@link LRT_MIN_BOOST}
+   * at `lrt_max_miles`. Sources beyond `lrt_max_miles` are treated as
+   * out-of-range and produce no boost.
+   *
+   * When `false` (default), all in-range detections produce the flat
+   * {@link LRT_BOOST_MULTIPLIER}.
+   */
+  applyDistanceDecay?: boolean;
+}
+
 /**
  * Detect LRT for a single allergen.
  *
- * An allergen receives an LRT boost when:
+ * An allergen receives an LRT boost when ALL of:
  * 1. It is LRT-capable
- * 2. Wind direction aligns with at least one source region
- * 3. The user's region is NOT one of the source regions (LRT = distant transport)
+ * 2. Wind data is available
+ * 3. At least one distant source region passes every requested check:
+ *    - Wind direction aligns with that region's bearing
+ *    - (optional) Source region is currently in bloom
+ *    - (optional) Source region is within `lrt_max_miles`
+ *
+ * The user's own region is excluded from source consideration — LRT
+ * describes _distant_ transport, not local pollen.
  *
  * @param allergen — allergen LRT data
  * @param userRegion — user's home region
  * @param windDirectionDeg — current wind direction (null = no wind data)
+ * @param options — optional bloom predicate and distance-decay flag
  * @returns LRTResult with detection status and multiplier
  */
 export function detectLRT(
   allergen: LRTAllergenInput,
   userRegion: Region,
   windDirectionDeg: number | null,
+  options: DetectLRTOptions = {},
 ): LRTResult {
+  const neutral: LRTResult = {
+    allergen_id: allergen.allergen_id,
+    lrt_detected: false,
+    multiplier: LRT_NEUTRAL_MULTIPLIER,
+  };
+
   // Not LRT-capable → no boost
-  if (!allergen.lrt_capable) {
-    return {
-      allergen_id: allergen.allergen_id,
-      lrt_detected: false,
-      multiplier: LRT_NEUTRAL_MULTIPLIER,
-    };
-  }
+  if (!allergen.lrt_capable) return neutral;
 
   // No wind data → can't detect LRT
-  if (windDirectionDeg === null) {
-    return {
-      allergen_id: allergen.allergen_id,
-      lrt_detected: false,
-      multiplier: LRT_NEUTRAL_MULTIPLIER,
-    };
-  }
+  if (windDirectionDeg === null) return neutral;
 
   // Filter source regions to exclude user's own region
   // (LRT is about distant transport, not local pollen)
@@ -118,15 +291,36 @@ export function detectLRT(
     (r) => r !== userRegion,
   );
 
-  // Check if wind is from any distant source region
-  const lrtDetected = distantSources.some((region) =>
-    isWindFromRegion(windDirectionDeg, region),
-  );
+  let bestMultiplier = LRT_NEUTRAL_MULTIPLIER;
 
+  for (const source of distantSources) {
+    // 1. Wind alignment
+    if (!isWindFromRegion(windDirectionDeg, source)) continue;
+
+    // 2. Bloom check (optional)
+    if (options.isSourceInBloom) {
+      if (!options.isSourceInBloom(allergen.allergen_id, source as Region)) {
+        continue;
+      }
+    }
+
+    // 3. Distance check (when decay is requested)
+    let multiplier = LRT_BOOST_MULTIPLIER;
+    if (options.applyDistanceDecay && allergen.lrt_max_miles !== null) {
+      const distance = regionDistanceMiles(source, userRegion);
+      if (distance === null) continue;
+      if (distance > allergen.lrt_max_miles) continue; // out of range
+      multiplier = distanceDecayMultiplier(distance, allergen.lrt_max_miles);
+    }
+
+    if (multiplier > bestMultiplier) bestMultiplier = multiplier;
+  }
+
+  const detected = bestMultiplier > LRT_NEUTRAL_MULTIPLIER;
   return {
     allergen_id: allergen.allergen_id,
-    lrt_detected: lrtDetected,
-    multiplier: lrtDetected ? LRT_BOOST_MULTIPLIER : LRT_NEUTRAL_MULTIPLIER,
+    lrt_detected: detected,
+    multiplier: detected ? bestMultiplier : LRT_NEUTRAL_MULTIPLIER,
   };
 }
 
@@ -136,14 +330,16 @@ export function detectLRT(
  * @param allergens — array of allergen LRT data
  * @param userRegion — user's home region
  * @param windDirectionDeg — current wind direction (null = no wind data)
+ * @param options — optional bloom predicate and distance-decay flag
  * @returns array of LRTResult, one per allergen
  */
 export function detectLRTForAll(
   allergens: LRTAllergenInput[],
   userRegion: Region,
   windDirectionDeg: number | null,
+  options: DetectLRTOptions = {},
 ): LRTResult[] {
   return allergens.map((allergen) =>
-    detectLRT(allergen, userRegion, windDirectionDeg),
+    detectLRT(allergen, userRegion, windDirectionDeg, options),
   );
 }


### PR DESCRIPTION
## Summary

Implements #32 — extends the Long-Range Transport (LRT) detector with the two checks the ticket's Definition of Done called out: source-region bloom verification and linear distance decay based on each allergen's `lrt_max_miles`.

Per the ticket's Guardrails, this is a simplified HYSPLIT surrogate — no external API call. Wind direction + inter-region distance + bloom status is sufficient for workshop-grade LRT detection.

### What changed

- `lib/engine/lrt.ts`
  - New `regionDistanceMiles()` — symmetric centroid-to-centroid distance table for the six US regions.
  - New `distanceDecayMultiplier()` — linear interpolation from 1.5 at source down to 1.1 at `lrt_max_miles`, then 1.0 beyond range.
  - `detectLRT()` / `detectLRTForAll()` accept an options bag:
    - `isSourceInBloom` — injected predicate (keeps `lrt.ts` a leaf; run orchestrator wires it to `getSeasonalSeverity` without a cross-module import).
    - `applyDistanceDecay` — opt-in decay using `lrt_max_miles`.
  - Both options default off so the current `run.ts` call site keeps its existing behavior until the orchestrator is updated in a follow-up.
- `lib/engine/index.ts` — re-exports the new helpers and option types.
- `__tests__/engine/lrt.test.ts` — expanded to 33 tests covering wind, distance, decay, bloom gate, and the Cedar Fever Happy Path scenario from the ticket.

### Definition of Done coverage

- Cedar/juniper LRT detected: source in bloom + south wind + within 1000 mi.
- LRT NOT detected when source not in bloom.
- LRT NOT detected when wind direction unfavorable.
- Distance decay reduces boost for farther sources (and yields no boost beyond `lrt_max_miles`).
- Non-LRT allergens untouched.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (1075 passed, 33 in lrt.test.ts)
- [x] `npm run build`

Closes #32