### PR TITLE
polish(allergens): propagate AllergenId type to ALLERGEN_IDS and TAXONOMY_MAP

### DIFF
--- a/__tests__/allergens/taxonomy-coverage.test.ts
+++ b/__tests__/allergens/taxonomy-coverage.test.ts
@@ -15,8 +15,12 @@ interface SeedRow {
 }
 
 describe("taxonomy coverage vs. allergens-seed.json", () => {
+  // Cast to `Set<string>` at the boundary so set-membership checks can
+  // accept arbitrary seed IDs. `ALLERGEN_IDS` is typed as
+  // `readonly AllergenId[]`, which narrows downstream consumers but
+  // would otherwise reject `.has(seedId: string)` here.
   const seedIds = new Set((allergensSeed as SeedRow[]).map((r) => r.id));
-  const taxonomyIds = new Set(ALLERGEN_IDS);
+  const taxonomyIds: Set<string> = new Set(ALLERGEN_IDS);
 
   it("seed data is non-empty (sanity)", () => {
     expect(seedIds.size).toBeGreaterThan(0);

--- a/lib/allergens/taxonomy.ts
+++ b/lib/allergens/taxonomy.ts
@@ -111,15 +111,18 @@ export const ALLERGEN_TAXONOMY = [
  */
 export type AllergenId = (typeof ALLERGEN_TAXONOMY)[number]["id"];
 
-export const ALLERGEN_IDS: readonly string[] = ALLERGEN_TAXONOMY.map(
+export const ALLERGEN_IDS: readonly AllergenId[] = ALLERGEN_TAXONOMY.map(
   (e) => e.id,
 );
 
 /**
  * Module-level index built once at import time. Replaces a linear
  * `Array.find()` scan (O(n)) with an O(1) `Map.get()` lookup.
+ *
+ * Keyed by `AllergenId` so `Map.get(id: AllergenId)` is the primary
+ * typed path; `getAllergenEntry(id: string)` casts at the boundary.
  */
-const ALLERGEN_BY_ID: ReadonlyMap<string, AllergenTaxonomyEntry> = new Map(
+const ALLERGEN_BY_ID: ReadonlyMap<AllergenId, AllergenTaxonomyEntry> = new Map(
   ALLERGEN_TAXONOMY.map((entry) => [entry.id, entry]),
 );
 
@@ -132,5 +135,8 @@ export function getAllergenEntry(
 export function getAllergenEntry(
   id: string,
 ): AllergenTaxonomyEntry | undefined {
-  return ALLERGEN_BY_ID.get(id);
+  // Cast at the boundary: the Map is keyed by the narrow `AllergenId`
+  // union, but the public overload accepts arbitrary strings and returns
+  // `undefined` for unknown keys.
+  return ALLERGEN_BY_ID.get(id as AllergenId);
 }


### PR DESCRIPTION
## Summary

Non-blocking polish from PR #219 review (ticket #220, parent #205). Propagates the `AllergenId` string literal union from the taxonomy source of truth out to two downstream spots so consumers get compile-time narrowing:

- `ALLERGEN_IDS` is now `readonly AllergenId[]` (was `readonly string[]`).
- `ALLERGEN_BY_ID` (the module-level O(1) lookup map) is now `ReadonlyMap<AllergenId, AllergenTaxonomyEntry>` (was keyed by `string`). The `getAllergenEntry(id: string)` overload still works via an explicit cast at the boundary so arbitrary-string lookups continue to return `undefined` for unknown IDs.

## Test plan

- [x] `__tests__/allergens/taxonomy-coverage.test.ts` still passes. It does `new Set(ALLERGEN_IDS)` and then `.has(seedId: string)`, which the narrower element type would otherwise reject — mitigated by annotating the local `taxonomyIds` as `Set<string>` at the test boundary (matches the seed-data shape, keeps the guard doing a pure string diff).
- [x] `__tests__/allergens/taxonomy.test.ts` passes unchanged.
- [x] `npm run lint && npm run typecheck && npm test && npm run build` all green locally.

Closes #220