### PR TITLE
polish(engine): doc-only cleanups from PR #196 review

### DIFF
--- a/components/leaderboard/types.ts
+++ b/components/leaderboard/types.ts
@@ -29,8 +29,14 @@ export interface RankedAllergen {
    * from `lib/engine/confidence-score#getDiscriminativeConfidence`.
    * Answers "how far is this allergen's Elo from the pack?". By
    * construction #1 is high, #N is low (see issue #193).
-   * Optional during rollout: older payloads (and some test fixtures)
-   * may still omit it; new server code should populate it.
+   *
+   * Canonical population: the leaderboard API path
+   * (`app/api/leaderboard/route.ts` → `buildRankedFromEloRows`)
+   * ALWAYS populates this field. The `?` exists purely for
+   * legacy unit-test fixtures authored before issue #193 landed;
+   * flipping this to required would ripple through those fixtures
+   * and is an intentional non-goal of issue #198. New server code
+   * must populate it; new tests should populate it too.
    */
   discriminative?: number;
   /**
@@ -39,7 +45,11 @@ export interface RankedAllergen {
    * Answers "probability this allergen is actually top-K in
    * repeated tournaments under bounded noise." This is the
    * tier-driving number going forward (issue #193).
-   * Optional during rollout (see `discriminative`).
+   *
+   * Canonical population: same as `discriminative` above — the
+   * leaderboard API path always populates it; optionality exists
+   * only for legacy fixtures (see issue #198, explicit non-goal
+   * to flip to required).
    */
   posterior?: number;
   rank: number;

--- a/lib/engine/confidence-score.ts
+++ b/lib/engine/confidence-score.ts
@@ -149,7 +149,16 @@ export function getDiscriminativeConfidence(
   return clamp(sigmoid(k * delta), 0, 1);
 }
 
-/** Median of a numeric array. Non-mutating. */
+/**
+ * Median of a numeric array. Non-mutating.
+ *
+ * Scaling ceiling (issue #198): `getDiscriminativeConfidence`
+ * allocates a fresh sorted copy per call via `[...values].sort(...)`,
+ * yielding O(N log N) per allergen and O(N² log N) when invoked
+ * once per allergen in the leaderboard route. Fine for N ≤ few
+ * hundred; revisit (sort neighbors once in the caller) if the
+ * allergen catalog grows by an order of magnitude.
+ */
 function medianOf(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b);
   const n = sorted.length;
@@ -197,6 +206,22 @@ export const POSTERIOR_DEFAULT_TOP_K = 4;
 export const POSTERIOR_DEFAULT_NOISE = 0.25;
 
 /**
+ * Input shape for `getPosteriorConfidence`.
+ *
+ * The posterior Monte Carlo runner only needs the fields that feed
+ * pairwise sorting (`allergen_id`, `composite_score`) plus the
+ * metadata that rides along for downstream callers. It never reads
+ * `tier` — that field is an output of the confidence layers, not an
+ * input — so we omit it here. Narrowing the input stops callers from
+ * fabricating a `tier: "low" as const` placeholder just to satisfy
+ * the older `TournamentEntry[]` signature (issue #198).
+ *
+ * `TournamentEntry[]` remains assignable to `PosteriorInput[]` by
+ * structural subtyping, so existing callers keep working unchanged.
+ */
+export type PosteriorInput = Omit<TournamentEntry, "tier">;
+
+/**
  * Compute the posterior confidence for every allergen on a
  * leaderboard via seeded Monte Carlo resampling of the pairwise
  * tournament.
@@ -220,7 +245,7 @@ export const POSTERIOR_DEFAULT_NOISE = 0.25;
  * @returns map from allergen_id to posterior in [0, 1]
  */
 export function getPosteriorConfidence(
-  leaderboard: TournamentEntry[],
+  leaderboard: PosteriorInput[],
   options: PosteriorConfidenceOptions = {},
 ): Record<string, number> {
   const runs = options.runs ?? POSTERIOR_DEFAULT_RUNS;
@@ -244,14 +269,18 @@ export function getPosteriorConfidence(
   const noiseMagnitude = Math.max(0, noise) * POSTERIOR_NOISE_BASE;
 
   for (let r = 0; r < runs; r++) {
-    const perturbed: TournamentEntry[] = leaderboard.map((entry) => ({
+    const perturbed: PosteriorInput[] = leaderboard.map((entry) => ({
       ...entry,
       // Uniform draw in [-noiseMagnitude, +noiseMagnitude].
       composite_score:
         entry.composite_score + (rng() * 2 - 1) * noiseMagnitude,
     }));
 
-    const sorted = pairwiseSort(perturbed);
+    // `pairwiseSort` only reads `composite_score` and `allergen_id`;
+    // the `tier` field on `TournamentEntry` is unused here. The cast
+    // below keeps `pairwiseSort`'s public signature untouched (issue
+    // #198 non-goal: don't broaden tournament.ts).
+    const sorted = pairwiseSort(perturbed as TournamentEntry[]);
     const topSize = Math.min(topK, sorted.length);
     for (let i = 0; i < topSize; i++) {
       tally[sorted[i].allergen_id] += 1;


### PR DESCRIPTION
## Summary

Three zero-behavior-change follow-ups from the PR #196 review, narrowed per the ticket scope on 2026-04-17.

1. **JSDoc on `RankedAllergen.discriminative?` / `posterior?`** — documents that the canonical API path (`app/api/leaderboard/route.ts` → `buildRankedFromEloRows`) always populates both fields; the `?` exists only for legacy unit-test fixtures. Flipping to required is an explicit non-goal.
2. **Scaling-ceiling comment on `medianOf`** — notes that `getDiscriminativeConfidence` allocates a sorted copy per call, yielding O(N^2 log N) when invoked per-allergen. Doc only; no refactor per ticket guardrail.
3. **Narrow `getPosteriorConfidence` input type** — introduces `PosteriorInput = Omit<TournamentEntry, "tier">` and uses it for the public signature. Existing callers that pass `TournamentEntry[]` still typecheck via structural subtyping, so no call-site updates were needed to keep the build green.

### Scope note

The ticket body called out dropping the `tier: "low" as const` placeholder in `app/api/leaderboard/route.ts`, but after the #200 refactor that placeholder now lives in `lib/engine/ranked-leaderboard.ts` and `app/api/report/pdf/route.ts` — outside the three files listed in the autonomous scope caveat. The type narrowing in this PR prevents *future* callers from needing to fabricate one; the two remaining in-tree placeholders can be cleaned up in a small follow-up if desired (they continue to typecheck as-is).

## Guardrail compliance

- No runtime behavior change — no sigmoid / noise / threshold tweaks
- No tests added or modified
- Optional fields on `RankedAllergen` stay optional (explicit non-goal)
- Route neighbor-sort refactor skipped (explicit non-goal)
- Files touched: `components/leaderboard/types.ts`, `lib/engine/confidence-score.ts`

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1089/1089 passing (unchanged)
- [x] `npm run build` — green

Closes #198