### PR TITLE
polish(engine): sweep stale tier placeholders

### DIFF
--- a/app/api/report/pdf/route.ts
+++ b/app/api/report/pdf/route.ts
@@ -19,7 +19,7 @@ import {
   getPosteriorConfidence,
   getConfidenceTierByPosterior,
 } from "@/lib/engine";
-import type { TournamentEntry } from "@/lib/engine";
+import type { PosteriorInput } from "@/lib/engine";
 
 /** Shape returned by the Supabase join query */
 interface EloRowWithAllergen {
@@ -103,12 +103,11 @@ export async function GET() {
   // Two-layer confidence model (issue #193) — mirrors the logic in
   // `app/api/leaderboard/route.ts` so the PDF report's tier string
   // matches the leaderboard byte-for-byte.
-  const tournamentEntries: TournamentEntry[] = eloRows.map((row) => ({
+  const tournamentEntries: PosteriorInput[] = eloRows.map((row) => ({
     allergen_id: row.allergen_id,
     common_name: row.allergens.common_name,
     category: row.allergens.category,
     composite_score: row.elo_score,
-    tier: "low" as const,
   }));
   const posteriors = getPosteriorConfidence(tournamentEntries, { seed: 0 });
 

--- a/lib/engine/index.ts
+++ b/lib/engine/index.ts
@@ -85,7 +85,7 @@ export {
   POSTERIOR_DEFAULT_TOP_K,
   POSTERIOR_DEFAULT_NOISE,
 } from "./confidence-score";
-export type { PosteriorConfidenceOptions } from "./confidence-score";
+export type { PosteriorConfidenceOptions, PosteriorInput } from "./confidence-score";
 
 // Monte Carlo exposure simulation
 export type {


### PR DESCRIPTION
## Summary

PR #230 narrowed `getPosteriorConfidence`'s input to `PosteriorInput = Omit<TournamentEntry, "tier">`. The PDF report route still fabricated a `tier: "low" as const` placeholder that now serves no purpose. This PR drops it and retypes the local as `PosteriorInput[]`.

## Scope note

The ticket also cited `lib/engine/ranked-leaderboard.ts` line ~88. That call site's `tournamentEntries` projection is **returned** from `buildRankedFromEloRows` and downstream fed into `buildBracketTrace`, which still accepts `readonly TournamentEntry[]`. Removing the placeholder there would require widening a third signature, which is outside the XS polish envelope. Left as-is; callable as a follow-up if desired.

## Changes

- `app/api/report/pdf/route.ts`: drop `tier: "low" as const` field; retype local from `TournamentEntry[]` to `PosteriorInput[]`; swap import.
- `lib/engine/index.ts`: re-export `PosteriorInput` so the route can import it.

Net: +3 / -4 lines, no behavior change.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` — all 1089 tests pass
- [x] `npm run build` succeeds

Closes #231