### PR TITLE
feat(travel): Travel Mode API + schema

### DIFF
--- a/__tests__/api/travel.test.ts
+++ b/__tests__/api/travel.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Travel Mode API Route Tests
+ *
+ * Tests the GET / POST / DELETE /api/travel endpoints.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/travel", () => ({
+  activateTravel: vi.fn(),
+  deactivateTravel: vi.fn(),
+  getActiveSession: vi.fn(),
+}));
+
+import { createClient } from "@/lib/supabase/server";
+import {
+  activateTravel,
+  deactivateTravel,
+  getActiveSession,
+} from "@/lib/travel";
+import { GET, POST, DELETE } from "@/app/api/travel/route";
+
+function mockSupabase(user: { id: string } | null) {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user } }),
+    },
+  };
+}
+
+describe("GET /api/travel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createClient).mockResolvedValue(mockSupabase(null) as never);
+    const response = await GET();
+    expect(response.status).toBe(401);
+  });
+
+  it("returns the active session for the authenticated user", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      mockSupabase({ id: "user-123" }) as never,
+    );
+    vi.mocked(getActiveSession).mockResolvedValue({
+      id: "sess-1",
+      location_id: "loc-1",
+      started_at: "2026-04-16T00:00:00.000Z",
+    });
+
+    const response = await GET();
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.session?.id).toBe("sess-1");
+  });
+
+  it("returns null session when there is no active session", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      mockSupabase({ id: "user-123" }) as never,
+    );
+    vi.mocked(getActiveSession).mockResolvedValue(null);
+
+    const response = await GET();
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.session).toBeNull();
+  });
+});
+
+describe("POST /api/travel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createClient).mockResolvedValue(mockSupabase(null) as never);
+    const req = new Request("http://localhost/api/travel", {
+      method: "POST",
+      body: JSON.stringify({ lat: 40.7, lng: -74.0 }),
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 with a session on successful activation", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      mockSupabase({ id: "user-123" }) as never,
+    );
+    vi.mocked(activateTravel).mockResolvedValue({
+      success: true,
+      session: {
+        id: "sess-1",
+        location_id: "loc-1",
+        started_at: "2026-04-16T00:00:00.000Z",
+      },
+    });
+
+    const req = new Request("http://localhost/api/travel", {
+      method: "POST",
+      body: JSON.stringify({ lat: 40.7, lng: -74.0 }),
+    });
+    const response = await POST(req);
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.session.id).toBe("sess-1");
+  });
+
+  it("returns 409 when an active session already exists", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      mockSupabase({ id: "user-123" }) as never,
+    );
+    vi.mocked(activateTravel).mockResolvedValue({
+      success: false,
+      error: "An active travel session already exists",
+      code: "active_session_exists",
+    });
+
+    const req = new Request("http://localhost/api/travel", {
+      method: "POST",
+      body: JSON.stringify({ lat: 40.7, lng: -74.0 }),
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(409);
+  });
+
+  it("returns 400 on invalid coordinates", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      mockSupabase({ id: "user-123" }) as never,
+    );
+    vi.mocked(activateTravel).mockResolvedValue({
+      success: false,
+      error: "Invalid coordinates",
+      code: "validation",
+    });
+
+    const req = new Request("http://localhost/api/travel", {
+      method: "POST",
+      body: JSON.stringify({ lat: 999, lng: 0 }),
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when the body is not valid JSON", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      mockSupabase({ id: "user-123" }) as never,
+    );
+    const req = new Request("http://localhost/api/travel", {
+      method: "POST",
+      body: "not json",
+    });
+    const response = await POST(req);
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/travel", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createClient).mockResolvedValue(mockSupabase(null) as never);
+    const response = await DELETE();
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 when deactivation succeeds", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      mockSupabase({ id: "user-123" }) as never,
+    );
+    vi.mocked(deactivateTravel).mockResolvedValue({
+      success: true,
+      session: {
+        id: "sess-1",
+        location_id: "loc-1",
+        started_at: "2026-04-16T00:00:00.000Z",
+      },
+    });
+    const response = await DELETE();
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 404 when there is no active session", async () => {
+    vi.mocked(createClient).mockResolvedValue(
+      mockSupabase({ id: "user-123" }) as never,
+    );
+    vi.mocked(deactivateTravel).mockResolvedValue({
+      success: false,
+      error: "No active travel session",
+      code: "no_active_session",
+    });
+    const response = await DELETE();
+    expect(response.status).toBe(404);
+  });
+});

