### PR TITLE
feat(bracket): visual bracket with progression and animations

### DIFF
--- a/__tests__/bracket/bracket.test.tsx
+++ b/__tests__/bracket/bracket.test.tsx
@@ -115,4 +115,74 @@ describe("Bracket", () => {
     expect(screen.getByTestId("bracket-empty")).toBeDefined();
     expect(screen.queryByTestId("bracket")).toBeNull();
   });
+
+  // -----------------------------------------------------------------
+  // Ticket #155 — animations + mobile scroll polish
+  // -----------------------------------------------------------------
+
+  it("wraps each node in an animation container with a staggered delay", () => {
+    // 8 entries -> 3 rounds; round 0 has 4 matches, round 1 has 2, round 2 has 1.
+    const trace = buildBracketTrace(makeEntries(8));
+    render(<Bracket nodes={trace} ranked={makeRanked(8)} />);
+
+    // Round 0 match 0 -> delay 0ms; round 1 match 0 -> 120ms; round 2 match 0 -> 240ms.
+    const r0 = screen.getByTestId("bracket-node-wrap-0-0");
+    const r1 = screen.getByTestId("bracket-node-wrap-1-0");
+    const r2 = screen.getByTestId("bracket-node-wrap-2-0");
+
+    expect(r0.className).toContain("bracket-node-enter");
+    expect(r1.className).toContain("bracket-node-enter");
+    expect(r2.className).toContain("bracket-node-enter");
+
+    expect(r0.getAttribute("style")).toContain("animation-delay: 0ms");
+    expect(r1.getAttribute("style")).toContain("animation-delay: 120ms");
+    expect(r2.getAttribute("style")).toContain("animation-delay: 240ms");
+  });
+
+  it("stacks additional per-node delay within a round", () => {
+    const trace = buildBracketTrace(makeEntries(8));
+    render(<Bracket nodes={trace} ranked={makeRanked(8)} />);
+    // Round 0 has 4 matches; match 1 should be offset by 40ms from match 0.
+    const n0 = screen.getByTestId("bracket-node-wrap-0-0");
+    const n1 = screen.getByTestId("bracket-node-wrap-0-1");
+    expect(n0.getAttribute("style")).toContain("animation-delay: 0ms");
+    expect(n1.getAttribute("style")).toContain("animation-delay: 40ms");
+  });
+
+  it("respects prefers-reduced-motion via a media query (CSS rule present)", async () => {
+    // We don't import globals.css into the JSDOM render, so verify the
+    // contract at the source: the bracket relies on a CSS class that is
+    // zeroed out under `prefers-reduced-motion: reduce`. The rule lives
+    // in app/globals.css and is asserted by reading the file directly.
+    // This keeps the test stable without a real browser engine.
+    const { readFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const css = await readFile(
+      join(process.cwd(), "app", "globals.css"),
+      "utf8",
+    );
+    expect(css).toMatch(/prefers-reduced-motion:\s*reduce/);
+    expect(css).toMatch(/\.bracket-node-enter\s*{[\s\S]*animation:\s*none/);
+  });
+
+  it("renders a mobile scroll hint when there is more than one round", () => {
+    const trace = buildBracketTrace(makeEntries(8));
+    render(<Bracket nodes={trace} ranked={makeRanked(8)} />);
+    const hint = screen.getByTestId("bracket-scroll-hint");
+    expect(hint.textContent?.toLowerCase()).toContain("swipe");
+    // Hidden from assistive tech — grid is already labelled.
+    expect(hint.getAttribute("aria-hidden")).toBe("true");
+    // Mobile-only utility class.
+    expect(hint.className).toContain("sm:hidden");
+  });
+
+  it("applies horizontal scroll + snap classes to the bracket grid", () => {
+    const trace = buildBracketTrace(makeEntries(8));
+    render(<Bracket nodes={trace} ranked={makeRanked(8)} />);
+    const grid = screen.getByTestId("bracket-grid");
+    expect(grid.className).toContain("overflow-x-auto");
+    expect(grid.className).toContain("snap-x");
+    // Snap turns off on >= sm so desktop doesn't jitter between columns.
+    expect(grid.className).toContain("sm:snap-none");
+  });
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -169,3 +169,29 @@ body {
     opacity: 0.5;
   }
 }
+
+/* Bracket slide-in (ticket #155) — fade + translate from left.
+   Tokenized duration/easing so individual nodes can opt into the
+   animation via inline `animation-delay` for per-round stagger.
+   `prefers-reduced-motion` forces an instant, static state so users
+   who opt out never see motion. */
+@keyframes bracket-node-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.bracket-node-enter {
+  animation: bracket-node-slide-in 300ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bracket-node-enter {
+    animation: none !important;
+  }
+}

--- a/components/bracket/bracket.tsx
+++ b/components/bracket/bracket.tsx
@@ -102,13 +102,18 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
 
       <div
         data-testid="bracket-grid"
-        className="flex gap-4 overflow-x-auto"
+        className="flex snap-x snap-mandatory gap-4 overflow-x-auto scroll-smooth sm:snap-none"
         style={{ gridTemplateColumns: `repeat(${totalRounds}, minmax(0, 1fr))` }}
       >
         {columns.map((column, roundIdx) => {
           const isFinal = roundIdx === totalRounds - 1;
+          // Per-round stagger: later rounds fade in slightly after earlier
+          // ones, producing a left-to-right "progression" reveal. Nodes
+          // within the same column share a delay — keeps the sequence
+          // readable without multiplying animation complexity.
+          const roundDelayMs = roundIdx * 120;
           return (
-            <div key={`round-group-${roundIdx}`} className="flex">
+            <div key={`round-group-${roundIdx}`} className="flex snap-start">
               <div
                 data-testid={`bracket-column-${roundIdx}`}
                 data-round={roundIdx}
@@ -121,12 +126,17 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
                   {roundLabel(roundIdx, totalRounds)}
                 </h3>
                 <div className="flex flex-col justify-around gap-3">
-                  {column.map((vm) => (
-                    <BracketNode
+                  {column.map((vm, nodeIdx) => (
+                    <div
                       key={`${vm.round}-${vm.matchId}`}
-                      node={vm}
-                      isFinal={isFinal}
-                    />
+                      data-testid={`bracket-node-wrap-${vm.round}-${vm.matchId}`}
+                      className="bracket-node-enter"
+                      style={{
+                        animationDelay: `${roundDelayMs + nodeIdx * 40}ms`,
+                      }}
+                    >
+                      <BracketNode node={vm} isFinal={isFinal} />
+                    </div>
                   ))}
                 </div>
               </div>
@@ -137,6 +147,20 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
           );
         })}
       </div>
+
+      {/* Mobile-only "scroll to see more" hint — hidden on >= sm when the
+          bracket fits on-screen without scrolling. Purely informational;
+          aria-hidden to avoid duplicate announcements because the grid
+          itself is already labelled. */}
+      {totalRounds > 1 && (
+        <p
+          data-testid="bracket-scroll-hint"
+          aria-hidden="true"
+          className="mt-2 text-center text-[11px] font-medium text-brand-text-secondary sm:hidden"
+        >
+          Swipe to see all rounds &rarr;
+        </p>
+      )}
 
       <footer className="mt-4 border-t border-brand-border-light pt-3">
         <p


### PR DESCRIPTION
Closes #155

## Summary

Completes the visual bracket experience by adding the progression-reveal animations and mobile scroll polish called for in ticket #155. The bracket container, node, and connector lines landed in prior tickets (#179, #199, #180, #212); this PR layers on the motion + mobile behaviors and keeps them on-brand (Champ Blue only, no raw hex, no new dependencies).

## What changed

- **Slide-in keyframes** (`app/globals.css`): new `@keyframes bracket-node-slide-in` (opacity + translateX) and a `.bracket-node-enter` utility class. A `@media (prefers-reduced-motion: reduce)` block zeroes the animation — users who opt out never see motion.
- **Per-round stagger** (`components/bracket/bracket.tsx`): each node is wrapped in a `bracket-node-enter` container with an inline `animation-delay`. Stagger formula: `roundIdx * 120ms + nodeIdx * 40ms` — produces a left-to-right progression reveal with a gentle cascade inside each column.
- **Mobile scroll** (`components/bracket/bracket.tsx`): grid now has `snap-x snap-mandatory` with `sm:snap-none` so phones get column snap points, tablets+ don't jitter. A small `Swipe to see all rounds →` hint appears only below `sm` and only when `totalRounds > 1`. `aria-hidden` because the grid itself is already labelled.
- **Tests** (`__tests__/bracket/bracket.test.tsx`): five new cases cover the stagger delays, the CSS motion-reduce contract (asserted against the globals.css source), the mobile hint presence/visibility, and the snap classes on the grid.

## Judgment calls (ticket left these open)

- **Duration**: 300ms ease-out — matches the existing pattern vocabulary (feels brisk, not flashy).
- **Per-round stagger**: 120ms — long enough to read as a progression, short enough that an 8-round bracket still settles in under 1s.
- **Within-round offset**: 40ms — a subtle cascade so adjacent matches don't pop in identically.
- **No Framer Motion**: the ticket said "add if not present — otherwise use CSS animations". CSS-only keeps bundle size flat and `prefers-reduced-motion` is handled natively.

## Guardrails honored

- No hard-coded round count — stagger computes from `roundIdx`, grid still renders N columns from props.
- Engine contract unchanged (`BracketMatch[]` + `RankedAllergen[]` inputs, same as before).
- `prefers-reduced-motion` respected at the CSS layer, not per-component.
- Mobile: horizontal scroll with momentum (`overflow-x-auto scroll-smooth`), no data-hiding collapse.
- Champ Blue only on lines/nodes; Nature Pop still reserved for the champion badge.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1060/1060 pass (14 bracket.test.tsx cases including the 5 new ones)
- [x] `npm run build` — succeeds
- [ ] Manual: load `/dashboard` on a narrow viewport, confirm snap scrolling and hint render; toggle `prefers-reduced-motion` in devtools and reload — nodes appear instantly