### PR TITLE
polish(engine): per-user posterior seeding

### DIFF
--- a/__tests__/api/leaderboard.test.ts
+++ b/__tests__/api/leaderboard.test.ts
@@ -314,3 +314,53 @@ describe("GET /api/leaderboard", () => {
     }
   });
 });
+
+/* ------------------------------------------------------------------ */
+/* Per-user posterior seeding (#229)                                   */
+/* ------------------------------------------------------------------ */
+
+describe("per-user posterior seeding (#229)", () => {
+  it("two different user IDs produce different posterior maps on the same leaderboard", async () => {
+    // Exercise `buildRankedFromEloRows` directly — same helper the
+    // route delegates to. A regression to `seed: 0` for all users
+    // would produce byte-identical maps and fail this test.
+    const { buildRankedFromEloRows } = await import(
+      "@/lib/engine/ranked-leaderboard"
+    );
+    const { hashStringToInt32 } = await import("@/lib/engine/hash");
+
+    // Enough entries (> default topK=4) with close Elos so tail
+    // allergens fall in and out of the top-K across Monte Carlo
+    // runs, making the posterior map genuinely seed-dependent.
+    const rows = [
+      { allergen_id: "a", elo_score: 1650, positive_signals: 10, negative_signals: 3, common_name: "A", category: "tree" },
+      { allergen_id: "b", elo_score: 1620, positive_signals: 9,  negative_signals: 3, common_name: "B", category: "tree" },
+      { allergen_id: "c", elo_score: 1600, positive_signals: 8,  negative_signals: 3, common_name: "C", category: "grass" },
+      { allergen_id: "d", elo_score: 1585, positive_signals: 7,  negative_signals: 3, common_name: "D", category: "grass" },
+      { allergen_id: "e", elo_score: 1570, positive_signals: 6,  negative_signals: 3, common_name: "E", category: "weed" },
+      { allergen_id: "f", elo_score: 1555, positive_signals: 5,  negative_signals: 3, common_name: "F", category: "weed" },
+      { allergen_id: "g", elo_score: 1540, positive_signals: 4,  negative_signals: 3, common_name: "G", category: "mold" },
+      { allergen_id: "h", elo_score: 1525, positive_signals: 3,  negative_signals: 3, common_name: "H", category: "mold" },
+    ];
+
+    const userA = "user-alpha";
+    const userB = "user-beta";
+
+    const resultA = buildRankedFromEloRows(rows, {
+      seed: hashStringToInt32(userA),
+      scoreSource: "discriminative",
+    });
+    const resultB = buildRankedFromEloRows(rows, {
+      seed: hashStringToInt32(userB),
+      scoreSource: "discriminative",
+    });
+
+    // Sanity: the hashes themselves differ.
+    expect(hashStringToInt32(userA)).not.toBe(hashStringToInt32(userB));
+
+    // Core assertion: posterior maps are NOT byte-identical.
+    const posteriorsA = resultA.allergens.map((a) => a.posterior);
+    const posteriorsB = resultB.allergens.map((a) => a.posterior);
+    expect(posteriorsA).not.toEqual(posteriorsB);
+  });
+});

