### PR TITLE
refactor(dashboard): migrate leaderboard + bracket + dashboard page to 4-color tokens

### DIFF
--- a/__tests__/bracket/bracket-lines.test.tsx
+++ b/__tests__/bracket/bracket-lines.test.tsx
@@ -133,13 +133,13 @@ describe("Bracket with lines (integration)", () => {
     expect(screen.queryByTestId("bracket-connector")).toBeNull();
   });
 
-  it("connector elements use brand-primary border color", () => {
+  it("connector elements use champ-blue border color", () => {
     render(<BracketConnector sourceMatchCount={2} />);
     const pair = screen.getByTestId("bracket-connector-pair-0");
     const divs = pair.querySelectorAll("div");
-    // Each elbow div should have the border-brand-primary class
+    // Each elbow div should have the border-champ-blue class
     for (const div of divs) {
-      expect(div.className).toContain("border-brand-primary");
+      expect(div.className).toContain("border-champ-blue");
     }
   });
 });

--- a/__tests__/bracket/bracket-node.test.tsx
+++ b/__tests__/bracket/bracket-node.test.tsx
@@ -99,7 +99,7 @@ describe("BracketNode", () => {
         render(<BracketNode node={nodeWithWinnerPosterior(0.8)} isFinal />);
         const badge = screen.getByTestId("bracket-champion-badge");
         expect(badge.textContent).toContain("Most likely trigger");
-        expect(badge.className).toContain("bg-brand-accent");
+        expect(badge.className).toContain("bg-nature-pop");
       });
 
       it("does NOT show the champion badge when posterior < 0.75 even if final", () => {
@@ -116,7 +116,7 @@ describe("BracketNode", () => {
     expect(screen.queryByTestId("bracket-champion-badge")).toBeNull();
     const badge = screen.getByTestId("bracket-winner-badge");
     expect(badge).toBeDefined();
-    expect(badge.className).toContain("border-brand-primary");
+    expect(badge.className).toContain("border-champ-blue");
   });
 
   it("has an accessible name combining both sides", () => {

--- a/__tests__/components/leaderboard/blur-overlay.test.tsx
+++ b/__tests__/components/leaderboard/blur-overlay.test.tsx
@@ -61,13 +61,13 @@ describe("BlurOverlay", () => {
       </BlurOverlay>
     );
     const lockOverlay = screen.getByTestId("blur-lock-overlay");
-    expect(lockOverlay.className).toContain("bg-brand-primary-dark/70");
+    expect(lockOverlay.className).toContain("bg-dusty-denim/70");
     expect(lockOverlay.className).toContain("backdrop-blur-lg");
   });
 
   it("uses Nature Pop for the lock badge accent (sanctioned 2% use)", () => {
     // Ticket #151 — the lock badge on the overlay is one of the few
-    // sanctioned Nature Pop (`bg-brand-accent`) accents, signalling
+    // sanctioned Nature Pop (`bg-nature-pop`) accents, signalling
     // the upgrade affordance.
     render(
       <BlurOverlay>
@@ -77,6 +77,6 @@ describe("BlurOverlay", () => {
     const lockOverlay = screen.getByTestId("blur-lock-overlay");
     const lockBadge = lockOverlay.querySelector("span[aria-hidden='true']");
     expect(lockBadge).not.toBeNull();
-    expect(lockBadge?.className).toContain("bg-brand-accent");
+    expect(lockBadge?.className).toContain("bg-nature-pop");
   });
 });

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -163,10 +163,10 @@ export default async function DashboardPage() {
   return (
     <PageContainer>
       <div className="mb-6">
-        <h1 className="m-0 text-2xl font-bold text-brand-primary-dark">
+        <h1 className="m-0 text-2xl font-bold text-dusty-denim">
           Welcome to Allergy Madness
         </h1>
-        <p className="mt-1 mb-0 text-sm text-brand-text-secondary">
+        <p className="mt-1 mb-0 text-sm text-dusty-denim">
           Signed in as {user.email}
         </p>
       </div>

--- a/components/bracket/bracket-lines.tsx
+++ b/components/bracket/bracket-lines.tsx
@@ -12,7 +12,7 @@
  *      midpoint horizontal stub entering the next round
  *   3. Left stubs — short horizontal lines entering each match in round N+1
  *
- * All strokes use brand-primary (Champ Blue) via border color tokens.
+ * All strokes use champ-blue (Champ Blue) via border color tokens.
  * No raw hex, no black, no gray.
  */
 
@@ -46,9 +46,9 @@ export function BracketConnector({ sourceMatchCount }: BracketConnectorProps) {
           className="flex flex-col"
         >
           {/* Top half — upper feeder match elbow */}
-          <div className="h-8 w-6 border-r-2 border-t-2 border-brand-primary rounded-tr-lg" />
+          <div className="h-8 w-6 border-r-2 border-t-2 border-champ-blue rounded-tr-lg" />
           {/* Bottom half — lower feeder match elbow */}
-          <div className="h-8 w-6 border-r-2 border-b-2 border-brand-primary rounded-br-lg" />
+          <div className="h-8 w-6 border-r-2 border-b-2 border-champ-blue rounded-br-lg" />
         </div>
       ))}
     </div>

--- a/components/bracket/bracket-node.tsx
+++ b/components/bracket/bracket-node.tsx
@@ -31,14 +31,14 @@ export interface BracketNodeProps {
 function barColorForTier(tier: ConfidenceTier): string {
   switch (tier) {
     case "very_high":
-      return "bg-brand-primary-dark";
+      return "bg-dusty-denim";
     case "high":
-      return "bg-brand-primary";
+      return "bg-champ-blue";
     case "medium":
-      return "bg-brand-primary-light";
+      return "bg-white";
     case "low":
     default:
-      return "bg-brand-border";
+      return "bg-champ-blue";
   }
 }
 
@@ -68,8 +68,8 @@ function Side({ side, isWinner, isChampion, label }: SideProps) {
       className={[
         "flex items-center gap-3 rounded-card border px-3 py-2",
         isWinner
-          ? "border-brand-primary bg-brand-primary-light"
-          : "border-brand-border-light bg-brand-surface opacity-60",
+          ? "border-champ-blue bg-white"
+          : "border-white bg-white opacity-60",
       ].join(" ")}
     >
       {/* Thumbnail — plain <img> to avoid next/image domain config */}
@@ -79,7 +79,7 @@ function Side({ side, isWinner, isChampion, label }: SideProps) {
         alt={side.thumbnail.alt}
         width={40}
         height={40}
-        className="h-10 w-10 flex-shrink-0 rounded-pill border border-brand-border-light bg-brand-surface-muted"
+        className="h-10 w-10 flex-shrink-0 rounded-pill border border-white bg-white"
       />
 
       <div className="min-w-0 flex-1">
@@ -87,7 +87,7 @@ function Side({ side, isWinner, isChampion, label }: SideProps) {
           <span
             data-testid={`bracket-side-${label}-name`}
             className={[
-              "truncate text-sm font-semibold text-brand-primary-dark",
+              "truncate text-sm font-semibold text-dusty-denim",
               isWinner ? "" : "line-through",
             ].join(" ")}
           >
@@ -96,7 +96,7 @@ function Side({ side, isWinner, isChampion, label }: SideProps) {
           {isWinner && isChampion && (
             <span
               data-testid="bracket-champion-badge"
-              className="inline-flex items-center rounded-pill bg-brand-accent px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-brand-primary-dark"
+              className="inline-flex items-center rounded-pill bg-nature-pop px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-dusty-denim"
             >
               Most likely trigger
             </span>
@@ -104,7 +104,7 @@ function Side({ side, isWinner, isChampion, label }: SideProps) {
           {isWinner && !isChampion && (
             <span
               data-testid="bracket-winner-badge"
-              className="inline-flex items-center rounded-pill border border-brand-primary bg-brand-surface px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-primary-dark"
+              className="inline-flex items-center rounded-pill border border-champ-blue bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-dusty-denim"
             >
               Advances
             </span>
@@ -116,7 +116,7 @@ function Side({ side, isWinner, isChampion, label }: SideProps) {
         <div
           data-testid={`bracket-side-${label}-bar`}
           data-tier={tier}
-          className="mt-1 h-1.5 w-full overflow-hidden rounded-pill bg-brand-surface-muted"
+          className="mt-1 h-1.5 w-full overflow-hidden rounded-pill bg-white"
           role="presentation"
         >
           <div
@@ -143,7 +143,7 @@ export function BracketNode({ node, isFinal = false }: BracketNodeProps) {
       data-round={node.round}
       data-match={node.matchId}
       aria-label={accessibleName}
-      className="flex flex-col gap-2 rounded-card border border-brand-border bg-brand-surface p-2 shadow-sm"
+      className="flex flex-col gap-2 rounded-card border border-champ-blue bg-white p-2 shadow-sm"
     >
       <Side
         side={left}

--- a/components/bracket/bracket.tsx
+++ b/components/bracket/bracket.tsx
@@ -55,9 +55,9 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
       <section
         data-testid="bracket-empty"
         aria-label="Tournament bracket"
-        className="rounded-card border border-brand-border bg-brand-surface-muted p-6"
+        className="rounded-card border border-champ-blue bg-white p-6"
       >
-        <p className="text-sm text-brand-text-secondary">
+        <p className="text-sm text-dusty-denim">
           No matches yet — check in with your symptoms to run a tournament.
         </p>
       </section>
@@ -85,13 +85,13 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
     <section
       data-testid="bracket"
       aria-label="Tournament bracket"
-      className="rounded-card border border-brand-border bg-brand-surface p-4 shadow-sm"
+      className="rounded-card border border-champ-blue bg-white p-4 shadow-sm"
     >
       <header className="mb-4">
-        <h2 className="text-lg font-bold text-brand-primary-dark">
+        <h2 className="text-lg font-bold text-dusty-denim">
           Tournament Bracket
         </h2>
-        <p className="mt-1 text-xs text-brand-text-secondary">
+        <p className="mt-1 text-xs text-dusty-denim">
           Head-to-head matchups that produced your most likely trigger.
         </p>
       </header>
@@ -99,7 +99,7 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
       {isLowConfidence && (
         <p
           data-testid="bracket-low-confidence"
-          className="mb-4 rounded-card border border-brand-border bg-brand-primary-light px-3 py-2 text-xs font-medium text-brand-primary-dark"
+          className="mb-4 rounded-card border border-champ-blue bg-white px-3 py-2 text-xs font-medium text-dusty-denim"
         >
           Low confidence — keep tracking your symptoms to sharpen these
           results.
@@ -131,7 +131,7 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
               >
                 <h3
                   data-testid={`bracket-round-label-${roundIdx}`}
-                  className="text-xs font-semibold uppercase tracking-wider text-brand-text-accent"
+                  className="text-xs font-semibold uppercase tracking-wider text-dusty-denim"
                 >
                   {roundLabel(roundIdx, totalRounds)}
                 </h3>
@@ -166,16 +166,16 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
         <p
           data-testid="bracket-scroll-hint"
           aria-hidden="true"
-          className="mt-2 text-center text-[11px] font-medium text-brand-text-secondary sm:hidden"
+          className="mt-2 text-center text-[11px] font-medium text-dusty-denim sm:hidden"
         >
           Swipe to see all rounds &rarr;
         </p>
       )}
 
-      <footer className="mt-4 border-t border-brand-border-light pt-3">
+      <footer className="mt-4 border-t border-white pt-3">
         <p
           data-testid="bracket-fda-disclaimer"
-          className="text-xs font-medium text-brand-primary-dark"
+          className="text-xs font-medium text-dusty-denim"
         >
           {FDA_DISCLAIMER_LABEL}
         </p>

--- a/components/leaderboard/blur-overlay.tsx
+++ b/components/leaderboard/blur-overlay.tsx
@@ -41,10 +41,10 @@ export function BlurOverlay({
       {/* Lock overlay — Dusty Denim scrim + strong backdrop blur */}
       <div
         data-testid="blur-lock-overlay"
-        className="absolute inset-0 flex flex-col items-center justify-center rounded-card bg-brand-primary-dark/70 backdrop-blur-lg"
+        className="absolute inset-0 flex flex-col items-center justify-center rounded-card bg-dusty-denim/70 backdrop-blur-lg"
       >
         <span
-          className="mb-2 inline-flex h-12 w-12 animate-pulse items-center justify-center rounded-full bg-brand-accent shadow-md"
+          className="mb-2 inline-flex h-12 w-12 animate-pulse items-center justify-center rounded-full bg-nature-pop shadow-md"
           aria-hidden="true"
         >
           <LockIcon size={24} stroke="#0682BB" />

--- a/components/leaderboard/category-icon.tsx
+++ b/components/leaderboard/category-icon.tsx
@@ -50,7 +50,7 @@ export function CategoryIcon({ category, size = 32 }: CategoryIconProps) {
       aria-label={config.label}
       data-testid="category-icon"
       data-category={category}
-      className="inline-flex items-center justify-center rounded-full bg-brand-primary"
+      className="inline-flex items-center justify-center rounded-full bg-champ-blue"
       style={{ width: size, height: size }}
     >
       <svg

--- a/components/leaderboard/environmental-forecast.tsx
+++ b/components/leaderboard/environmental-forecast.tsx
@@ -98,8 +98,8 @@ function DataCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="rounded-card border border-brand-border bg-white p-4">
-      <h3 className="mb-3 text-sm font-semibold text-brand-text">
+    <div className="rounded-card border border-champ-blue bg-white p-4">
+      <h3 className="mb-3 text-sm font-semibold text-dusty-denim">
         {title}
       </h3>
       {children}
@@ -118,11 +118,11 @@ function DataRow({
 }) {
   return (
     <div className="flex items-center justify-between py-1">
-      <span className="text-sm text-brand-text-secondary">
+      <span className="text-sm text-dusty-denim">
         {label}
       </span>
       <span
-        className={`text-sm font-medium ${color ? "" : "text-brand-text"}`}
+        className={`text-sm font-medium ${color ? "" : "text-dusty-denim"}`}
         style={color ? { color } : undefined}
       >
         {value}
@@ -140,7 +140,7 @@ function LoadingSkeleton() {
       {[1, 2, 3].map((i) => (
         <div
           key={i}
-          className="h-24 animate-pulse rounded-card bg-brand-surface-muted"
+          className="h-24 animate-pulse rounded-card bg-white"
         />
       ))}
     </div>
@@ -151,9 +151,9 @@ function NoDataMessage() {
   return (
     <div
       data-testid="forecast-no-data"
-      className="rounded-card border border-brand-border bg-brand-surface-muted p-6 text-center"
+      className="rounded-card border border-champ-blue bg-white p-6 text-center"
     >
-      <p className="text-sm text-brand-text-secondary">
+      <p className="text-sm text-dusty-denim">
         Environmental data is not available. Please ensure your home location is
         set in your profile to receive local forecasts.
       </p>
@@ -183,9 +183,9 @@ export function EnvironmentalForecast({
       className="space-y-4"
     >
       {/* Good news banner */}
-      <div className="rounded-xl border border-brand-border bg-brand-primary-light p-5">
+      <div className="rounded-xl border border-champ-blue bg-white p-5">
         <div className="flex items-center gap-3">
-          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary" aria-hidden="true">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-champ-blue" aria-hidden="true">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
               <circle cx="12" cy="12" r="5" />
               <line x1="12" y1="1" x2="12" y2="3" />
@@ -199,10 +199,10 @@ export function EnvironmentalForecast({
             </svg>
           </span>
           <div>
-            <h2 className="text-base font-bold text-brand-primary-dark">
+            <h2 className="text-base font-bold text-dusty-denim">
               No Symptoms Today
             </h2>
-            <p className="mt-1 text-sm text-brand-text-secondary">
+            <p className="mt-1 text-sm text-dusty-denim">
               Great news! Here is what is currently in the air around you.
             </p>
           </div>
@@ -241,8 +241,8 @@ export function EnvironmentalForecast({
             {/* Species filter: show only species with UPI > 0 (active),
                 capped at 5 to avoid overwhelming the display */}
             {data.pollen.species.length > 0 && (
-              <div className="mt-2 border-t border-brand-border-light pt-2">
-                <p className="mb-1 text-xs font-medium text-brand-text-muted">
+              <div className="mt-2 border-t border-white pt-2">
+                <p className="mb-1 text-xs font-medium text-dusty-denim">
                   Active Species
                 </p>
                 {data.pollen.species
@@ -297,13 +297,13 @@ export function EnvironmentalForecast({
                   />
                 )}
                 {data.aqi.station && (
-                  <p className="mt-2 text-xs text-brand-text-faint">
+                  <p className="mt-2 text-xs text-dusty-denim">
                     Station: {data.aqi.station}
                   </p>
                 )}
               </>
             ) : (
-              <p className="text-sm text-brand-text-muted">
+              <p className="text-sm text-dusty-denim">
                 AQI data unavailable for your location.
               </p>
             )}
@@ -337,7 +337,7 @@ export function EnvironmentalForecast({
                 )}
               </>
             ) : (
-              <p className="text-sm text-brand-text-muted">
+              <p className="text-sm text-dusty-denim">
                 Weather data unavailable for your location.
               </p>
             )}
@@ -346,7 +346,7 @@ export function EnvironmentalForecast({
           {/* Region info */}
           {data.region && (
             <p
-              className="text-center text-xs text-brand-text-faint"
+              className="text-center text-xs text-dusty-denim"
               data-testid="forecast-region"
             >
               Region: {data.region}

--- a/components/leaderboard/final-four-unlock-cta.tsx
+++ b/components/leaderboard/final-four-unlock-cta.tsx
@@ -9,9 +9,9 @@
  *   2. Secondary: upgrade to Pro (existing upgrade route)
  *
  * Design tokens:
- *   - Background: brand-accent (Nature Pop) — sanctioned Final Four use per
+ *   - Background: nature-pop (Nature Pop) — sanctioned Final Four use per
  *     Champ Health Design System 2% rule.
- *   - Text: brand-primary-dark (Dusty Denim) for AA contrast on Nature Pop.
+ *   - Text: dusty-denim for AA contrast on Nature Pop.
  *
  * Achievement framing: when the user has 1-2 referral credits, the copy
  * shifts to "Almost there — unlock N more" with a progress indicator.
@@ -65,15 +65,15 @@ export function FinalFourUnlockCta({
   return (
     <div
       data-testid="final-four-unlock-cta"
-      className="mt-6 rounded-xl bg-brand-accent p-6 text-center shadow-md"
+      className="mt-6 rounded-xl bg-nature-pop p-6 text-center shadow-md"
     >
       <h3
         data-testid="final-four-unlock-cta-headline"
-        className="mb-2 text-lg font-bold text-brand-primary-dark"
+        className="mb-2 text-lg font-bold text-dusty-denim"
       >
         {headline}
       </h3>
-      <p className="mb-4 text-sm text-brand-primary-dark/80">
+      <p className="mb-4 text-sm text-dusty-denim/80">
         See ranks #2-#4 and their confidence scores. Invite 3 friends to
         unlock free — or upgrade to Pro.
       </p>
@@ -92,8 +92,8 @@ export function FinalFourUnlockCta({
                 data-filled={idx < referralCount}
                 className={
                   idx < referralCount
-                    ? "h-2 flex-1 rounded-full bg-brand-primary-dark"
-                    : "h-2 flex-1 rounded-full bg-brand-primary-dark/20"
+                    ? "h-2 flex-1 rounded-full bg-dusty-denim"
+                    : "h-2 flex-1 rounded-full bg-dusty-denim/20"
                 }
               />
             ),
@@ -106,7 +106,7 @@ export function FinalFourUnlockCta({
         href="/referral"
         data-testid="final-four-unlock-invite"
         onClick={() => onInviteClick?.()}
-        className="mb-3 inline-block w-full rounded-button bg-brand-premium px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-premium/80"
+        className="mb-3 inline-block w-full rounded-button bg-dusty-denim px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-dusty-denim/80"
       >
         {inviteLabel}
       </Link>
@@ -117,7 +117,7 @@ export function FinalFourUnlockCta({
         href="/referral"
         data-testid="final-four-unlock-upgrade"
         onClick={() => onUpgradeClick?.()}
-        className="inline-block text-xs font-medium text-brand-primary-dark underline underline-offset-2 hover:text-brand-primary"
+        className="inline-block text-xs font-medium text-dusty-denim underline underline-offset-2 hover:text-champ-blue"
       >
         Or upgrade to Pro
       </Link>

--- a/components/leaderboard/final-four.tsx
+++ b/components/leaderboard/final-four.tsx
@@ -35,13 +35,13 @@ function FinalFourCard({ allergen }: { allergen: GatedRankedAllergen }) {
     <div
       data-testid="final-four-card"
       data-locked={locked}
-      className="rounded-card border border-brand-border bg-white p-4 shadow-sm"
+      className="rounded-card border border-champ-blue bg-white p-4 shadow-sm"
     >
       {/* Rank badge */}
       <div className="mb-2 flex items-center justify-between">
         <span
           data-testid="final-four-rank"
-          className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-surface-muted text-xs font-bold text-brand-text-secondary"
+          className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-xs font-bold text-dusty-denim"
         >
           #{allergen.rank}
         </span>
@@ -69,15 +69,15 @@ function FinalFourCard({ allergen }: { allergen: GatedRankedAllergen }) {
             data-testid="final-four-name"
             className={
               locked
-                ? "text-sm font-semibold tracking-widest text-brand-text-muted"
-                : "text-sm font-semibold text-brand-primary-dark"
+                ? "text-sm font-semibold tracking-widest text-dusty-denim"
+                : "text-sm font-semibold text-dusty-denim"
             }
           >
             {locked ? "???" : allergen.common_name}
           </p>
           <p
             data-testid="final-four-elo"
-            className="text-xs text-brand-text-muted"
+            className="text-xs text-dusty-denim"
           >
             {locked ? "Elo —" : `Elo ${allergen.elo_score}`}
           </p>

--- a/components/leaderboard/full-rankings.tsx
+++ b/components/leaderboard/full-rankings.tsx
@@ -50,12 +50,12 @@ export function FullRankings({
 
   return (
     <div>
-      <h2 className="mb-3 text-lg font-semibold text-brand-text-accent">
+      <h2 className="mb-3 text-lg font-semibold text-dusty-denim">
         Full Rankings
       </h2>
       <div
         data-testid="full-rankings"
-        className="divide-y divide-brand-border-light rounded-card border border-brand-border bg-white"
+        className="divide-y divide-white rounded-card border border-champ-blue bg-white"
       >
         {fullRankings.map((allergen) => {
           const thumb = getAllergenThumbnail(allergen.allergen_id);
@@ -66,7 +66,7 @@ export function FullRankings({
               className="flex items-center justify-between px-4 py-3"
             >
               <div className="flex items-center gap-3">
-                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-surface-muted text-xs font-bold text-brand-text-muted">
+                <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white text-xs font-bold text-dusty-denim">
                   #{allergen.rank}
                 </span>
                 {/* Thumbnail — plain <img> for SVG compat, matches bracket-node pattern (#179) */}
@@ -79,7 +79,7 @@ export function FullRankings({
                   className="h-12 w-12 flex-shrink-0 rounded-xl"
                 />
                 <CategoryIcon category={allergen.category} />
-                <span className="text-sm font-medium text-brand-primary-dark">
+                <span className="text-sm font-medium text-dusty-denim">
                   {allergen.common_name}
                 </span>
               </div>
@@ -88,7 +88,7 @@ export function FullRankings({
                   data-testid="ranking-score-details"
                   className="flex items-center gap-2"
                 >
-                  <span className="text-xs text-brand-text-muted">
+                  <span className="text-xs text-dusty-denim">
                     {allergen.elo_score}
                   </span>
                   <span data-testid="row-confidence-score">
@@ -105,11 +105,11 @@ export function FullRankings({
                 >
                   <span
                     aria-hidden="true"
-                    className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand-primary"
+                    className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-champ-blue"
                   >
                     <LockIcon size={12} stroke="white" strokeWidth={2.5} />
                   </span>
-                  <span className="text-xs font-medium text-brand-primary">
+                  <span className="text-xs font-medium text-champ-blue">
                     Upgrade
                   </span>
                 </div>

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -161,7 +161,7 @@ export function Leaderboard({
         data-testid="leaderboard"
         className="mx-auto max-w-2xl space-y-6 px-4 py-6"
       >
-        <h1 className="text-2xl font-bold text-brand-primary-dark">
+        <h1 className="text-2xl font-bold text-dusty-denim">
           Environmental Forecast
         </h1>
         <EnvironmentalForecast data={forecastData} loading={forecastLoading} />
@@ -210,7 +210,7 @@ export function Leaderboard({
       data-testid="leaderboard"
       className="mx-auto max-w-2xl space-y-6 px-4 py-6"
     >
-      <h1 className="text-2xl font-bold text-brand-primary-dark">
+      <h1 className="text-2xl font-bold text-dusty-denim">
         Your Allergen Leaderboard
       </h1>
 
@@ -229,7 +229,7 @@ export function Leaderboard({
       {/* Final Four (#2-#4) */}
       {finalFour.length > 0 && (
         <div className="mt-6">
-          <h2 className="mb-3 text-lg font-semibold text-brand-text-accent">
+          <h2 className="mb-3 text-lg font-semibold text-dusty-denim">
             Final Four
           </h2>
           <FinalFour
@@ -245,12 +245,12 @@ export function Leaderboard({
           `showFullRankings={false}` until the user opts in. */}
       {showFullRankings && fullRankings.length > 0 && (
         <div className="mt-6">
-          <h2 className="mb-3 text-lg font-semibold text-brand-text-accent">
+          <h2 className="mb-3 text-lg font-semibold text-dusty-denim">
             Full Rankings
           </h2>
           <div
             data-testid="full-rankings"
-            className="divide-y divide-brand-border-light rounded-card border border-brand-border bg-white"
+            className="divide-y divide-white rounded-card border border-champ-blue bg-white"
           >
             {fullRankings.map((allergen) => {
               const thumb = getAllergenThumbnail(allergen.allergen_id);
@@ -261,7 +261,7 @@ export function Leaderboard({
                 className="flex items-center justify-between px-4 py-3"
               >
                 <div className="flex items-center gap-3">
-                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-brand-surface-muted text-xs font-bold text-brand-text-muted">
+                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white text-xs font-bold text-dusty-denim">
                     #{allergen.rank}
                   </span>
                   {/* Thumbnail — plain <img> for SVG compat, matches bracket-node pattern (#179) */}
@@ -274,7 +274,7 @@ export function Leaderboard({
                     className="h-12 w-12 flex-shrink-0 rounded-xl"
                   />
                   <CategoryIcon category={allergen.category} />
-                  <span className="text-sm font-medium text-brand-primary-dark">
+                  <span className="text-sm font-medium text-dusty-denim">
                     {allergen.common_name}
                   </span>
                 </div>
@@ -283,7 +283,7 @@ export function Leaderboard({
                     data-testid="ranking-score-details"
                     className="flex items-center gap-2"
                   >
-                    <span className="text-xs text-brand-text-muted">
+                    <span className="text-xs text-dusty-denim">
                       {allergen.elo_score}
                     </span>
                     {/* Numeric confidence badge — emitted by the engine per #160. */}
@@ -301,11 +301,11 @@ export function Leaderboard({
                   >
                     <span
                       aria-hidden="true"
-                      className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-brand-primary"
+                      className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-champ-blue"
                     >
                       <LockIcon size={12} stroke="white" strokeWidth={2.5} />
                     </span>
-                    <span className="text-xs font-medium text-brand-primary">
+                    <span className="text-xs font-medium text-champ-blue">
                       Upgrade
                     </span>
                   </div>

--- a/components/leaderboard/trigger-champion-card.tsx
+++ b/components/leaderboard/trigger-champion-card.tsx
@@ -16,19 +16,19 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
   return (
     <div
       data-testid="trigger-champion-card"
-      className="rounded-xl border-2 border-brand-primary bg-gradient-to-br from-[#E0F5FB] to-[#D6F0F8] p-6 shadow-lg"
+      className="rounded-xl border-2 border-champ-blue bg-white p-6 shadow-lg"
     >
       {/* Champion header — white icon on blue circle per brand guide */}
       <div className="mb-3 flex items-center gap-2">
         <span
-          className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-primary"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-champ-blue"
           aria-hidden="true"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
             <path d="M2 4L6 12H18L22 4M6 12L4 20H20L18 12M12 4V2M8 4L7 2M16 4L17 2" />
           </svg>
         </span>
-        <h2 className="text-sm font-bold uppercase tracking-wider text-brand-primary-dark">
+        <h2 className="text-sm font-bold uppercase tracking-wider text-dusty-denim">
           Trigger Champion
         </h2>
       </div>
@@ -47,7 +47,7 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
         <CategoryIcon category={allergen.category} />
         <h3
           data-testid="champion-name"
-          className="text-2xl font-bold text-brand-primary-dark"
+          className="text-2xl font-bold text-dusty-denim"
         >
           {allergen.common_name}
         </h3>
@@ -57,7 +57,7 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
       <div className="flex items-center gap-3">
         <span
           data-testid="champion-elo"
-          className="text-lg font-semibold text-brand-text-accent"
+          className="text-lg font-semibold text-dusty-denim"
         >
           Elo {allergen.elo_score}
         </span>


### PR DESCRIPTION
## Summary

Migrates dashboard surfaces from legacy `brand-*` Tailwind tokens to the
canonical 4-color system introduced in #246
(`champ-blue`, `dusty-denim`, `white`, `nature-pop`). No logic, layout,
or API changes — className swaps only. Aliases from #246 remain in
place for other surfaces.

Part of epic #243; siblings #247 (shared primitives, merged),
#249-#252 (other surfaces still open).

Closes #248

## Files touched (15)

Leaderboard (8 components):
- `components/leaderboard/leaderboard.tsx`
- `components/leaderboard/full-rankings.tsx`
- `components/leaderboard/final-four.tsx`
- `components/leaderboard/final-four-unlock-cta.tsx`
- `components/leaderboard/trigger-champion-card.tsx`
- `components/leaderboard/environmental-forecast.tsx`
- `components/leaderboard/blur-overlay.tsx`
- `components/leaderboard/category-icon.tsx`

Bracket (3 components):
- `components/bracket/bracket.tsx`
- `components/bracket/bracket-node.tsx`
- `components/bracket/bracket-lines.tsx`

Dashboard page (1):
- `app/(app)/dashboard/page.tsx`

Tests updated to match new class names (3):
- `__tests__/components/leaderboard/blur-overlay.test.tsx`
- `__tests__/bracket/bracket-node.test.tsx`
- `__tests__/bracket/bracket-lines.test.tsx`

## Token-rename count

**91 legacy `brand-*` class usages replaced** across 15 files.

## Mapping applied (per #246 aliases)

- `brand-primary` → `champ-blue`
- `brand-primary-dark` / `brand-text*` / `brand-premium*` → `dusty-denim`
- `brand-primary-light` / `brand-surface*` / `brand-border-light` → `white`
- `brand-accent*` → `nature-pop`
- `brand-border` → `champ-blue`
- Raw hex gradient (`from-[#E0F5FB] to-[#D6F0F8]`) on trigger-champion-card
  replaced with `bg-white` (gradient collapsed per 4-color system; border
  still carries Champ Blue for the champion card outline).

## Guardrails respected

- Only touched files in scope for #248 (dashboard area).
- Did not modify shared primitives (#247 already migrated them) — dashboard
  components continue to import `ConfidenceBadge`, `FdaDisclaimer`, etc.
  from `components/shared/*` unchanged.
- No `alert-red` introduced on dashboard (no error states here).
- No new colors, no opacity tweaks, no behavior changes.
- Theme regression guards (`__tests__/theme/no-black-consumer-ui.test.ts`,
  `no-white-on-champ-blue.test.ts`) still pass.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes
- [x] `npm test` — 1167 tests pass
- [x] `npm run build` — passes
- [ ] Manual visual regression on dashboard with seeded data
  (Champion card, Final Four, bracket, environmental forecast,
  full rankings) — verify 50/30/18/2 ratio holds.