### PR TITLE
refactor(onboarding-auth): migrate onboarding wizard + auth pages to 4-color tokens

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -4,7 +4,7 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-brand-surface-muted px-4">
+    <div className="flex min-h-screen items-center justify-center bg-white px-4">
       <div className="w-full max-w-sm">{children}</div>
     </div>
   );

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -35,13 +35,13 @@ export default function LoginPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-center text-2xl font-bold text-brand-primary-dark">
+      <h1 className="mb-6 text-center text-2xl font-bold text-dusty-denim">
         Sign in to Allergy Madness
       </h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <div className="rounded-card bg-[#E0F0F8] p-3 text-sm text-[#055A8C]">
+          <div className="rounded-card border border-alert-red bg-white p-3 text-sm text-alert-red">
             {error}
           </div>
         )}
@@ -49,7 +49,7 @@ export default function LoginPage() {
         <div>
           <label
             htmlFor="email"
-            className="mb-1 block text-sm font-medium text-brand-text"
+            className="mb-1 block text-sm font-medium text-dusty-denim"
           >
             Email
           </label>
@@ -59,7 +59,7 @@ export default function LoginPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-champ-blue px-3 py-2 text-sm focus:border-champ-blue focus:outline-none focus:ring-1 focus:ring-champ-blue"
             placeholder="you@example.com"
           />
         </div>
@@ -67,7 +67,7 @@ export default function LoginPage() {
         <div>
           <label
             htmlFor="password"
-            className="mb-1 block text-sm font-medium text-brand-text"
+            className="mb-1 block text-sm font-medium text-dusty-denim"
           >
             Password
           </label>
@@ -77,7 +77,7 @@ export default function LoginPage() {
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-champ-blue px-3 py-2 text-sm focus:border-champ-blue focus:outline-none focus:ring-1 focus:ring-champ-blue"
             placeholder="Enter your password"
           />
         </div>
@@ -85,15 +85,15 @@ export default function LoginPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full rounded-button bg-brand-premium px-4 py-2 text-sm font-medium text-white hover:bg-brand-premium/80 disabled:opacity-50"
+          className="w-full rounded-button bg-dusty-denim px-4 py-2 text-sm font-medium text-white hover:bg-dusty-denim/80 disabled:opacity-50"
         >
           {loading ? "Signing in..." : "Sign in"}
         </button>
       </form>
 
-      <p className="mt-4 text-center text-sm text-brand-text-secondary">
+      <p className="mt-4 text-center text-sm text-dusty-denim">
         Don&apos;t have an account?{" "}
-        <Link href="/signup" className="text-brand-primary hover:underline">
+        <Link href="/signup" className="text-champ-blue hover:underline">
           Sign up
         </Link>
       </p>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -50,13 +50,13 @@ export default function SignupPage() {
 
   return (
     <div>
-      <h1 className="mb-6 text-center text-2xl font-bold text-brand-primary-dark">
+      <h1 className="mb-6 text-center text-2xl font-bold text-dusty-denim">
         Create your account
       </h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && (
-          <div className="rounded-card bg-[#E0F0F8] p-3 text-sm text-[#055A8C]">
+          <div className="rounded-card border border-alert-red bg-white p-3 text-sm text-alert-red">
             {error}
           </div>
         )}
@@ -64,7 +64,7 @@ export default function SignupPage() {
         <div>
           <label
             htmlFor="email"
-            className="mb-1 block text-sm font-medium text-brand-text"
+            className="mb-1 block text-sm font-medium text-dusty-denim"
           >
             Email
           </label>
@@ -74,7 +74,7 @@ export default function SignupPage() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-champ-blue px-3 py-2 text-sm focus:border-champ-blue focus:outline-none focus:ring-1 focus:ring-champ-blue"
             placeholder="you@example.com"
           />
         </div>
@@ -82,7 +82,7 @@ export default function SignupPage() {
         <div>
           <label
             htmlFor="password"
-            className="mb-1 block text-sm font-medium text-brand-text"
+            className="mb-1 block text-sm font-medium text-dusty-denim"
           >
             Password
           </label>
@@ -92,7 +92,7 @@ export default function SignupPage() {
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-champ-blue px-3 py-2 text-sm focus:border-champ-blue focus:outline-none focus:ring-1 focus:ring-champ-blue"
             placeholder="At least 6 characters"
           />
         </div>
@@ -100,7 +100,7 @@ export default function SignupPage() {
         <div>
           <label
             htmlFor="confirmPassword"
-            className="mb-1 block text-sm font-medium text-brand-text"
+            className="mb-1 block text-sm font-medium text-dusty-denim"
           >
             Confirm password
           </label>
@@ -110,7 +110,7 @@ export default function SignupPage() {
             required
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
-            className="w-full rounded-button border border-brand-border px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="w-full rounded-button border border-champ-blue px-3 py-2 text-sm focus:border-champ-blue focus:outline-none focus:ring-1 focus:ring-champ-blue"
             placeholder="Re-enter your password"
           />
         </div>
@@ -118,15 +118,15 @@ export default function SignupPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full rounded-button bg-brand-premium px-4 py-2 text-sm font-medium text-white hover:bg-brand-premium/80 disabled:opacity-50"
+          className="w-full rounded-button bg-dusty-denim px-4 py-2 text-sm font-medium text-white hover:bg-dusty-denim/80 disabled:opacity-50"
         >
           {loading ? "Creating account..." : "Create account"}
         </button>
       </form>
 
-      <p className="mt-4 text-center text-sm text-brand-text-secondary">
+      <p className="mt-4 text-center text-sm text-dusty-denim">
         Already have an account?{" "}
-        <Link href="/login" className="text-brand-primary hover:underline">
+        <Link href="/login" className="text-champ-blue hover:underline">
           Sign in
         </Link>
       </p>

--- a/components/onboarding/onboarding-wizard.tsx
+++ b/components/onboarding/onboarding-wizard.tsx
@@ -105,10 +105,10 @@ export function OnboardingWizard() {
                 <div
                   className={`flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold ${
                     isActive
-                      ? "bg-brand-premium text-white"
+                      ? "bg-dusty-denim text-white"
                       : isCompleted
-                        ? "bg-brand-primary-light text-brand-primary"
-                        : "bg-brand-border-light text-brand-text-muted"
+                        ? "bg-white text-champ-blue"
+                        : "bg-white text-dusty-denim"
                   }`}
                   aria-current={isActive ? "step" : undefined}
                 >
@@ -117,8 +117,8 @@ export function OnboardingWizard() {
                 <span
                   className={`mt-1 text-xs ${
                     isActive
-                      ? "font-medium text-brand-primary"
-                      : "text-brand-text-muted"
+                      ? "font-medium text-champ-blue"
+                      : "text-dusty-denim"
                   }`}
                 >
                   {STEP_LABELS[step]}

--- a/components/onboarding/processing-screen.tsx
+++ b/components/onboarding/processing-screen.tsx
@@ -96,11 +96,11 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
   if (error) {
     return (
       <div className="space-y-4 text-center">
-        <div className="rounded-card border border-brand-border bg-brand-premium-light p-4">
-          <p className="text-sm font-medium text-brand-premium">
+        <div className="rounded-card border border-champ-blue bg-white p-4">
+          <p className="text-sm font-medium text-dusty-denim">
             Something went wrong
           </p>
-          <p className="mt-1 text-sm text-brand-text-secondary">
+          <p className="mt-1 text-sm text-dusty-denim">
             {error}
           </p>
         </div>
@@ -112,7 +112,7 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
             setAnimationDone(false);
             submitOnboarding();
           }}
-          className="rounded-button bg-brand-premium px-4 py-2 text-sm font-medium text-white"
+          className="rounded-button bg-dusty-denim px-4 py-2 text-sm font-medium text-white"
         >
           Try again
         </button>
@@ -129,10 +129,10 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
       data-testid="processing-screen"
     >
       <div>
-        <h2 className="text-xl font-bold text-brand-primary-dark">
+        <h2 className="text-xl font-bold text-dusty-denim">
           Building your prediction
         </h2>
-        <p className="mt-2 text-sm text-brand-text-muted">
+        <p className="mt-2 text-sm text-dusty-denim">
           Analyzing your data against regional allergen profiles...
         </p>
       </div>
@@ -140,7 +140,7 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
       {/* Spinner */}
       <div className="flex justify-center">
         <div
-          className="h-12 w-12 animate-spin rounded-full border-4 border-brand-border border-t-brand-primary"
+          className="h-12 w-12 animate-spin rounded-full border-4 border-champ-blue border-t-dusty-denim"
           role="status"
           aria-label="Processing"
         />
@@ -148,7 +148,7 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
 
       {/* Current message */}
       <p
-        className="min-h-5 text-sm font-medium text-brand-text"
+        className="min-h-5 text-sm font-medium text-dusty-denim"
         data-testid="processing-message"
         aria-live="polite"
       >
@@ -157,9 +157,9 @@ export function ProcessingScreen({ formData }: ProcessingScreenProps) {
 
       {/* Progress bar */}
       <div className="mx-auto w-full max-w-xs">
-        <div className="h-2 w-full overflow-hidden rounded-full bg-brand-border-light">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-white">
           <div
-            className="h-full rounded-full bg-brand-primary transition-all duration-500"
+            className="h-full rounded-full bg-champ-blue transition-all duration-500"
             style={{ width: `${progress}%` }}
             role="progressbar"
             aria-valuenow={progress}

--- a/components/onboarding/step-address.tsx
+++ b/components/onboarding/step-address.tsx
@@ -32,10 +32,10 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
     <form onSubmit={handleSubmit}>
       <div className="space-y-6">
         <div>
-          <h2 className="text-xl font-bold text-brand-primary-dark">
+          <h2 className="text-xl font-bold text-dusty-denim">
             Where do you live?
           </h2>
-          <p className="mt-2 text-sm text-brand-text-secondary">
+          <p className="mt-2 text-sm text-dusty-denim">
             Your address helps us identify regional allergens and auto-populate
             your home profile. We use it to predict which allergens are most
             likely to affect you.
@@ -45,7 +45,7 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
         <div>
           <label
             htmlFor="address"
-            className="block text-sm font-medium text-brand-text"
+            className="block text-sm font-medium text-dusty-denim"
           >
             Home address
           </label>
@@ -60,11 +60,11 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
             placeholder="123 Main St, City, State ZIP"
             autoFocus
             autoComplete="street-address"
-            className="mt-1 block w-full rounded-button border border-brand-border px-3 py-2 text-sm shadow-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            className="mt-1 block w-full rounded-button border border-champ-blue px-3 py-2 text-sm shadow-sm focus:border-champ-blue focus:outline-none focus:ring-1 focus:ring-champ-blue"
           />
           {error && (
             <p
-              className="mt-1 text-sm text-[#055A8C]"
+              className="mt-1 text-sm text-dusty-denim"
               role="alert"
             >
               {error}
@@ -72,14 +72,14 @@ export function StepAddress({ formData, onUpdate, onNext }: StepProps) {
           )}
         </div>
 
-        <p className="text-xs text-brand-text-muted">
+        <p className="text-xs text-dusty-denim">
           Your address is geocoded server-side. It is never shared or sold. We
           use it to look up property age, type, and regional pollen data.
         </p>
 
         <button
           type="submit"
-          className="w-full rounded-button bg-brand-premium px-4 py-2 text-sm font-medium text-white hover:bg-brand-premium/80 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2"
+          className="w-full rounded-button bg-dusty-denim px-4 py-2 text-sm font-medium text-white hover:bg-dusty-denim/80 focus:outline-none focus:ring-2 focus:ring-champ-blue focus:ring-offset-2"
         >
           Continue
         </button>

--- a/components/onboarding/step-confirmation.tsx
+++ b/components/onboarding/step-confirmation.tsx
@@ -34,16 +34,16 @@ export function StepConfirmation({
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-bold text-brand-primary-dark">
+        <h2 className="text-xl font-bold text-dusty-denim">
           Confirm your information
         </h2>
-        <p className="mt-2 text-sm text-brand-text-secondary">
+        <p className="mt-2 text-sm text-dusty-denim">
           Review the details below. You can go back to make changes.
         </p>
       </div>
 
       {/* Summary card */}
-      <div className="rounded-card border border-brand-border bg-brand-surface-muted p-4">
+      <div className="rounded-card border border-champ-blue bg-white p-4">
         <dl className="space-y-3 text-sm">
           <SummaryRow label="Address" value={formData.address} />
           <SummaryRow
@@ -85,7 +85,7 @@ export function StepConfirmation({
         </dl>
       </div>
 
-      <p className="text-xs text-brand-text-muted">
+      <p className="text-xs text-dusty-denim">
         By continuing, we will analyze your regional allergen data and build your
         personalized prediction. This typically takes about 4 seconds.
       </p>
@@ -95,7 +95,7 @@ export function StepConfirmation({
         <button
           type="button"
           onClick={onBack}
-          className="flex-1 rounded-button border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
+          className="flex-1 rounded-button border border-champ-blue bg-white px-4 py-2 text-sm font-medium text-dusty-denim hover:bg-white"
         >
           Back
         </button>
@@ -103,7 +103,7 @@ export function StepConfirmation({
           type="button"
           onClick={onNext}
           data-testid="submit-onboarding"
-          className="flex-1 rounded-button bg-brand-premium px-4 py-2 text-sm font-medium text-white hover:bg-brand-premium/80"
+          className="flex-1 rounded-button bg-dusty-denim px-4 py-2 text-sm font-medium text-white hover:bg-dusty-denim/80"
         >
           Build My Prediction
         </button>
@@ -120,11 +120,11 @@ function SummaryRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex justify-between">
       {label && (
-        <dt className="font-medium text-brand-text-muted">
+        <dt className="font-medium text-dusty-denim">
           {label}
         </dt>
       )}
-      <dd className="text-right text-brand-primary-dark">
+      <dd className="text-right text-dusty-denim">
         {value}
       </dd>
     </div>

--- a/components/onboarding/step-health-questions.tsx
+++ b/components/onboarding/step-health-questions.tsx
@@ -48,17 +48,17 @@ export function StepHealthQuestions({
     <form onSubmit={handleSubmit}>
       <div className="space-y-6">
         <div>
-          <h2 className="text-xl font-bold text-brand-primary-dark">
+          <h2 className="text-xl font-bold text-dusty-denim">
             A few quick questions
           </h2>
-          <p className="mt-2 text-sm text-brand-text-secondary">
+          <p className="mt-2 text-sm text-dusty-denim">
             These help us fine-tune your allergen predictions.
           </p>
         </div>
 
         {/* Pets */}
         <fieldset className="border-none p-0 m-0">
-          <legend className="mb-2 text-sm font-medium text-brand-text">
+          <legend className="mb-2 text-sm font-medium text-dusty-denim">
             Do you have pets at home?
           </legend>
           <div className="flex gap-4">
@@ -94,8 +94,8 @@ export function StepHealthQuestions({
                     onClick={() => togglePetType(pet)}
                     className={`rounded-full border px-3 py-1 text-sm cursor-pointer ${
                       selected
-                        ? "border-brand-primary bg-brand-primary-light text-brand-primary-dark"
-                        : "border-brand-border bg-white text-brand-text"
+                        ? "border-champ-blue bg-champ-blue text-white"
+                        : "border-champ-blue bg-white text-dusty-denim"
                     }`}
                     aria-pressed={selected}
                   >
@@ -109,7 +109,7 @@ export function StepHealthQuestions({
 
         {/* Prior diagnosis */}
         <fieldset className="border-none p-0 m-0">
-          <legend className="mb-2 text-sm font-medium text-brand-text">
+          <legend className="mb-2 text-sm font-medium text-dusty-denim">
             Have you been diagnosed with allergies before?
           </legend>
           <div className="flex gap-4">
@@ -154,7 +154,7 @@ export function StepHealthQuestions({
                 seasonal_pattern: e.target.value as SeasonalPattern,
               })
             }
-            className="mt-1 block w-full rounded-button border border-brand-border bg-white px-3 py-2 text-sm"
+            className="mt-1 block w-full rounded-button border border-champ-blue bg-white px-3 py-2 text-sm"
           >
             {SEASONAL_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -166,7 +166,7 @@ export function StepHealthQuestions({
 
         {/* Indoor risk factors */}
         <fieldset className="border-none p-0 m-0">
-          <legend className="mb-2 text-sm font-medium text-brand-text">
+          <legend className="mb-2 text-sm font-medium text-dusty-denim">
             Indoor risk factors (check any that apply)
           </legend>
           <div className="space-y-2">
@@ -208,13 +208,13 @@ export function StepHealthQuestions({
           <button
             type="button"
             onClick={onBack}
-            className="flex-1 rounded-button border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
+            className="flex-1 rounded-button border border-champ-blue bg-white px-4 py-2 text-sm font-medium text-dusty-denim hover:bg-white"
           >
             Back
           </button>
           <button
             type="submit"
-            className="flex-1 rounded-button bg-brand-premium px-4 py-2 text-sm font-medium text-white hover:bg-brand-premium/80"
+            className="flex-1 rounded-button bg-dusty-denim px-4 py-2 text-sm font-medium text-white hover:bg-dusty-denim/80"
           >
             Continue
           </button>

--- a/components/onboarding/step-health-questions.tsx
+++ b/components/onboarding/step-health-questions.tsx
@@ -142,7 +142,7 @@ export function StepHealthQuestions({
         <div>
           <label
             htmlFor="seasonal_pattern"
-            className="block text-sm font-medium text-brand-text"
+            className="block text-sm font-medium text-dusty-denim"
           >
             When are your symptoms worst?
           </label>

--- a/components/onboarding/step-home-details.tsx
+++ b/components/onboarding/step-home-details.tsx
@@ -35,10 +35,10 @@ export function StepHomeDetails({
     <form onSubmit={handleSubmit}>
       <div className="space-y-6">
         <div>
-          <h2 className="text-xl font-bold text-brand-primary-dark">
+          <h2 className="text-xl font-bold text-dusty-denim">
             About your home
           </h2>
-          <p className="mt-2 text-sm text-brand-text-secondary">
+          <p className="mt-2 text-sm text-dusty-denim">
             Home characteristics affect indoor allergen exposure. We
             auto-populate what we can — feel free to adjust.
           </p>
@@ -48,7 +48,7 @@ export function StepHomeDetails({
         <div>
           <label
             htmlFor="home_type"
-            className="block text-sm font-medium text-brand-text"
+            className="block text-sm font-medium text-dusty-denim"
           >
             Home type
           </label>
@@ -60,7 +60,7 @@ export function StepHomeDetails({
                 home_type: (e.target.value || null) as HomeType | null,
               })
             }
-            className="mt-1 block w-full rounded-button border border-brand-border bg-white px-3 py-2 text-sm"
+            className="mt-1 block w-full rounded-button border border-champ-blue bg-white px-3 py-2 text-sm"
           >
             <option value="">Select home type...</option>
             {HOME_TYPE_OPTIONS.map((opt) => (
@@ -75,7 +75,7 @@ export function StepHomeDetails({
         <div>
           <label
             htmlFor="year_built"
-            className="block text-sm font-medium text-brand-text"
+            className="block text-sm font-medium text-dusty-denim"
           >
             Year built (approximate)
           </label>
@@ -91,7 +91,7 @@ export function StepHomeDetails({
               })
             }
             placeholder="e.g. 1985"
-            className="mt-1 block w-full rounded-button border border-brand-border px-3 py-2 text-sm"
+            className="mt-1 block w-full rounded-button border border-champ-blue px-3 py-2 text-sm"
           />
         </div>
 
@@ -99,7 +99,7 @@ export function StepHomeDetails({
         <div>
           <label
             htmlFor="sqft"
-            className="block text-sm font-medium text-brand-text"
+            className="block text-sm font-medium text-dusty-denim"
           >
             Square footage (approximate)
           </label>
@@ -115,11 +115,11 @@ export function StepHomeDetails({
               })
             }
             placeholder="e.g. 1500"
-            className="mt-1 block w-full rounded-button border border-brand-border px-3 py-2 text-sm"
+            className="mt-1 block w-full rounded-button border border-champ-blue px-3 py-2 text-sm"
           />
         </div>
 
-        <p className="text-xs text-brand-text-muted">
+        <p className="text-xs text-dusty-denim">
           All fields are optional. Older homes and certain construction types may
           have higher indoor allergen risk.
         </p>
@@ -129,13 +129,13 @@ export function StepHomeDetails({
           <button
             type="button"
             onClick={onBack}
-            className="flex-1 rounded-button border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
+            className="flex-1 rounded-button border border-champ-blue bg-white px-4 py-2 text-sm font-medium text-dusty-denim hover:bg-white"
           >
             Back
           </button>
           <button
             type="submit"
-            className="flex-1 rounded-button bg-brand-premium px-4 py-2 text-sm font-medium text-white hover:bg-brand-premium/80"
+            className="flex-1 rounded-button bg-dusty-denim px-4 py-2 text-sm font-medium text-white hover:bg-dusty-denim/80"
           >
             Continue
           </button>


### PR DESCRIPTION
## Summary

Brand-token migration for the onboarding wizard and auth route surfaces, child #249 of epic #243. Swaps `brand-*` alias classes and legacy hex codes for the canonical 4-color tokens (`champ-blue`, `dusty-denim`, `nature-pop`, `alert-red`). className-only — no behavior, copy, or step-logic changes.

Closes #249

## Files changed (9, 72 token/hex replacements)

- `app/(auth)/layout.tsx` (1)
- `app/(auth)/login/page.tsx` (8)
- `app/(auth)/signup/page.tsx` (10)
- `components/onboarding/onboarding-wizard.tsx` (5)
- `components/onboarding/step-address.tsx` (6)
- `components/onboarding/step-home-details.tsx` (11)
- `components/onboarding/step-health-questions.tsx` (11)
- `components/onboarding/step-confirmation.tsx` (8)
- `components/onboarding/processing-screen.tsx` (10)

`app/(app)/onboarding/page.tsx` had no brand-token refs (verified), so it is untouched — the wizard shell it renders is migrated via the components above.

## Mapping applied

| Legacy | Canonical |
|---|---|
| `bg-brand-premium`, `bg-brand-premium/80` (primary CTA) | `bg-dusty-denim`, `bg-dusty-denim/80` |
| `text-brand-primary-dark`, `text-brand-text*`, `text-brand-premium` | `text-dusty-denim` |
| `border-brand-border`, `focus:ring-brand-primary`, `focus:border-brand-primary` | `border-champ-blue`, `focus:ring-champ-blue`, `focus:border-champ-blue` |
| `text-brand-primary`, `bg-brand-primary` (progress fill) | `text-champ-blue`, `bg-champ-blue` |
| `bg-brand-surface-muted`, `bg-brand-primary-light`, `bg-brand-border-light`, `bg-brand-premium-light` | `bg-white` |
| Legacy hex `#E0F0F8` / `#055A8C` on login/signup error banner | `bg-white border-alert-red text-alert-red` (per ticket: alert-red for form-validation errors on auth only) |
| Legacy hex `#055A8C` on onboarding address error text | `text-dusty-denim` (non-auth error stays in palette; guardrail reserves alert-red for login/signup) |

Pet-type toggle in `step-health-questions` previously used `brand-primary-light` tint for selected state; the 4-color system has no tint, so selected now inverts to `bg-champ-blue text-white` vs. unselected `bg-white text-dusty-denim` to preserve the state distinction without opacity tricks.

## Verification

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 1167 / 1167 pass (106 files)
- `npm run build` — succeeds

## Epic context

Part of epic #243 (brand consolidation). Siblings:
- #247 — shared primitives (PR #261, in review)
- #248 — dashboard (PR #262, in review)
- #250 — children / places (pending)
- #251 — check-in (pending)
- #252 — misc surfaces (pending)

## Test plan

- [ ] Walk signup -> onboarding wizard (address -> home -> health -> confirm -> processing) end-to-end in a PR preview
- [ ] Verify login error banner renders in alert-red
- [ ] Verify signup mismatched-password error renders in alert-red
- [ ] Verify pet-type toggles show a clear selected vs. unselected state
- [ ] Verify processing screen spinner + progress bar render in champ-blue