--- a/__tests__/travel/service.test.ts
+++ b/__tests__/travel/service.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Travel Mode Service Tests
+ *
+ * Tests business logic for activating / deactivating travel sessions and
+ * the guardrail that home Elo rows must not be modified.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  activateTravel,
+  deactivateTravel,
+  getActiveSession,
+} from "@/lib/travel/service";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/* ------------------------------------------------------------------ */
+/* Mock client helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+interface TableState {
+  user_locations: Array<{
+    id: string;
+    user_id: string;
+    is_home: boolean;
+    lat: number | null;
+    lng: number | null;
+    region: string | null;
+    state: string | null;
+  }>;
+  travel_sessions: Array<{
+    id: string;
+    user_id: string;
+    location_id: string;
+    started_at: string;
+    ended_at: string | null;
+  }>;
+  user_allergen_elo: Array<{
+    id: string;
+    user_id: string;
+    allergen_id: string;
+    location_id: string | null;
+    elo_score: number;
+  }>;
+}
+
+/**
+ * A minimal in-memory Supabase stub that supports the exact chain shapes
+ * used by `lib/travel/service.ts`. Unsupported chains throw loudly.
+ */
+function makeStub(state: TableState) {
+  let idCounter = 1;
+  function nextId() {
+    return `id-${idCounter++}`;
+  }
+
+  function fromUserLocations() {
+    return {
+      // .select("...").eq("user_id", id).eq("is_home", false)
+      select: (_cols: string) => ({
+        eq: (col1: string, val1: string) => ({
+          eq: (col2: string, val2: unknown) => {
+            const rows = state.user_locations.filter(
+              (r) =>
+                (r as unknown as Record<string, unknown>)[col1] === val1 &&
+                (r as unknown as Record<string, unknown>)[col2] === val2,
+            );
+            return Promise.resolve({ data: rows, error: null });
+          },
+        }),
+      }),
+      insert: (data: {
+        user_id: string;
+        is_home: boolean;
+        lat: number;
+        lng: number;
+        region: string | null;
+        state: string | null;
+        nickname: string | null;
+      }) => ({
+        select: (_cols: string) => ({
+          single: () => {
+            const row = {
+              id: nextId(),
+              user_id: data.user_id,
+              is_home: data.is_home,
+              lat: data.lat,
+              lng: data.lng,
+              region: data.region,
+              state: data.state,
+            };
+            state.user_locations.push(row);
+            return Promise.resolve({
+              data: { id: row.id, region: row.region },
+              error: null,
+            });
+          },
+        }),
+      }),
+    };
+  }
+
+  function fromTravelSessions() {
+    return {
+      select: (_cols: string) => ({
+        eq: (_col1: string, val1: string) => ({
+          is: (_col2: string, _val2: null) => ({
+            maybeSingle: () => {
+              const row = state.travel_sessions.find(
+                (r) => r.user_id === val1 && r.ended_at === null,
+              );
+              return Promise.resolve({
+                data: row
+                  ? {
+                      id: row.id,
+                      location_id: row.location_id,
+                      started_at: row.started_at,
+                    }
+                  : null,
+                error: null,
+              });
+            },
+          }),
+        }),
+      }),
+      insert: (data: { user_id: string; location_id: string }) => ({
+        select: (_cols: string) => ({
+          single: () => {
+            // Enforce partial unique index semantics.
+            const hasActive = state.travel_sessions.some(
+              (r) => r.user_id === data.user_id && r.ended_at === null,
+            );
+            if (hasActive) {
+              return Promise.resolve({
+                data: null,
+                error: {
+                  message: "duplicate key value violates unique constraint",
+                  code: "23505",
+                },
+              });
+            }
+            const row = {
+              id: nextId(),
+              user_id: data.user_id,
+              location_id: data.location_id,
+              started_at: new Date().toISOString(),
+              ended_at: null,
+            };
+            state.travel_sessions.push(row);
+            return Promise.resolve({
+              data: {
+                id: row.id,
+                location_id: row.location_id,
+                started_at: row.started_at,
+              },
+              error: null,
+            });
+          },
+        }),
+      }),
+      update: (data: { ended_at: string }) => ({
+        eq: (_col1: string, val1: string) => ({
+          is: (_col2: string, _val2: null) => {
+            const row = state.travel_sessions.find(
+              (r) => r.user_id === val1 && r.ended_at === null,
+            );
+            if (row) row.ended_at = data.ended_at;
+            return Promise.resolve({ error: null });
+          },
+        }),
+      }),
+    };
+  }
+
+  function fromUserAllergenElo() {
+    return {
+      insert: (rows: Array<{
+        user_id: string;
+        allergen_id: string;
+        location_id: string | null;
+        elo_score: number;
+      }>) => {
+        for (const r of rows) {
+          state.user_allergen_elo.push({
+            id: nextId(),
+            user_id: r.user_id,
+            allergen_id: r.allergen_id,
+            location_id: r.location_id,
+            elo_score: r.elo_score,
+          });
+        }
+        return Promise.resolve({ error: null });
+      },
+    };
+  }
+
+  const client = {
+    from: (table: string) => {
+      if (table === "user_locations") return fromUserLocations();
+      if (table === "travel_sessions") return fromTravelSessions();
+      if (table === "user_allergen_elo") return fromUserAllergenElo();
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  } as unknown as SupabaseClient;
+
+  return client;
+}
+
+function emptyState(): TableState {
+  return {
+    user_locations: [],
+    travel_sessions: [],
+    user_allergen_elo: [],
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+const USER_A = "user-a";
+const USER_B = "user-b";
+
+describe("activateTravel", () => {
+  it("rejects invalid coordinates with a validation error", async () => {
+    const client = makeStub(emptyState());
+    const result = await activateTravel(client, USER_A, {
+      lat: 999,
+      lng: 0,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("validation");
+    }
+  });
+
+  it("creates a new location, inserts a session, and seeds location-scoped Elo", async () => {
+    const state = emptyState();
+    // Seed a home location + one home Elo row that must remain untouched.
+    state.user_locations.push({
+      id: "home-loc",
+      user_id: USER_A,
+      is_home: true,
+      lat: 36.16,
+      lng: -86.78,
+      region: "Southeast",
+      state: "TN",
+    });
+    state.user_allergen_elo.push({
+      id: "home-elo",
+      user_id: USER_A,
+      allergen_id: "oak",
+      location_id: "home-loc",
+      elo_score: 1650,
+    });
+
+    const client = makeStub(state);
+    const result = await activateTravel(client, USER_A, {
+      lat: 40.7,
+      lng: -74.0,
+      state: "NY",
+    });
+
+    expect(result.success).toBe(true);
+    expect(state.travel_sessions).toHaveLength(1);
+    expect(state.travel_sessions[0].user_id).toBe(USER_A);
+    expect(state.travel_sessions[0].ended_at).toBeNull();
+
+    // Home elo untouched (count + value).
+    const homeRows = state.user_allergen_elo.filter(
+      (r) => r.location_id === "home-loc",
+    );
+    expect(homeRows).toHaveLength(1);
+    expect(homeRows[0].elo_score).toBe(1650);
+
+    // New travel-scoped Elo rows exist under the new location_id.
+    const travelLocationId = state.travel_sessions[0].location_id;
+    const travelRows = state.user_allergen_elo.filter(
+      (r) => r.location_id === travelLocationId,
+    );
+    expect(travelRows.length).toBeGreaterThan(0);
+  });
+
+  it("reuses an existing nearby non-home user_locations row (~1km)", async () => {
+    const state = emptyState();
+    state.user_locations.push({
+      id: "nearby",
+      user_id: USER_A,
+      is_home: false,
+      lat: 40.7001,
+      lng: -74.0001,
+      region: "Northeast",
+      state: "NY",
+    });
+
+    const client = makeStub(state);
+    const result = await activateTravel(client, USER_A, {
+      lat: 40.7,
+      lng: -74.0,
+    });
+
+    expect(result.success).toBe(true);
+    // No new user_locations row created.
+    expect(state.user_locations).toHaveLength(1);
+    if (result.success) {
+      expect(result.session.location_id).toBe("nearby");
+    }
+  });
+
+  it("returns 409-style active_session_exists when a session is already open", async () => {
+    const state = emptyState();
+    const client = makeStub(state);
+
+    const first = await activateTravel(client, USER_A, {
+      lat: 40.7,
+      lng: -74.0,
+    });
+    expect(first.success).toBe(true);
+
+    const second = await activateTravel(client, USER_A, {
+      lat: 40.7,
+      lng: -74.0,
+    });
+    expect(second.success).toBe(false);
+    if (!second.success) {
+      expect(second.code).toBe("active_session_exists");
+    }
+  });
+});
+
+describe("deactivateTravel", () => {
+  it("sets ended_at on the active session and leaves home Elo untouched", async () => {
+    const state = emptyState();
+    state.user_allergen_elo.push({
+      id: "home-elo",
+      user_id: USER_A,
+      allergen_id: "oak",
+      location_id: "home-loc",
+      elo_score: 1650,
+    });
+    const client = makeStub(state);
+
+    const activated = await activateTravel(client, USER_A, {
+      lat: 40.7,
+      lng: -74.0,
+    });
+    expect(activated.success).toBe(true);
+
+    const deactivated = await deactivateTravel(client, USER_A);
+    expect(deactivated.success).toBe(true);
+
+    expect(state.travel_sessions[0].ended_at).not.toBeNull();
+
+    // Home elo assertion.
+    const homeRows = state.user_allergen_elo.filter(
+      (r) => r.location_id === "home-loc",
+    );
+    expect(homeRows).toHaveLength(1);
+    expect(homeRows[0].elo_score).toBe(1650);
+  });
+
+  it("returns no_active_session when there is nothing to end", async () => {
+    const client = makeStub(emptyState());
+    const result = await deactivateTravel(client, USER_A);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe("no_active_session");
+    }
+  });
+});
+
+describe("getActiveSession", () => {
+  it("returns null when no active session exists", async () => {
+    const client = makeStub(emptyState());
+    const result = await getActiveSession(client, USER_A);
+    expect(result).toBeNull();
+  });
+
+  it("returns only the caller's own active session (RLS-consistent)", async () => {
+    // RLS is enforced at the DB — our stub only filters by user_id on the
+    // chain. This test simulates the surface behavior: user B's session
+    // is not returned when user A queries.
+    const state = emptyState();
+    state.travel_sessions.push({
+      id: "sess-b",
+      user_id: USER_B,
+      location_id: "loc-b",
+      started_at: new Date().toISOString(),
+      ended_at: null,
+    });
+
+    const client = makeStub(state);
+    const result = await getActiveSession(client, USER_A);
+    expect(result).toBeNull();
+  });
+});
+
+// Silence logger.error calls that otherwise pollute test output.
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));

--- a/app/api/travel/route.ts
+++ b/app/api/travel/route.ts
@@ -1,0 +1,153 @@
+/**
+ * /api/travel — Travel Mode activation
+ *
+ * POST   — Activate travel mode for a given lat/lng. Seeds location-scoped
+ *          Elo. Returns 409 if an active session already exists.
+ * DELETE — Deactivate the current active session (sets ended_at).
+ * GET    — Return the current active session, or `{ session: null }`.
+ *
+ * Ticket: #223 — Travel Mode API + schema
+ *
+ * Auth: all methods require a Supabase user. Server-only — do not import
+ * from a client component.
+ */
+
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import {
+  activateTravel,
+  deactivateTravel,
+  getActiveSession,
+} from "@/lib/travel";
+import type { ActivateTravelInput } from "@/lib/travel";
+import { logger } from "@/lib/logger";
+
+interface ErrorResponse {
+  success: false;
+  error: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* GET /api/travel — current active session                           */
+/* ------------------------------------------------------------------ */
+
+export async function GET(): Promise<NextResponse> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" } satisfies ErrorResponse,
+        { status: 401 },
+      );
+    }
+
+    const session = await getActiveSession(supabase, user.id);
+    return NextResponse.json({ success: true, session });
+  } catch (err) {
+    logger.error("Travel GET error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { success: false, error: "An unexpected error occurred" } satisfies ErrorResponse,
+      { status: 500 },
+    );
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* POST /api/travel — activate                                         */
+/* ------------------------------------------------------------------ */
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" } satisfies ErrorResponse,
+        { status: 401 },
+      );
+    }
+
+    let body: ActivateTravelInput;
+    try {
+      body = (await request.json()) as ActivateTravelInput;
+    } catch {
+      return NextResponse.json(
+        { success: false, error: "Invalid JSON body" } satisfies ErrorResponse,
+        { status: 400 },
+      );
+    }
+
+    const result = await activateTravel(supabase, user.id, body);
+
+    if (!result.success) {
+      const status =
+        result.code === "validation"
+          ? 400
+          : result.code === "active_session_exists"
+            ? 409
+            : 500;
+      return NextResponse.json(
+        { success: false, error: result.error } satisfies ErrorResponse,
+        { status },
+      );
+    }
+
+    return NextResponse.json({ success: true, session: result.session });
+  } catch (err) {
+    logger.error("Travel POST error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { success: false, error: "An unexpected error occurred" } satisfies ErrorResponse,
+      { status: 500 },
+    );
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* DELETE /api/travel — deactivate                                     */
+/* ------------------------------------------------------------------ */
+
+export async function DELETE(): Promise<NextResponse> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" } satisfies ErrorResponse,
+        { status: 401 },
+      );
+    }
+
+    const result = await deactivateTravel(supabase, user.id);
+    if (!result.success) {
+      const status = result.code === "no_active_session" ? 404 : 500;
+      return NextResponse.json(
+        { success: false, error: result.error } satisfies ErrorResponse,
+        { status },
+      );
+    }
+
+    return NextResponse.json({ success: true, session: result.session });
+  } catch (err) {
+    logger.error("Travel DELETE error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { success: false, error: "An unexpected error occurred" } satisfies ErrorResponse,
+      { status: 500 },
+    );
+  }
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -686,6 +686,30 @@ export interface Database {
         };
       };
 
