### PR TITLE
feat(dashboard): restructure layout — FDA bottom, Rankings gated, bracket below Final Four

### DIFF
--- a/__tests__/app/dashboard-layout.test.tsx
+++ b/__tests__/app/dashboard-layout.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Dashboard Layout Tests (ticket #242)
+ *
+ * Pins the restructured DOM order:
+ *   Welcome → Champion → Final Four → Bracket reveal button →
+ *     View All reveal button → FDA disclaimer (bottom)
+ *
+ * Also covers:
+ *   - Bracket not in DOM by default; revealed on click
+ *   - Full Rankings not in DOM by default; revealed on click
+ *   - aria-expanded toggles correctly on both buttons
+ *   - Environmental Forecast mode suppresses the bracket reveal button
+ *   - Empty bracket data suppresses the bracket reveal button
+ *
+ * Testing approach: the dashboard page itself is an async server
+ * component tied to Supabase; rather than stub the entire data layer
+ * we render the same composition of client-safe sub-components in a
+ * small harness. This is close enough to the real page that a DOM-order
+ * regression would be caught here first.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { DashboardLeaderboard } from "@/app/(app)/dashboard/dashboard-leaderboard";
+import { FullRankings } from "@/components/leaderboard";
+import { FdaDisclaimer, RevealGate } from "@/components/shared";
+import type { RankedAllergen } from "@/components/leaderboard/types";
+
+/* ------------------------------------------------------------------ */
+/* Supabase client mock (the Leaderboard imports it for the           */
+/* disclaimer-acknowledgment mutation — never actually called when    */
+/* `fdaAcknowledged` is true).                                        */
+/* ------------------------------------------------------------------ */
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: () => ({
+      update: () => ({ eq: vi.fn().mockResolvedValue({ error: null }) }),
+    }),
+  }),
+}));
+
+/* ------------------------------------------------------------------ */
+/* Test data                                                           */
+/* ------------------------------------------------------------------ */
+
+const mockAllergens: RankedAllergen[] = [
+  { allergen_id: "oak", common_name: "Oak", category: "tree", elo_score: 1650, confidence_tier: "very_high", score: 0.95, rank: 1 },
+  { allergen_id: "birch", common_name: "Birch", category: "tree", elo_score: 1500, confidence_tier: "high", score: 0.8, rank: 2 },
+  { allergen_id: "ragweed", common_name: "Ragweed", category: "weed", elo_score: 1450, confidence_tier: "medium", score: 0.6, rank: 3 },
+  { allergen_id: "bermuda_grass", common_name: "Bermuda Grass", category: "grass", elo_score: 1400, confidence_tier: "low", score: 0.3, rank: 4 },
+  { allergen_id: "dust_mites", common_name: "Dust Mites", category: "indoor", elo_score: 1300, confidence_tier: "low", score: 0.2, rank: 5 },
+  { allergen_id: "cat", common_name: "Cat Dander", category: "indoor", elo_score: 1250, confidence_tier: "low", score: 0.15, rank: 6 },
+];
+
+/**
+ * Render a harness that mirrors the composition in
+ * `app/(app)/dashboard/page.tsx`. Keep the order in lock-step with
+ * that file so DOM-order assertions here are meaningful.
+ */
+function renderDashboard(opts: {
+  isEnvironmentalForecast?: boolean;
+  bracketTrace?: unknown[];
+  allergens?: RankedAllergen[];
+} = {}) {
+  const {
+    isEnvironmentalForecast = false,
+    bracketTrace = [{}, {}, {}], // non-empty sentinel
+    allergens = mockAllergens,
+  } = opts;
+
+  return render(
+    <div>
+      <div data-testid="welcome-header">Welcome to Allergy Madness</div>
+
+      <DashboardLeaderboard
+        allergens={allergens}
+        isPremium={true}
+        hasFullRankings={true}
+        isEnvironmentalForecast={isEnvironmentalForecast}
+        fdaAcknowledged={true}
+        userId="user-123"
+        showFdaDisclaimer={false}
+        showFullRankings={false}
+      />
+
+      {!isEnvironmentalForecast && bracketTrace.length > 0 && (
+        <div data-testid="bracket-reveal-gate">
+          <RevealGate label="Show Bracket" hideLabel="Hide Bracket">
+            <div data-testid="bracket-content">Bracket Content</div>
+          </RevealGate>
+        </div>
+      )}
+
+      {!isEnvironmentalForecast && allergens.length > 4 && (
+        <div data-testid="rankings-reveal-gate">
+          <RevealGate label="View All" hideLabel="Hide Rankings">
+            <FullRankings
+              allergens={allergens}
+              isPremium={true}
+              hasFullRankings={true}
+            />
+          </RevealGate>
+        </div>
+      )}
+
+      {!isEnvironmentalForecast && (
+        <div data-testid="dashboard-fda-disclaimer">
+          <FdaDisclaimer />
+        </div>
+      )}
+    </div>,
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("Dashboard layout (#242)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("DOM order", () => {
+    it("renders champion, final four, bracket button, view-all button, and FDA disclaimer in that order", () => {
+      const { container } = renderDashboard();
+
+      const champion = screen.getByTestId("trigger-champion-card");
+      const finalFourHeading = screen.getByText("Final Four");
+      const bracketButton = screen.getByRole("button", { name: /show bracket/i });
+      const viewAllButton = screen.getByRole("button", { name: /view all/i });
+      const fda = screen.getByTestId("dashboard-fda-disclaimer");
+
+      // Node.compareDocumentPosition returns a bitmask with
+      // DOCUMENT_POSITION_FOLLOWING (0x04) when the *argument* comes
+      // AFTER the reference node in document order.
+      const follows = (a: Node, b: Node) =>
+        Boolean(
+          a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING,
+        );
+
+      expect(follows(champion, finalFourHeading)).toBe(true);
+      expect(follows(finalFourHeading, bracketButton)).toBe(true);
+      expect(follows(bracketButton, viewAllButton)).toBe(true);
+      expect(follows(viewAllButton, fda)).toBe(true);
+
+      // FDA must be the final content block (nothing after it).
+      expect(container.contains(fda)).toBe(true);
+      expect(
+        container.querySelector(
+          "[data-testid='dashboard-fda-disclaimer'] ~ *",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("Bracket reveal gate", () => {
+    it("does NOT render the bracket content by default", () => {
+      renderDashboard();
+      expect(screen.queryByTestId("bracket-content")).toBeNull();
+    });
+
+    it("renders the bracket content after the reveal button is clicked", () => {
+      renderDashboard();
+      const btn = screen.getByRole("button", { name: /show bracket/i });
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(btn);
+      expect(screen.getByTestId("bracket-content")).toBeDefined();
+    });
+
+    it("toggles aria-expanded on click", () => {
+      renderDashboard();
+      const btn = screen.getByRole("button", { name: /show bracket/i });
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(btn);
+      // Once revealed, the button becomes the "hide" toggle — still
+      // the same element and still carries aria-expanded.
+      const hideBtn = screen.getByRole("button", { name: /hide bracket/i });
+      expect(hideBtn.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("wires aria-controls to the revealed panel", () => {
+      renderDashboard();
+      const btn = screen.getByRole("button", { name: /show bracket/i });
+      const controlsId = btn.getAttribute("aria-controls");
+      expect(controlsId).toBeTruthy();
+      // The controlled element exists in the DOM.
+      expect(document.getElementById(controlsId ?? "")).toBeTruthy();
+    });
+
+    it("suppresses the bracket reveal button in Environmental Forecast mode", () => {
+      renderDashboard({
+        isEnvironmentalForecast: true,
+        allergens: [],
+        bracketTrace: [],
+      });
+      expect(
+        screen.queryByRole("button", { name: /show bracket/i }),
+      ).toBeNull();
+      expect(screen.queryByTestId("bracket-reveal-gate")).toBeNull();
+    });
+
+    it("suppresses the bracket reveal button when bracketTrace is empty", () => {
+      renderDashboard({ bracketTrace: [] });
+      expect(
+        screen.queryByRole("button", { name: /show bracket/i }),
+      ).toBeNull();
+      expect(screen.queryByTestId("bracket-reveal-gate")).toBeNull();
+    });
+  });
+
+  describe("Rankings reveal gate", () => {
+    it("does NOT render the Full Rankings list by default", () => {
+      renderDashboard();
+      expect(screen.queryByTestId("full-rankings")).toBeNull();
+      expect(screen.queryByText("Full Rankings")).toBeNull();
+    });
+
+    it("renders the Full Rankings list after 'View All' is clicked", () => {
+      renderDashboard();
+      const btn = screen.getByRole("button", { name: /view all/i });
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(btn);
+      expect(screen.getByTestId("full-rankings")).toBeDefined();
+      expect(screen.getByText("Full Rankings")).toBeDefined();
+      // #5 and #6 appear as ranked rows.
+      const rows = screen.getAllByTestId("ranked-allergen-row");
+      expect(rows.length).toBe(2);
+    });
+
+    it("toggles aria-expanded on the View All button", () => {
+      renderDashboard();
+      const btn = screen.getByRole("button", { name: /view all/i });
+      expect(btn.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(btn);
+      const hideBtn = screen.getByRole("button", { name: /hide rankings/i });
+      expect(hideBtn.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("wires aria-controls on the View All button", () => {
+      renderDashboard();
+      const btn = screen.getByRole("button", { name: /view all/i });
+      const controlsId = btn.getAttribute("aria-controls");
+      expect(controlsId).toBeTruthy();
+      expect(document.getElementById(controlsId ?? "")).toBeTruthy();
+    });
+
+    it("does not render the View All button when there are no ranks beyond #4", () => {
+      renderDashboard({ allergens: mockAllergens.slice(0, 4) });
+      expect(
+        screen.queryByRole("button", { name: /view all/i }),
+      ).toBeNull();
+    });
+  });
+
+  describe("FDA disclaimer placement", () => {
+    it("renders the FDA disclaimer exactly once at the bottom", () => {
+      renderDashboard();
+      const disclaimers = screen.getAllByTestId("fda-disclaimer");
+      // The Leaderboard is told not to emit its inline disclaimer,
+      // so the page-level one is the only copy present.
+      expect(disclaimers.length).toBe(1);
+
+      const fdaWrapper = screen.getByTestId("dashboard-fda-disclaimer");
+      expect(within(fdaWrapper).getByTestId("fda-disclaimer")).toBeDefined();
+    });
+  });
+});

--- a/__tests__/components/shared/reveal-gate.test.tsx
+++ b/__tests__/components/shared/reveal-gate.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * RevealGate primitive tests (ticket #242).
+ *
+ * Pins the a11y contract and ephemeral state behavior.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RevealGate } from "@/components/shared/reveal-gate";
+
+describe("RevealGate", () => {
+  it("renders a real <button> element with the provided label", () => {
+    render(
+      <RevealGate label="Show Secret">
+        <p>hidden text</p>
+      </RevealGate>,
+    );
+    const btn = screen.getByRole("button", { name: "Show Secret" });
+    expect(btn.tagName).toBe("BUTTON");
+  });
+
+  it("does not render children by default", () => {
+    render(
+      <RevealGate label="Show Secret">
+        <p data-testid="secret">hidden text</p>
+      </RevealGate>,
+    );
+    expect(screen.queryByTestId("secret")).toBeNull();
+  });
+
+  it("renders children after click", () => {
+    render(
+      <RevealGate label="Show Secret">
+        <p data-testid="secret">hidden text</p>
+      </RevealGate>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Secret" }));
+    expect(screen.getByTestId("secret")).toBeDefined();
+  });
+
+  it("sets aria-expanded=false initially and true after reveal", () => {
+    render(
+      <RevealGate label="Show Secret" hideLabel="Hide Secret">
+        <p>hidden text</p>
+      </RevealGate>,
+    );
+    const btn = screen.getByRole("button", { name: "Show Secret" });
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(btn);
+    const hideBtn = screen.getByRole("button", { name: "Hide Secret" });
+    expect(hideBtn.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("wires aria-controls to the panel container", () => {
+    render(
+      <RevealGate label="Show Secret">
+        <p data-testid="secret">hidden text</p>
+      </RevealGate>,
+    );
+    const btn = screen.getByRole("button", { name: "Show Secret" });
+    const controlsId = btn.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId ?? "")).not.toBeNull();
+  });
+
+  it("removes the button entirely after reveal when no hideLabel is provided", () => {
+    render(
+      <RevealGate label="Show Secret">
+        <p>now visible</p>
+      </RevealGate>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Show Secret" }));
+    expect(
+      screen.queryByRole("button", { name: "Show Secret" }),
+    ).toBeNull();
+  });
+});

--- a/app/(app)/dashboard/dashboard-leaderboard.tsx
+++ b/app/(app)/dashboard/dashboard-leaderboard.tsx
@@ -28,6 +28,10 @@ interface DashboardLeaderboardProps {
   isEnvironmentalForecast: boolean;
   fdaAcknowledged: boolean;
   userId: string;
+  /** Forwarded to the underlying Leaderboard. See #242. */
+  showFdaDisclaimer?: boolean;
+  /** Forwarded to the underlying Leaderboard. See #242. */
+  showFullRankings?: boolean;
 }
 
 export function DashboardLeaderboard({
@@ -40,6 +44,8 @@ export function DashboardLeaderboard({
   isEnvironmentalForecast,
   fdaAcknowledged,
   userId,
+  showFdaDisclaimer,
+  showFullRankings,
 }: DashboardLeaderboardProps) {
   return (
     <Leaderboard
@@ -52,6 +58,8 @@ export function DashboardLeaderboard({
       isEnvironmentalForecast={isEnvironmentalForecast}
       fdaAcknowledged={fdaAcknowledged}
       userId={userId}
+      showFdaDisclaimer={showFdaDisclaimer}
+      showFullRankings={showFullRankings}
     />
   );
 }

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -13,6 +13,8 @@ import {
 import { Bracket } from "@/components/bracket";
 import { DashboardLeaderboard } from "./dashboard-leaderboard";
 import { PageContainer } from "@/components/layout";
+import { FullRankings } from "@/components/leaderboard";
+import { FdaDisclaimer, RevealGate } from "@/components/shared";
 
 /**
  * Shape returned by the Supabase join query.
@@ -169,16 +171,9 @@ export default async function DashboardPage() {
         </p>
       </div>
 
-      {/* Tournament bracket (ticket #179). Rendered above the
-          leaderboard so users can see the path to their champion
-          before the ranked list. Hidden in Environmental Forecast
-          mode — no tournament has been played yet. */}
-      {!isEnvironmentalForecast && bracketTrace.length > 0 && (
-        <div className="mb-6">
-          <Bracket nodes={bracketTrace} ranked={allergens} />
-        </div>
-      )}
-
+      {/* Champion + Final Four (core leaderboard surface). Full
+          Rankings and the FDA disclaimer are rendered lower on the
+          page per #242 — the Leaderboard emits neither here. */}
       <DashboardLeaderboard
         allergens={finalFourView.allergensForClient}
         finalFourGated={finalFourView.gated}
@@ -189,7 +184,54 @@ export default async function DashboardPage() {
         isEnvironmentalForecast={isEnvironmentalForecast}
         fdaAcknowledged={fdaAcknowledged}
         userId={user.id}
+        showFdaDisclaimer={false}
+        showFullRankings={false}
       />
+
+      {/* Tournament bracket (ticket #179) — gated behind a reveal
+          button per #242. Hidden entirely in Environmental Forecast
+          mode and when the bracket trace is empty (first-time users
+          have no tournament data yet). */}
+      {!isEnvironmentalForecast && bracketTrace.length > 0 && (
+        <div className="mt-6" data-testid="bracket-reveal-gate">
+          <RevealGate label="Show Bracket" hideLabel="Hide Bracket">
+            <div className="mt-4">
+              <Bracket nodes={bracketTrace} ranked={allergens} />
+            </div>
+          </RevealGate>
+        </div>
+      )}
+
+      {/* Full Rankings — gated behind a "View All" reveal button per
+          #242. Only renders when the leaderboard surface has ranks
+          #5+ to show (i.e., not in Environmental Forecast mode or
+          when the user has fewer than 5 ranked allergens). */}
+      {!isEnvironmentalForecast &&
+        finalFourView.allergensForClient.length > 4 && (
+          <div className="mt-6" data-testid="rankings-reveal-gate">
+            <RevealGate label="View All" hideLabel="Hide Rankings">
+              <div className="mt-4">
+                <FullRankings
+                  allergens={finalFourView.allergensForClient}
+                  finalFourGated={finalFourView.gated}
+                  isPremium={isPremium}
+                  hasFullRankings={hasFullRankings}
+                />
+              </div>
+            </RevealGate>
+          </div>
+        )}
+
+      {/* FDA disclaimer — moved to the bottom of the page per #242.
+          Text unchanged; only position relative to prior inline
+          placement inside the Leaderboard surface.
+          Suppressed in Environmental Forecast mode because that
+          surface already embeds its own FDA disclaimer. */}
+      {!isEnvironmentalForecast && (
+        <div className="mt-8" data-testid="dashboard-fda-disclaimer">
+          <FdaDisclaimer />
+        </div>
+      )}
     </PageContainer>
   );
 }

--- a/components/leaderboard/full-rankings.tsx
+++ b/components/leaderboard/full-rankings.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+/**
+ * FullRankings
+ *
+ * Renders the ranks #5+ list extracted from the shared `Leaderboard`
+ * component so the dashboard (#242) can gate it behind a "View All"
+ * reveal button without rendering the Champion / Final Four twice.
+ *
+ * Gating & redaction semantics match the inline implementation in
+ * `Leaderboard`:
+ *   - When `finalFourGated` is provided, we assume the server stripped
+ *     ranks #2-#4 from `allergens` (defense in depth) and treat every
+ *     entry with `rank >= 5` as part of the Full Rankings slice.
+ *   - When not provided (legacy/tests), we slice off the first four.
+ *   - `hasFullRankings` takes precedence over `isPremium` for the
+ *     Elo / confidence reveal; when both are undefined or false the
+ *     rows render in their locked "Upgrade" state.
+ */
+
+import { LockIcon } from "@/components/shared";
+import { ConfidenceBadge } from "@/components/shared/confidence-badge";
+import { UpgradeCta } from "@/components/subscription/upgrade-cta";
+import { CategoryIcon } from "./category-icon";
+import { getAllergenThumbnail } from "@/lib/allergens/thumbnails";
+import type { RankedAllergen, GatedRankedAllergen } from "./types";
+
+export interface FullRankingsProps {
+  allergens: RankedAllergen[];
+  finalFourGated?: GatedRankedAllergen[];
+  isPremium: boolean;
+  hasFullRankings?: boolean;
+}
+
+export function FullRankings({
+  allergens,
+  finalFourGated,
+  isPremium,
+  hasFullRankings,
+}: FullRankingsProps) {
+  const fullRankings = finalFourGated
+    ? allergens.filter((a) => a.rank >= 5)
+    : allergens.slice(4);
+
+  const fullRankingsUnlocked = hasFullRankings ?? isPremium;
+
+  if (fullRankings.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <h2 className="mb-3 text-lg font-semibold text-brand-text-accent">
+        Full Rankings
+      </h2>
+      <div
+        data-testid="full-rankings"
+        className="divide-y divide-brand-border-light rounded-card border border-brand-border bg-white"
+      >
+        {fullRankings.map((allergen) => {
+          const thumb = getAllergenThumbnail(allergen.allergen_id);
+          return (
+            <div
+              key={allergen.allergen_id}
+              data-testid="ranked-allergen-row"
+              className="flex items-center justify-between px-4 py-3"
+            >
+              <div className="flex items-center gap-3">
+                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-surface-muted text-xs font-bold text-brand-text-muted">
+                  #{allergen.rank}
+                </span>
+                {/* Thumbnail — plain <img> for SVG compat, matches bracket-node pattern (#179) */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={thumb.src}
+                  alt={thumb.alt}
+                  width={48}
+                  height={48}
+                  className="h-12 w-12 flex-shrink-0 rounded-xl"
+                />
+                <CategoryIcon category={allergen.category} />
+                <span className="text-sm font-medium text-brand-primary-dark">
+                  {allergen.common_name}
+                </span>
+              </div>
+              {fullRankingsUnlocked ? (
+                <div
+                  data-testid="ranking-score-details"
+                  className="flex items-center gap-2"
+                >
+                  <span className="text-xs text-brand-text-muted">
+                    {allergen.elo_score}
+                  </span>
+                  <span data-testid="row-confidence-score">
+                    <ConfidenceBadge
+                      score={allergen.score}
+                      variant="compact"
+                    />
+                  </span>
+                </div>
+              ) : (
+                <div
+                  data-testid="ranking-score-locked"
+                  className="flex items-center gap-1.5"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand-primary"
+                  >
+                    <LockIcon size={12} stroke="white" strokeWidth={2.5} />
+                  </span>
+                  <span className="text-xs font-medium text-brand-primary">
+                    Upgrade
+                  </span>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {!fullRankingsUnlocked && (
+        <div data-testid="rankings-upgrade-cta" className="mt-4">
+          <UpgradeCta feature="full ranking details" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/leaderboard/index.ts
+++ b/components/leaderboard/index.ts
@@ -16,6 +16,8 @@ export { BlurOverlay } from "./blur-overlay";
 // `ConfidenceBadge` from `@/components/shared/confidence-badge` for the
 // numeric 0–1 variant.
 export { CategoryIcon } from "./category-icon";
+export { FullRankings } from "./full-rankings";
+export type { FullRankingsProps } from "./full-rankings";
 export { EnvironmentalForecast } from "./environmental-forecast";
 export type { ForecastData, EnvironmentalForecastProps } from "./environmental-forecast";
 

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -78,6 +78,21 @@ export interface LeaderboardClientProps {
   userId: string;
   /** PFAS cross-reactivity entries for top allergens (optional) */
   pfasEntries?: PfasCrossReactivity[];
+  /**
+   * When `false`, the FDA disclaimer block is NOT rendered inside the
+   * leaderboard surface. Used by the dashboard (#242) which renders
+   * the disclaimer at the very bottom of the page instead of inline.
+   * Defaults to `true` for backwards compatibility with existing
+   * callers and tests that expect the inline banner.
+   */
+  showFdaDisclaimer?: boolean;
+  /**
+   * When `false`, the Full Rankings (ranks #5+) section is NOT
+   * rendered. Used by the dashboard (#242) to gate the full list
+   * behind a "View All" reveal button owned by the page. Defaults
+   * to `true` for backwards compatibility.
+   */
+  showFullRankings?: boolean;
 }
 
 export function Leaderboard({
@@ -91,6 +106,8 @@ export function Leaderboard({
   fdaAcknowledged,
   userId,
   pfasEntries = [],
+  showFdaDisclaimer = true,
+  showFullRankings = true,
 }: LeaderboardClientProps) {
   const [acknowledged, setAcknowledged] = useState(fdaAcknowledged);
   const [forecastData, setForecastData] = useState<ForecastData | null>(null);
@@ -197,8 +214,10 @@ export function Leaderboard({
         Your Allergen Leaderboard
       </h1>
 
-      {/* FDA Disclaimer — always visible */}
-      <FdaDisclaimer />
+      {/* FDA Disclaimer — always visible unless the parent surface
+          has opted to render it elsewhere (see #242, where the
+          dashboard moves it to the very bottom of the page). */}
+      {showFdaDisclaimer && <FdaDisclaimer />}
 
       {/* Trigger Champion */}
       {champion && (
@@ -221,8 +240,10 @@ export function Leaderboard({
         </div>
       )}
 
-      {/* Full Ranked List (beyond top 4) */}
-      {fullRankings.length > 0 && (
+      {/* Full Ranked List (beyond top 4). The dashboard (#242) gates
+          this behind a "View All" reveal button by passing
+          `showFullRankings={false}` until the user opts in. */}
+      {showFullRankings && fullRankings.length > 0 && (
         <div className="mt-6">
           <h2 className="mb-3 text-lg font-semibold text-brand-text-accent">
             Full Rankings

--- a/components/shared/index.ts
+++ b/components/shared/index.ts
@@ -22,3 +22,6 @@ export type {
   ConfidenceBadgeProps,
   ConfidenceBadgeVariant,
 } from "./confidence-badge";
+
+export { RevealGate } from "./reveal-gate";
+export type { RevealGateProps } from "./reveal-gate";

--- a/components/shared/reveal-gate.tsx
+++ b/components/shared/reveal-gate.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+/**
+ * RevealGate
+ *
+ * Small reusable primitive that renders a labeled button which, on
+ * click, reveals its children beneath. Used by the dashboard (ticket
+ * #242) to defer rendering of the bracket and full rankings until the
+ * user opts in.
+ *
+ * Accessibility:
+ * - Uses a real `<button>` element
+ * - `aria-expanded` reflects the current reveal state
+ * - `aria-controls` points at the container ID holding `children`
+ *
+ * State:
+ * - Purely ephemeral `useState` — deliberately not persisted across
+ *   page reloads.
+ */
+
+import { useId, useState, type ReactNode } from "react";
+
+export interface RevealGateProps {
+  /** Label shown on the button before the content is revealed. */
+  label: string;
+  /**
+   * Optional label shown once the content is revealed (acts as a
+   * "hide" toggle). When omitted, the button is removed from the DOM
+   * after reveal so the surface stays uncluttered.
+   */
+  hideLabel?: string;
+  /** The content to reveal on click. */
+  children: ReactNode;
+  /** Optional test id for the wrapper element. */
+  "data-testid"?: string;
+  /** Optional CSS classes applied to the button. */
+  buttonClassName?: string;
+}
+
+export function RevealGate({
+  label,
+  hideLabel,
+  children,
+  "data-testid": dataTestId,
+  buttonClassName,
+}: RevealGateProps) {
+  const [revealed, setRevealed] = useState(false);
+  const panelId = useId();
+
+  const defaultButtonClasses =
+    "inline-flex items-center justify-center rounded-card border border-brand-border bg-white px-4 py-2 text-sm font-semibold text-brand-primary-dark hover:bg-brand-surface-muted";
+
+  return (
+    <div data-testid={dataTestId}>
+      {(!revealed || hideLabel) && (
+        <button
+          type="button"
+          aria-expanded={revealed}
+          aria-controls={panelId}
+          onClick={() => setRevealed((v) => !v)}
+          className={buttonClassName ?? defaultButtonClasses}
+        >
+          {revealed && hideLabel ? hideLabel : label}
+        </button>
+      )}
+      <div id={panelId} hidden={!revealed}>
+        {revealed ? children : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Restructures the dashboard DOM per the target layout in #242:

1. Welcome header (unchanged)
2. Champion card
3. Final Four (existing referral/premium gating preserved)
4. **NEW:** Bracket reveal button — click to show the bracket below
5. **NEW:** "View All" rankings reveal button — click to show Full Rankings
6. **NEW:** FDA disclaimer moved to the very bottom of the page

## Implementation notes

- **New `RevealGate` primitive** (`components/shared/reveal-gate.tsx`). ~75 lines. Real `<button>` element, `aria-expanded`, `aria-controls`, ephemeral `useState` (not persisted across reloads). Accepts `label` and optional `hideLabel` so callers can use it as a one-way reveal or a toggle.
- **Extracted `FullRankings`** out of `Leaderboard` into its own component so the dashboard page can gate it behind the "View All" reveal without rendering Champion/Final Four twice. Locking/unlock semantics unchanged — logic lifted verbatim.
- **`Leaderboard` gains two opt-out props**: `showFdaDisclaimer` and `showFullRankings`. Both default to `true` for backwards compatibility with all existing callers and the existing test suite. The dashboard passes `false` for both.
- **Bracket suppression preserved**: still hidden entirely in Environmental Forecast mode and when `bracketTrace.length === 0`. The reveal button is removed from the DOM in those cases — not just the bracket content.
- **FDA disclaimer in forecast mode**: `EnvironmentalForecast` already embeds its own FDA disclaimer, so the page-level bottom disclaimer is suppressed when `isEnvironmentalForecast` is true to avoid a duplicate banner.

## Judgment calls

- Button copy: `"Show Bracket"` / `"Hide Bracket"` and `"View All"` / `"Hide Rankings"`. Matches the ticket language ("View All" is ticket-canonical; "Show Bracket" chosen over "Reveal Bracket" as more conventional).
- Used `useId()` from React for `aria-controls` to avoid ID collisions.

## Scope guardrails honored

- No data-fetching changes in the dashboard page.
- No Final Four gating changes.
- No new brand tokens — all classes use existing `brand-*` utilities already in `globals.css`. Token consolidation (#243) remains out of scope.
- Real `<button>` elements (not div+onClick).
- FDA disclaimer text unchanged — only position.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 106 files, 1167 tests passing (+14 new)
- [x] `npm run build` — success
- [x] New tests cover DOM order, hidden-by-default, reveal-on-click, `aria-expanded` toggle, `aria-controls` wiring, Environmental Forecast suppression, empty-bracket suppression, and the "no ranks beyond #4" no-show case.

Closes #242