### PR TITLE
polish(ui): Final Four gate follow-ups — TODO, naming, PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+<!--
+  PR title should use a conventional-commit prefix, e.g.:
+    feat(scope): ...
+    fix(scope): ...
+    polish(ui): ...
+  The PR body MUST include `Closes #<issue-number>` to auto-close the linked ticket on merge.
+-->
+
+## Summary
+
+<!-- 1-3 bullet points describing what changed and why. -->
+
+## Linked Issue
+
+Closes #
+
+## Test Plan
+
+- [ ] `npm run lint` passes
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
+- [ ] `npm run build` succeeds
+- [ ] Manual verification of the happy path (if applicable)
+
+## Screenshots
+
+<!--
+  Required for any PR that changes visible UI (components, pages, styles,
+  copy shown to users). Include a before/after pair when modifying existing
+  UI; a single shot is fine for net-new UI.
+
+  Skip this section only for backend-only, infra, docs, test-only, or
+  tooling PRs. If skipping, briefly note why (e.g. "backend-only, no UI
+  surface touched").
+-->
+
+## Notes for Reviewer
+
+<!-- Anything reviewers should pay extra attention to, or known follow-ups. -->

--- a/components/leaderboard/final-four-unlock-cta.tsx
+++ b/components/leaderboard/final-four-unlock-cta.tsx
@@ -113,6 +113,7 @@ export function FinalFourUnlockCta({
 
       {/* Secondary CTA — upgrade to Pro */}
       <Link
+        // TODO(billing): point to /upgrade once Stripe checkout lands. Tracked in future billing epic.
         href="/referral"
         data-testid="final-four-unlock-upgrade"
         onClick={() => onUpgradeClick?.()}

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -8,10 +8,16 @@
  *
  * Features:
  * - Trigger Champion (#1) always visible
- * - Final Four (#2-4) blurred for free tier, visible for premium
+ * - Final Four (#2-4) blurred for free tier; unlocked for Pro users or
+ *   free users who earn >= 3 referral credits via the referral-unlock path
  * - FDA disclaimer always visible
  * - Environmental Forecast mode when severity = 0
  * - First-time FDA acknowledgment gate
+ *
+ * Naming note: "Final Four" is the tournament-stage brand term (four
+ * survivors enter the semifinals). The UI renders three cards because
+ * rank #1 is extracted into the Trigger Champion above, leaving #2-#4
+ * in this section. Do not rename the user-facing copy.
  */
 
 import { useState, useEffect } from "react";


### PR DESCRIPTION
## Summary

Four small, independent polish items from the #164 review of the Final Four gated reveal (#157). No runtime behavior change.

- **TODO(billing) comment** added at the `/referral` placeholder in `components/leaderboard/final-four-unlock-cta.tsx` so the future `/upgrade` route intent survives beyond the merged PR body.
- **Header comment** in `components/leaderboard/leaderboard.tsx` updated to reflect the referral-unlock path (previously referenced only `isPremium`) and to explain the "Final Four" naming quirk inline: the tournament stage has four survivors; the UI renders three cards because rank #1 is extracted into the Trigger Champion above.
- **PR template** added at `.github/pull_request_template.md` with an explicit Screenshots section that clarifies when screenshots are required (UI-visible change) vs when to skip (backend/docs/infra — note briefly why).

## Linked Issue

Closes #165
Follow-up to #164.

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (1089 tests, 98 files)
- [x] `npm run build` succeeds

## Screenshots

Not applicable — changes are code comments, a header docblock, and a markdown template. No user-visible UI surface touched.

## Notes for Reviewer

- No public props, exported types, or user-facing copy changed.
- Did not rename any Final Four internals; ticket allowed either a comment or a variable rename and preferred the comment.
- Did not touch Final Four gate logic, redaction, or thresholds (explicit guardrail).