+      travel_sessions: {
+        Row: {
+          id: string;
+          user_id: string;
+          location_id: string;
+          started_at: string;
+          ended_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          location_id: string;
+          started_at?: string;
+          ended_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          location_id?: string;
+          started_at?: string;
+          ended_at?: string | null;
+        };
+      };
+
       referrals: {
         Row: {
           id: string;
@@ -760,6 +784,10 @@ export type UserSubscriptionUpdate = Tables["user_subscriptions"]["Update"];
 export type Referral = Tables["referrals"]["Row"];
 export type ReferralInsert = Tables["referrals"]["Insert"];
 export type ReferralUpdate = Tables["referrals"]["Update"];
+
+export type TravelSession = Tables["travel_sessions"]["Row"];
+export type TravelSessionInsert = Tables["travel_sessions"]["Insert"];
+export type TravelSessionUpdate = Tables["travel_sessions"]["Update"];
 
 /**
  * UserProfile with income_tier stripped out.

--- a/lib/travel/index.ts
+++ b/lib/travel/index.ts
@@ -1,0 +1,11 @@
+export {
+  activateTravel,
+  deactivateTravel,
+  getActiveSession,
+} from "./service";
+export type {
+  ActivateTravelInput,
+  TravelSessionSummary,
+  ActivateResult,
+  DeactivateResult,
+} from "./service";

--- a/lib/travel/service.ts
+++ b/lib/travel/service.ts
@@ -1,0 +1,420 @@
+/**
+ * Travel Mode Service
+ *
+ * Server-side business logic for activating, deactivating, and reading
+ * transient travel sessions. A travel session scopes a fresh set of
+ * regional Elo records to a specific `user_locations.id` so the tournament
+ * engine can re-rank allergens for the user's current physical location
+ * WITHOUT corrupting the user's home Elo history.
+ *
+ * Ticket: #223 — Travel Mode API + schema
+ * Parent Epic: #27 — Travel Mode + Saved Places
+ *
+ * Guardrails:
+ * - Server-only: must NEVER be imported by a client component.
+ * - Does not log lat/lng/address/PHI — uses opaque IDs only.
+ * - Only one active session per user is allowed. The partial unique index
+ *   on `travel_sessions(user_id) WHERE ended_at IS NULL` enforces this at
+ *   the DB level; we surface a 409 on violation.
+ * - NEVER deletes or updates `user_allergen_elo` rows with the home
+ *   `location_id` (or NULL). Travel re-seed only INSERTs new rows scoped
+ *   to the travel location_id.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
+import type {
+  UserAllergenEloInsert,
+  Region,
+} from "@/lib/supabase/types";
+import { getRegionFromState } from "@/lib/onboarding";
+import { initializeAllElo } from "@/lib/engine/elo";
+import allergenSeed from "@/lib/data/allergens-seed.json";
+import type { Allergen } from "@/lib/engine/types";
+import { logger } from "@/lib/logger";
+
+type SupabaseDB = SupabaseClient<Database>;
+
+/** Nearest-match radius for reusing an existing user_locations row. ~1km. */
+const NEAREST_MATCH_DEGREES = 0.01;
+
+/* ------------------------------------------------------------------ */
+/* Public types                                                        */
+/* ------------------------------------------------------------------ */
+
+export interface ActivateTravelInput {
+  lat: number;
+  lng: number;
+  nickname?: string;
+  /** Optional state abbreviation used to seed regional allergens. */
+  state?: string;
+}
+
+export interface TravelSessionSummary {
+  id: string;
+  location_id: string;
+  started_at: string;
+}
+
+export type ActivateResult =
+  | { success: true; session: TravelSessionSummary }
+  | { success: false; error: string; code: "active_session_exists" | "location_failed" | "session_failed" | "validation" };
+
+export type DeactivateResult =
+  | { success: true; session: TravelSessionSummary }
+  | { success: false; error: string; code: "no_active_session" | "update_failed" };
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function isValidLatLng(lat: unknown, lng: unknown): lat is number {
+  return (
+    typeof lat === "number" &&
+    typeof lng === "number" &&
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+/**
+ * Find the nearest non-home user_locations row within ~1km, or create one.
+ * We intentionally never log lat/lng here — only the resulting opaque id.
+ */
+async function findOrCreateTravelLocation(
+  supabase: SupabaseDB,
+  userId: string,
+  input: ActivateTravelInput,
+): Promise<{ id: string; region: Region | null } | null> {
+  const { lat, lng } = input;
+
+  // Look for an existing non-home location close to the given coords.
+  const { data: candidates, error: lookupError } = await supabase
+    .from("user_locations")
+    .select("id, lat, lng, region, state")
+    .eq("user_id", userId)
+    .eq("is_home", false);
+
+  if (lookupError) {
+    logger.error("Travel location lookup failed", { user_id_hash: userId });
+    return null;
+  }
+
+  type LocationRow = {
+    id: string;
+    lat: number | null;
+    lng: number | null;
+    region: string | null;
+    state: string | null;
+  };
+  const rows = (candidates ?? []) as unknown as LocationRow[];
+
+  for (const row of rows) {
+    if (
+      row.lat !== null &&
+      row.lng !== null &&
+      Math.abs(row.lat - lat) < NEAREST_MATCH_DEGREES &&
+      Math.abs(row.lng - lng) < NEAREST_MATCH_DEGREES
+    ) {
+      return { id: row.id, region: (row.region ?? null) as Region | null };
+    }
+  }
+
+  // No nearby match — insert a new non-home location row.
+  const derivedRegion = getRegionFromState(input.state ?? null);
+  type LocationInsertChain = {
+    insert: (data: {
+      user_id: string;
+      is_home: boolean;
+      nickname: string | null;
+      lat: number;
+      lng: number;
+      state: string | null;
+      region: string | null;
+    }) => {
+      select: (cols: string) => {
+        single: () => Promise<{
+          data: { id: string; region: string | null } | null;
+          error: { message: string } | null;
+        }>;
+      };
+    };
+  };
+
+  const insertResult = await (
+    supabase.from("user_locations") as unknown as LocationInsertChain
+  )
+    .insert({
+      user_id: userId,
+      is_home: false,
+      nickname: input.nickname?.trim() || null,
+      lat,
+      lng,
+      state: input.state ?? null,
+      region: derivedRegion,
+    })
+    .select("id, region")
+    .single();
+
+  if (insertResult.error || !insertResult.data) {
+    logger.error("Travel location insert failed", {
+      user_id_hash: userId,
+      reason: insertResult.error?.message ?? "unknown",
+    });
+    return null;
+  }
+
+  return {
+    id: insertResult.data.id,
+    region: (insertResult.data.region ?? derivedRegion) as Region | null,
+  };
+}
+
+/**
+ * Seed user_allergen_elo rows for a travel location. INSERT-only — never
+ * touches rows scoped to home (home_location_id or NULL).
+ */
+async function seedTravelElo(
+  supabase: SupabaseDB,
+  userId: string,
+  locationId: string,
+  region: Region,
+): Promise<boolean> {
+  const regionField = `region_${region
+    .toLowerCase()
+    .replaceAll(" ", "_")}` as keyof (typeof allergenSeed)[0];
+
+  const regionalAllergens = allergenSeed.filter(
+    (a) => (a[regionField] as number) > 0,
+  );
+
+  const allergenData: Allergen[] = regionalAllergens.map((a) => ({
+    id: a.id,
+    common_name: a.common_name,
+    category: a.category,
+    base_elo: a.base_elo,
+    region_northeast: a.region_northeast,
+    region_midwest: a.region_midwest,
+    region_northwest: a.region_northwest,
+    region_south_central: a.region_south_central,
+    region_southeast: a.region_southeast,
+    region_southwest: a.region_southwest,
+  }));
+
+  const eloRecords = initializeAllElo(allergenData, region);
+
+  const eloInserts: UserAllergenEloInsert[] = eloRecords.map((elo) => ({
+    user_id: userId,
+    allergen_id: elo.allergen_id,
+    location_id: locationId,
+    elo_score: elo.elo_score,
+    positive_signals: 0,
+    negative_signals: 0,
+  }));
+
+  if (eloInserts.length === 0) return true;
+
+  type InsertQuery = {
+    insert: (
+      data: UserAllergenEloInsert[],
+    ) => Promise<{ error: { message: string } | null }>;
+  };
+
+  const { error } = await (
+    supabase.from("user_allergen_elo") as unknown as InsertQuery
+  ).insert(eloInserts);
+
+  if (error) {
+    logger.error("Travel Elo seeding failed", {
+      user_id_hash: userId,
+      reason: error.message,
+    });
+    return false;
+  }
+
+  return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Service functions                                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Return the current active travel session for the user (ended_at IS NULL),
+ * or null if none.
+ */
+export async function getActiveSession(
+  supabase: SupabaseDB,
+  userId: string,
+): Promise<TravelSessionSummary | null> {
+  type SelectChain = {
+    select: (cols: string) => {
+      eq: (col: string, val: string) => {
+        is: (col: string, val: null) => {
+          maybeSingle: () => Promise<{
+            data: TravelSessionSummary | null;
+            error: { message: string } | null;
+          }>;
+        };
+      };
+    };
+  };
+
+  const { data, error } = await (
+    supabase.from("travel_sessions") as unknown as SelectChain
+  )
+    .select("id, location_id, started_at")
+    .eq("user_id", userId)
+    .is("ended_at", null)
+    .maybeSingle();
+
+  if (error) {
+    logger.warn("Active session lookup failed", {
+      user_id_hash: userId,
+      reason: error.message,
+    });
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * Activate travel mode: find-or-create a non-home user_locations row,
+ * insert a travel_sessions row, seed location-scoped Elo.
+ */
+export async function activateTravel(
+  supabase: SupabaseDB,
+  userId: string,
+  input: ActivateTravelInput,
+): Promise<ActivateResult> {
+  if (!isValidLatLng(input.lat, input.lng)) {
+    return {
+      success: false,
+      error: "Invalid coordinates",
+      code: "validation",
+    };
+  }
+
+  // Resolve / create the travel location row.
+  const loc = await findOrCreateTravelLocation(supabase, userId, input);
+  if (!loc) {
+    return {
+      success: false,
+      error: "Failed to resolve travel location",
+      code: "location_failed",
+    };
+  }
+
+  // Insert travel_sessions row.
+  type SessionInsertChain = {
+    insert: (data: {
+      user_id: string;
+      location_id: string;
+    }) => {
+      select: (cols: string) => {
+        single: () => Promise<{
+          data: TravelSessionSummary | null;
+          error: { message: string; code?: string } | null;
+        }>;
+      };
+    };
+  };
+
+  const insertResult = await (
+    supabase.from("travel_sessions") as unknown as SessionInsertChain
+  )
+    .insert({ user_id: userId, location_id: loc.id })
+    .select("id, location_id, started_at")
+    .single();
+
+  if (insertResult.error || !insertResult.data) {
+    const msg = insertResult.error?.message ?? "unknown";
+    // Partial unique index violation → active session already exists.
+    const isUniqueViolation =
+      insertResult.error?.code === "23505" ||
+      msg.toLowerCase().includes("duplicate") ||
+      msg.toLowerCase().includes("unique");
+    if (isUniqueViolation) {
+      return {
+        success: false,
+        error: "An active travel session already exists",
+        code: "active_session_exists",
+      };
+    }
+    logger.error("Travel session insert failed", {
+      user_id_hash: userId,
+      reason: msg,
+    });
+    return {
+      success: false,
+      error: "Failed to start travel session",
+      code: "session_failed",
+    };
+  }
+
+  // Seed regional Elo scoped to the travel location.
+  const region: Region = loc.region ?? "Southeast";
+  await seedTravelElo(supabase, userId, loc.id, region);
+
+  return { success: true, session: insertResult.data };
+}
+
+/**
+ * Deactivate the user's active travel session by setting ended_at = NOW().
+ * Home Elo is untouched — travel-scoped Elo rows remain for history but
+ * no longer feed the "active" location lookup.
+ */
+export async function deactivateTravel(
+  supabase: SupabaseDB,
+  userId: string,
+): Promise<DeactivateResult> {
+  const active = await getActiveSession(supabase, userId);
+  if (!active) {
+    return {
+      success: false,
+      error: "No active travel session",
+      code: "no_active_session",
+    };
+  }
+
+  type UpdateChain = {
+    update: (data: { ended_at: string }) => {
+      eq: (col: string, val: string) => {
+        is: (col: string, val: null) => Promise<{
+          error: { message: string } | null;
+        }>;
+      };
+    };
+  };
+
+  const endedAt = new Date().toISOString();
+
+  const { error } = await (
+    supabase.from("travel_sessions") as unknown as UpdateChain
+  )
+    .update({ ended_at: endedAt })
+    .eq("user_id", userId)
+    .is("ended_at", null);
+
+  if (error) {
+    logger.error("Travel session deactivation failed", {
+      user_id_hash: userId,
+      reason: error.message,
+    });
+    return {
+      success: false,
+      error: "Failed to end travel session",
+      code: "update_failed",
+    };
+  }
+
+  return {
+    success: true,
+    session: { ...active, started_at: active.started_at },
+  };
+}

--- a/supabase/migrations/20260416120000_travel_sessions.sql
+++ b/supabase/migrations/20260416120000_travel_sessions.sql
@@ -1,0 +1,70 @@
+-- Travel Sessions — transient per-user travel mode
+--
+-- Ticket: #223 — feat(travel): Travel Mode API + schema
+-- Parent Epic: #27 — Travel Mode + Saved Places
+--
+-- Represents an active "travel mode" session. When a user activates travel
+-- mode, the tournament engine re-seeds Elo scoped to the travel location_id
+-- without touching home Elo. Only one active session per user is allowed,
+-- enforced by a partial unique index where ended_at IS NULL.
+--
+-- HIPAA note: location PII (lat/lng/address) lives in user_locations — we
+-- intentionally store only the foreign key here to avoid duplicating PHI.
+--
+-- Idempotent: safe to run against an environment that already has the table.
+
+CREATE TABLE IF NOT EXISTS travel_sessions (
+  id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id     UUID NOT NULL REFERENCES user_profiles(id) ON DELETE CASCADE,
+  location_id UUID NOT NULL REFERENCES user_locations(id) ON DELETE CASCADE,
+  started_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ended_at    TIMESTAMPTZ
+);
+
+ALTER TABLE travel_sessions ENABLE ROW LEVEL SECURITY;
+
+-- RLS: four-policy pattern mirroring user_locations
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE policyname = 'travel_sessions_select_own' AND tablename = 'travel_sessions'
+  ) THEN
+    CREATE POLICY travel_sessions_select_own ON travel_sessions
+      FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE policyname = 'travel_sessions_insert_own' AND tablename = 'travel_sessions'
+  ) THEN
+    CREATE POLICY travel_sessions_insert_own ON travel_sessions
+      FOR INSERT WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE policyname = 'travel_sessions_update_own' AND tablename = 'travel_sessions'
+  ) THEN
+    CREATE POLICY travel_sessions_update_own ON travel_sessions
+      FOR UPDATE USING (auth.uid() = user_id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE policyname = 'travel_sessions_delete_own' AND tablename = 'travel_sessions'
+  ) THEN
+    CREATE POLICY travel_sessions_delete_own ON travel_sessions
+      FOR DELETE USING (auth.uid() = user_id);
+  END IF;
+END $$;
+
+-- Partial unique index: only one active session per user at a time.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_travel_sessions_one_active_per_user
+  ON travel_sessions(user_id)
+  WHERE ended_at IS NULL;
+
+-- Lookup index for the common GET (active session) query.
+CREATE INDEX IF NOT EXISTS idx_travel_sessions_user_id
+  ON travel_sessions(user_id);


### PR DESCRIPTION
## Summary

- Adds `travel_sessions` table (RLS + partial unique index for one active session per user) via migration `20260416120000_travel_sessions.sql`.
- Implements `lib/travel/service.ts` with `activateTravel` / `deactivateTravel` / `getActiveSession`. Re-seeds regional Elo scoped to the travel `location_id` without touching home Elo.
- Wires `/api/travel` route (GET / POST / DELETE) with 401/400/404/409 semantics.
- Extends `lib/supabase/types.ts` with `TravelSession` row types.
- Adds 19 tests across `__tests__/travel/service.test.ts` and `__tests__/api/travel.test.ts`.

## Guardrails honored

- RLS enabled on `travel_sessions` with four self-scoped policies (HIPAA requirement).
- Service never logs lat/lng; only opaque user/location IDs.
- Home Elo rows (scoped to `home_location_id`) are never read, updated, or deleted by the travel flow — re-seed is INSERT-only under the travel `location_id`.
- Server-only — not imported by any client component.
- Migration uses `IF NOT EXISTS` / named policies for idempotency.

## Judgment calls (per the ticket's autonomous caveat)

- Nearest-match radius for reusing a non-home `user_locations` row: `0.01` degrees (~1km) using simple bounding-box comparison. Keeps the DB path index-free on coords since we filter by `user_id` first.
- 409 is returned for a duplicate active session (detected via partial unique index `23505`). Fallback string match on "duplicate"/"unique" covers non-code errors.
- When lat/lng fall outside \[-90, 90\] × \[-180, 180\], the service returns `code: "validation"` and the route responds 400.
- `DELETE` returns 404 when there is no active session (matches "nothing to end" semantics); ticket body did not specify so this mirrors other CRUD error shapes.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1108 passed (includes 19 new tests)
- [x] `npm run build` — `/api/travel` registered
- [ ] Manual: activate/deactivate cycle against a Supabase preview branch (reviewer can exercise)

Closes #223