--- a/__tests__/engine/hash.test.ts
+++ b/__tests__/engine/hash.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for `hashStringToInt32` (issue #229).
+ *
+ * The hash drives per-user posterior seeding on the leaderboard route.
+ * It must be deterministic, small-change sensitive, and always produce
+ * a valid int32 — those are the four properties exercised here.
+ */
+
+import { describe, it, expect } from "vitest";
+import { hashStringToInt32 } from "@/lib/engine/hash";
+
+const INT32_MIN = -(2 ** 31);
+const INT32_MAX = 2 ** 31 - 1;
+
+describe("hashStringToInt32", () => {
+  it("is deterministic — same input produces same output", () => {
+    expect(hashStringToInt32("a")).toBe(hashStringToInt32("a"));
+    expect(hashStringToInt32("user-123")).toBe(hashStringToInt32("user-123"));
+    expect(hashStringToInt32("")).toBe(hashStringToInt32(""));
+  });
+
+  it("is sensitive to small changes — adjacent inputs diverge", () => {
+    expect(hashStringToInt32("abc")).not.toBe(hashStringToInt32("abd"));
+    expect(hashStringToInt32("user-1")).not.toBe(hashStringToInt32("user-2"));
+  });
+
+  it("returns the FNV-1a offset basis (cast to int32) for the empty string", () => {
+    // 0x811c9dc5 has the high bit set, so `| 0` casts it to a negative int32.
+    expect(hashStringToInt32("")).toBe(0x811c9dc5 | 0);
+    expect(hashStringToInt32("")).toBe(-2128831035);
+  });
+
+  it("always returns a valid int32", () => {
+    const samples = [
+      "",
+      "a",
+      "ab",
+      "abc",
+      "user-123",
+      "00000000-0000-0000-0000-000000000000",
+      "e7c9c4a2-1234-5678-9abc-def012345678",
+      "\u{1F600}\u{1F4A9}",
+      "a".repeat(1000),
+    ];
+
+    for (const s of samples) {
+      const h = hashStringToInt32(s);
+      expect(Number.isInteger(h)).toBe(true);
+      expect(h).toBeGreaterThanOrEqual(INT32_MIN);
+      expect(h).toBeLessThanOrEqual(INT32_MAX);
+    }
+  });
+});

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { buildRankedFromEloRows } from "@/lib/engine";
+import { hashStringToInt32 } from "@/lib/engine/hash";
 
 /**
  * Shape returned by the Supabase join query.
@@ -120,7 +121,7 @@ export async function GET() {
       common_name: row.allergens.common_name,
       category: row.allergens.category,
     })),
-    { seed: 0, scoreSource: "discriminative" },
+    { seed: hashStringToInt32(user.id), scoreSource: "discriminative" },
   );
 
   return NextResponse.json({

--- a/lib/engine/hash.ts
+++ b/lib/engine/hash.ts
@@ -1,0 +1,30 @@
+/**
+ * Deterministic string-to-int32 hash (FNV-1a).
+ *
+ * Used to derive a per-user seed for posterior confidence Monte Carlo
+ * sampling (issue #229). Keeping the hash pure and deterministic means
+ * every user gets a reproducible noise sequence, while two different
+ * users get decorrelated sequences — avoiding the prior behavior where
+ * every user shared the hardcoded `seed: 0`.
+ *
+ * Non-adversarial bucketing: FNV-1a is not a cryptographic hash and
+ * must not be used where collision resistance matters.
+ *
+ * Implementation notes:
+ *   - Pure function: no randomness, no wall-clock, no I/O.
+ *   - No dependencies: ~10 lines of JS.
+ *   - Output is always a valid int32 in `[-2^31, 2^31 - 1]`, compatible
+ *     with the downstream `seed: number` parameter on
+ *     `getPosteriorConfidence`.
+ *   - `Math.imul` keeps the intermediate multiplication inside int32
+ *     space (JS `*` would promote to float64 and lose low bits on the
+ *     FNV prime).
+ */
+export function hashStringToInt32(s: string): number {
+  let h = 0x811c9dc5; // FNV-1a offset basis
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193); // FNV-1a prime
+  }
+  return h | 0; // force int32
+}


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `seed: 0` in `app/api/leaderboard/route.ts` with `hashStringToInt32(user.id)` so every user gets a deterministic-but-decorrelated Monte Carlo noise sequence for posterior confidence.
- Adds a pure FNV-1a string-to-int32 hash in `lib/engine/hash.ts` (no deps, always int32, no randomness/wall-clock).
- Adds unit coverage for the hash and a regression test asserting two different user IDs produce different posterior maps on the same leaderboard fixture.

## Details

Before this change, two users with identical Elo rows got byte-identical posterior maps because the route pinned `seed: 0`. The helper `buildRankedFromEloRows` already forwards a `seed` option to `getPosteriorConfidence`, so the route is the only production wiring change. Existing unit tests that rely on `seed: 0` continue to call the engine helpers directly with an explicit seed and are unaffected.

Scope follows the ticket Happy Path exactly. No changes to sigmoid, noise base, or tier thresholds.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (1094 tests pass)
- [x] `npm run build`
- [x] New `__tests__/engine/hash.test.ts` covers determinism, small-change sensitivity, empty-string offset basis, int32 range
- [x] New case in `__tests__/api/leaderboard.test.ts` asserts per-user posterior differentiation

Closes #229

Generated with Claude Code