### PR TITLE
refactor(children-places): migrate child profiles + saved places to 4-color tokens

### DIFF
--- a/__tests__/components/children/child-form-fields.test.tsx
+++ b/__tests__/components/children/child-form-fields.test.tsx
@@ -91,13 +91,13 @@ describe("ChildFormFields", () => {
     expect(screen.queryByTestId("edit-child-error")).toBeNull();
   });
 
-  it("uses brand tokens (not raw hex) for the error banner classes", () => {
+  it("uses 4-color tokens (not raw hex) for the error banner classes", () => {
     renderFields({ idPrefix: "add", error: "Oops" });
 
     const banner = screen.getByTestId("add-child-error");
     // Guard against regressing back to raw hex literals.
-    expect(banner.className).toContain("bg-brand-premium-light");
-    expect(banner.className).toContain("text-brand-premium");
+    expect(banner.className).toContain("bg-white");
+    expect(banner.className).toContain("text-alert-red");
     expect(banner.className).not.toMatch(/#E0F0F8/i);
     expect(banner.className).not.toMatch(/#055A8C/i);
   });

--- a/app/(app)/children/page.tsx
+++ b/app/(app)/children/page.tsx
@@ -39,10 +39,10 @@ export default async function ChildrenPage() {
   return (
     <PageContainer>
       <div className="mb-6">
-        <h1 className="m-0 text-2xl font-bold text-brand-primary-dark">
+        <h1 className="m-0 text-2xl font-bold text-dusty-denim">
           Child Profiles
         </h1>
-        <p className="mt-1 mb-0 text-sm text-brand-text-secondary">
+        <p className="mt-1 mb-0 text-sm text-dusty-denim">
           Track allergies independently for each child in your family.
         </p>
       </div>

--- a/app/(app)/places/page.tsx
+++ b/app/(app)/places/page.tsx
@@ -30,10 +30,10 @@ export default async function PlacesPage() {
   return (
     <PageContainer>
       <div className="mb-6">
-        <h1 className="m-0 text-2xl font-bold text-brand-primary-dark">
+        <h1 className="m-0 text-2xl font-bold text-dusty-denim">
           Saved Places
         </h1>
-        <p className="mt-1 mb-0 text-sm text-brand-text-secondary">
+        <p className="mt-1 mb-0 text-sm text-dusty-denim">
           Track allergen exposure at recurring locations like a grandparent&apos;s
           house or a vacation home.
         </p>

--- a/components/children/add-child-form.tsx
+++ b/components/children/add-child-form.tsx
@@ -34,9 +34,9 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
     <form
       data-testid="add-child-form"
       onSubmit={handleSubmit}
-      className="rounded-card border border-brand-primary-light bg-white p-4 shadow-sm"
+      className="rounded-card border border-champ-blue bg-white p-4 shadow-sm"
     >
-      <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">Add Child</h3>
+      <h3 className="mb-3 text-sm font-semibold text-dusty-denim">Add Child</h3>
 
       <ChildFormFields
         idPrefix="add"
@@ -52,7 +52,7 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
           type="button"
           onClick={onCancel}
           disabled={isLoading}
-          className="rounded-button border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
+          className="rounded-button border border-champ-blue bg-white px-4 py-2 text-xs font-medium text-dusty-denim hover:bg-white disabled:opacity-50"
         >
           Cancel
         </button>
@@ -60,7 +60,7 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
           type="submit"
           data-testid="save-child-btn"
           disabled={isLoading || !name.trim()}
-          className="rounded-button bg-brand-premium px-4 py-2 text-xs font-semibold text-white hover:bg-brand-premium/80 disabled:opacity-50"
+          className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80 disabled:opacity-50"
         >
           {isLoading ? "Saving..." : "Save"}
         </button>

--- a/components/children/child-form-fields.tsx
+++ b/components/children/child-form-fields.tsx
@@ -31,8 +31,8 @@ export interface ChildFormFieldsProps {
 }
 
 const INPUT_CLASS =
-  "w-full rounded-button border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary";
-const LABEL_CLASS = "mb-1 block text-xs font-medium text-brand-text";
+  "w-full rounded-button border border-champ-blue px-3 py-2 text-sm text-dusty-denim placeholder-dusty-denim focus:border-champ-blue focus:outline-none focus:ring-1 focus:ring-champ-blue";
+const LABEL_CLASS = "mb-1 block text-xs font-medium text-dusty-denim";
 
 export function ChildFormFields({
   idPrefix,
@@ -57,7 +57,7 @@ export function ChildFormFields({
       {error && (
         <p
           data-testid={errorTestId}
-          className="mb-3 rounded-card bg-brand-premium-light p-2 text-xs text-brand-premium"
+          className="mb-3 rounded-card bg-white p-2 text-xs text-alert-red"
         >
           {error}
         </p>

--- a/components/children/child-profile-card.tsx
+++ b/components/children/child-profile-card.tsx
@@ -25,16 +25,16 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
   return (
     <div
       data-testid="child-profile-card"
-      className="flex items-center justify-between rounded-card border border-brand-border bg-white p-4 shadow-sm"
+      className="flex items-center justify-between rounded-card border border-champ-blue bg-white p-4 shadow-sm"
     >
       <div className="flex items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary-light text-sm font-bold text-brand-primary">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-champ-blue text-sm font-bold text-white">
           {child.name.charAt(0).toUpperCase()}
         </div>
         <div>
-          <p className="text-sm font-semibold text-brand-primary-dark">{child.name}</p>
+          <p className="text-sm font-semibold text-dusty-denim">{child.name}</p>
           {age !== null && (
-            <p className="text-xs text-brand-text-muted">
+            <p className="text-xs text-dusty-denim">
               Age {age}
             </p>
           )}
@@ -45,7 +45,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
         <button
           type="button"
           data-testid="edit-child-btn"
-          className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-text hover:bg-brand-surface-muted"
+          className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-dusty-denim hover:bg-white"
           onClick={() => onEdit(child.id)}
         >
           Edit
@@ -56,7 +56,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
             <button
               type="button"
               data-testid="confirm-delete-btn"
-              className="rounded-button bg-[#055A8C] px-3 py-1.5 text-xs font-medium text-white hover:bg-[#044A72]"
+              className="rounded-button bg-champ-blue px-3 py-1.5 text-xs font-medium text-white hover:bg-champ-blue/80"
               onClick={() => {
                 onDelete(child.id);
                 setConfirmDelete(false);
@@ -66,7 +66,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
             </button>
             <button
               type="button"
-              className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-text hover:bg-brand-surface-muted"
+              className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-dusty-denim hover:bg-white"
               onClick={() => setConfirmDelete(false)}
             >
               Cancel
@@ -76,7 +76,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
           <button
             type="button"
             data-testid="delete-child-btn"
-            className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-[#055A8C] hover:bg-[#E0F0F8]"
+            className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-champ-blue hover:bg-white"
             onClick={() => setConfirmDelete(true)}
           >
             Remove

--- a/components/children/children-manager.tsx
+++ b/components/children/children-manager.tsx
@@ -135,7 +135,7 @@ export function ChildrenManager({
   if (!hasAccess) {
     return (
       <div data-testid="children-upgrade-gate" className="space-y-4">
-        <p className="text-sm text-brand-text-secondary">
+        <p className="text-sm text-dusty-denim">
           Track allergies for up to {maxChildren} children with independent
           leaderboards and check-ins.
         </p>
@@ -149,7 +149,7 @@ export function ChildrenManager({
   return (
     <div data-testid="children-manager" className="space-y-4">
       <div className="flex items-center justify-between">
-        <p className="text-sm text-brand-text-secondary">
+        <p className="text-sm text-dusty-denim">
           {childList.length} of {maxChildren} profiles used
         </p>
         {canAddMore && !showAddForm && (
@@ -160,7 +160,7 @@ export function ChildrenManager({
               setShowAddForm(true);
               setError(null);
             }}
-            className="rounded-button bg-brand-premium px-4 py-2 text-xs font-semibold text-white hover:bg-brand-premium/80"
+            className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80"
           >
             + Add Child
           </button>
@@ -184,19 +184,19 @@ export function ChildrenManager({
       {childList.length === 0 && !showAddForm ? (
         <div
           data-testid="empty-children-state"
-          className="rounded-card border border-dashed border-brand-border bg-brand-surface-muted p-8 text-center"
+          className="rounded-card border border-dashed border-champ-blue bg-white p-8 text-center"
         >
-          <p className="mb-2 text-sm font-medium text-brand-text">
+          <p className="mb-2 text-sm font-medium text-dusty-denim">
             No child profiles yet
           </p>
-          <p className="mb-4 text-xs text-brand-text-muted">
+          <p className="mb-4 text-xs text-dusty-denim">
             Add a child to track their allergy triggers independently.
           </p>
           <button
             type="button"
             data-testid="empty-state-add-btn"
             onClick={() => setShowAddForm(true)}
-            className="rounded-button bg-brand-premium px-4 py-2 text-xs font-semibold text-white hover:bg-brand-premium/80"
+            className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80"
           >
             + Add Your First Child
           </button>
@@ -232,7 +232,7 @@ export function ChildrenManager({
       {!canAddMore && (
         <p
           data-testid="max-children-notice"
-          className="text-center text-xs text-brand-text-muted"
+          className="text-center text-xs text-dusty-denim"
         >
           Maximum of {maxChildren} child profiles reached.
         </p>

--- a/components/children/edit-child-form.tsx
+++ b/components/children/edit-child-form.tsx
@@ -37,9 +37,9 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
     <form
       data-testid="edit-child-form"
       onSubmit={handleSubmit}
-      className="rounded-card border border-brand-primary-light bg-white p-4 shadow-sm"
+      className="rounded-card border border-champ-blue bg-white p-4 shadow-sm"
     >
-      <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">Edit Child</h3>
+      <h3 className="mb-3 text-sm font-semibold text-dusty-denim">Edit Child</h3>
 
       <ChildFormFields
         idPrefix="edit"
@@ -56,7 +56,7 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
           onClick={onCancel}
           disabled={isLoading}
           data-testid="edit-child-cancel-btn"
-          className="rounded-button border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
+          className="rounded-button border border-champ-blue bg-white px-4 py-2 text-xs font-medium text-dusty-denim hover:bg-white disabled:opacity-50"
         >
           Cancel
         </button>
@@ -64,7 +64,7 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
           type="submit"
           data-testid="edit-child-save-btn"
           disabled={isLoading || !name.trim()}
-          className="rounded-button bg-brand-premium px-4 py-2 text-xs font-semibold text-white hover:bg-brand-premium/80 disabled:opacity-50"
+          className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80 disabled:opacity-50"
         >
           {isLoading ? "Saving..." : "Save"}
         </button>

--- a/components/children/profile-switcher.tsx
+++ b/components/children/profile-switcher.tsx
@@ -45,14 +45,14 @@ export function ProfileSwitcher({
         type="button"
         data-testid="profile-switcher-toggle"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 rounded-button border border-brand-border bg-white px-3 py-2 text-sm font-medium text-brand-text shadow-sm hover:bg-brand-surface-muted"
+        className="flex items-center gap-2 rounded-button border border-champ-blue bg-white px-3 py-2 text-sm font-medium text-dusty-denim shadow-sm hover:bg-white"
       >
-        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-primary-light text-xs font-bold text-brand-primary">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-champ-blue text-xs font-bold text-white">
           {activeLabel.charAt(0).toUpperCase()}
         </span>
         <span>{activeLabel}</span>
         <svg
-          className={`h-4 w-4 text-brand-text-faint transition-transform ${isOpen ? "rotate-180" : ""}`}
+          className={`h-4 w-4 text-dusty-denim transition-transform ${isOpen ? "rotate-180" : ""}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -64,7 +64,7 @@ export function ProfileSwitcher({
       {isOpen && (
         <div
           data-testid="profile-switcher-menu"
-          className="absolute left-0 z-10 mt-1 w-56 rounded-card border border-brand-border bg-white py-1 shadow-lg"
+          className="absolute left-0 z-10 mt-1 w-56 rounded-card border border-champ-blue bg-white py-1 shadow-lg"
         >
           {/* Parent/Self option */}
           <button
@@ -76,18 +76,18 @@ export function ProfileSwitcher({
             }}
             className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm ${
               activeChildId === null
-                ? "bg-brand-primary-light font-semibold text-brand-primary"
-                : "text-brand-text hover:bg-brand-surface-muted"
+                ? "bg-champ-blue font-semibold text-white"
+                : "text-dusty-denim hover:bg-white"
             }`}
           >
-            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-surface-muted text-xs font-bold text-brand-text-secondary">
+            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-white text-xs font-bold text-dusty-denim">
               {parentLabel.charAt(0).toUpperCase()}
             </span>
             {parentLabel} (Me)
           </button>
 
           {/* Divider */}
-          <div className="my-1 border-t border-brand-border-light" />
+          <div className="my-1 border-t border-champ-blue" />
 
           {/* Child options */}
           {childProfiles.map((child) => (
@@ -101,11 +101,11 @@ export function ProfileSwitcher({
               }}
               className={`flex w-full items-center gap-2 px-4 py-2 text-left text-sm ${
                 activeChildId === child.id
-                  ? "bg-brand-primary-light font-semibold text-brand-primary"
-                  : "text-brand-text hover:bg-brand-surface-muted"
+                  ? "bg-champ-blue font-semibold text-white"
+                  : "text-dusty-denim hover:bg-white"
               }`}
             >
-              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-brand-primary-light text-xs font-bold text-brand-primary">
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-champ-blue text-xs font-bold text-white">
                 {child.name.charAt(0).toUpperCase()}
               </span>
               {child.name}

--- a/components/places/add-place-form.tsx
+++ b/components/places/add-place-form.tsx
@@ -44,9 +44,9 @@ export function AddPlaceForm({
     <form
       data-testid="add-place-form"
       onSubmit={handleSubmit}
-      className="rounded-card border border-brand-primary-light bg-white p-4 shadow-sm"
+      className="rounded-card border border-champ-blue bg-white p-4 shadow-sm"
     >
-      <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">
+      <h3 className="mb-3 text-sm font-semibold text-dusty-denim">
         Add Saved Place
       </h3>
 
@@ -68,7 +68,7 @@ export function AddPlaceForm({
           type="button"
           onClick={onCancel}
           disabled={isLoading}
-          className="rounded-button border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
+          className="rounded-button border border-champ-blue bg-white px-4 py-2 text-xs font-medium text-dusty-denim hover:bg-white disabled:opacity-50"
         >
           Cancel
         </button>
@@ -76,7 +76,7 @@ export function AddPlaceForm({
           type="submit"
           data-testid="save-place-btn"
           disabled={isLoading || !nickname.trim()}
-          className="rounded-button bg-brand-premium px-4 py-2 text-xs font-semibold text-white hover:bg-brand-premium/80 disabled:opacity-50"
+          className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80 disabled:opacity-50"
         >
           {isLoading ? "Saving..." : "Save"}
         </button>

--- a/components/places/edit-place-form.tsx
+++ b/components/places/edit-place-form.tsx
@@ -46,9 +46,9 @@ export function EditPlaceForm({
     <form
       data-testid="edit-place-form"
       onSubmit={handleSubmit}
-      className="rounded-card border border-brand-primary-light bg-white p-4 shadow-sm"
+      className="rounded-card border border-champ-blue bg-white p-4 shadow-sm"
     >
-      <h3 className="mb-3 text-sm font-semibold text-brand-primary-dark">
+      <h3 className="mb-3 text-sm font-semibold text-dusty-denim">
         Edit Saved Place
       </h3>
 
@@ -71,7 +71,7 @@ export function EditPlaceForm({
           onClick={onCancel}
           disabled={isLoading}
           data-testid="edit-place-cancel-btn"
-          className="rounded-button border border-brand-border bg-white px-4 py-2 text-xs font-medium text-brand-text hover:bg-brand-surface-muted disabled:opacity-50"
+          className="rounded-button border border-champ-blue bg-white px-4 py-2 text-xs font-medium text-dusty-denim hover:bg-white disabled:opacity-50"
         >
           Cancel
         </button>
@@ -79,7 +79,7 @@ export function EditPlaceForm({
           type="submit"
           data-testid="edit-place-save-btn"
           disabled={isLoading || !nickname.trim()}
-          className="rounded-button bg-brand-premium px-4 py-2 text-xs font-semibold text-white hover:bg-brand-premium/80 disabled:opacity-50"
+          className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80 disabled:opacity-50"
         >
           {isLoading ? "Saving..." : "Save"}
         </button>

--- a/components/places/place-card.tsx
+++ b/components/places/place-card.tsx
@@ -35,23 +35,23 @@ export function PlaceCard({ place, onDelete, onEdit }: PlaceCardProps) {
   return (
     <div
       data-testid="place-card"
-      className="flex items-center justify-between rounded-card border border-brand-border bg-white p-4 shadow-sm"
+      className="flex items-center justify-between rounded-card border border-champ-blue bg-white p-4 shadow-sm"
     >
       <div className="flex min-w-0 items-center gap-3">
-        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary-light text-sm font-bold text-brand-primary">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-champ-blue text-sm font-bold text-white">
           {nickname.charAt(0).toUpperCase()}
         </div>
         <div className="min-w-0">
-          <p className="truncate text-sm font-semibold text-brand-primary-dark">
+          <p className="truncate text-sm font-semibold text-dusty-denim">
             {nickname}
           </p>
           {place.address && (
-            <p className="truncate text-xs text-brand-text-muted">
+            <p className="truncate text-xs text-dusty-denim">
               {place.address}
             </p>
           )}
           {lastVisit && (
-            <p className="text-xs text-brand-text-muted">
+            <p className="text-xs text-dusty-denim">
               Last visit: {lastVisit}
             </p>
           )}
@@ -62,7 +62,7 @@ export function PlaceCard({ place, onDelete, onEdit }: PlaceCardProps) {
         <button
           type="button"
           data-testid="edit-place-btn"
-          className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-text hover:bg-brand-surface-muted"
+          className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-dusty-denim hover:bg-white"
           onClick={() => onEdit(place.id)}
         >
           Edit
@@ -73,7 +73,7 @@ export function PlaceCard({ place, onDelete, onEdit }: PlaceCardProps) {
             <button
               type="button"
               data-testid="confirm-delete-place-btn"
-              className="rounded-button bg-brand-premium px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-premium/80"
+              className="rounded-button bg-dusty-denim px-3 py-1.5 text-xs font-medium text-white hover:bg-dusty-denim/80"
               onClick={() => {
                 onDelete(place.id);
                 setConfirmDelete(false);
@@ -83,7 +83,7 @@ export function PlaceCard({ place, onDelete, onEdit }: PlaceCardProps) {
             </button>
             <button
               type="button"
-              className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-text hover:bg-brand-surface-muted"
+              className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-dusty-denim hover:bg-white"
               onClick={() => setConfirmDelete(false)}
             >
               Cancel
@@ -93,7 +93,7 @@ export function PlaceCard({ place, onDelete, onEdit }: PlaceCardProps) {
           <button
             type="button"
             data-testid="delete-place-btn"
-            className="rounded-button border border-brand-border bg-white px-3 py-1.5 text-xs font-medium text-brand-premium hover:bg-brand-premium-light"
+            className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-dusty-denim hover:bg-white"
             onClick={() => setConfirmDelete(true)}
           >
             Remove

--- a/components/places/place-form-fields.tsx
+++ b/components/places/place-form-fields.tsx
@@ -36,8 +36,8 @@ export interface PlaceFormFieldsProps {
 }
 
 const INPUT_CLASS =
-  "w-full rounded-button border border-brand-border px-3 py-2 text-sm text-brand-primary-dark placeholder-brand-text-faint focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary";
-const LABEL_CLASS = "mb-1 block text-xs font-medium text-brand-text";
+  "w-full rounded-button border border-champ-blue px-3 py-2 text-sm text-dusty-denim placeholder-dusty-denim focus:border-champ-blue focus:outline-none focus:ring-1 focus:ring-champ-blue";
+const LABEL_CLASS = "mb-1 block text-xs font-medium text-dusty-denim";
 
 export function PlaceFormFields({
   idPrefix,
@@ -62,7 +62,7 @@ export function PlaceFormFields({
       {error && (
         <p
           data-testid={errorTestId}
-          className="mb-3 rounded-card bg-brand-premium-light p-2 text-xs text-brand-premium"
+          className="mb-3 rounded-card bg-white p-2 text-xs text-alert-red"
         >
           {error}
         </p>

--- a/components/places/places-manager.tsx
+++ b/components/places/places-manager.tsx
@@ -135,7 +135,7 @@ export function PlacesManager({ initialPlaces }: PlacesManagerProps) {
   return (
     <div data-testid="places-manager" className="space-y-4">
       <div className="flex items-center justify-between">
-        <p className="text-sm text-brand-text-secondary">
+        <p className="text-sm text-dusty-denim">
           {placeList.length} saved place{placeList.length === 1 ? "" : "s"}
         </p>
         {!showAddForm && (
@@ -146,7 +146,7 @@ export function PlacesManager({ initialPlaces }: PlacesManagerProps) {
               setShowAddForm(true);
               setError(null);
             }}
-            className="rounded-button bg-brand-premium px-4 py-2 text-xs font-semibold text-white hover:bg-brand-premium/80"
+            className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80"
           >
             + Add Place
           </button>
@@ -168,12 +168,12 @@ export function PlacesManager({ initialPlaces }: PlacesManagerProps) {
       {placeList.length === 0 && !showAddForm ? (
         <div
           data-testid="empty-places-state"
-          className="rounded-card border border-dashed border-brand-border bg-brand-surface-muted p-8 text-center"
+          className="rounded-card border border-dashed border-champ-blue bg-white p-8 text-center"
         >
-          <p className="mb-2 text-sm font-medium text-brand-text">
+          <p className="mb-2 text-sm font-medium text-dusty-denim">
             No saved places yet
           </p>
-          <p className="mb-4 text-xs text-brand-text-muted">
+          <p className="mb-4 text-xs text-dusty-denim">
             Save recurring locations (grandma&apos;s house, vacation home) to
             track their allergen profile independently.
           </p>
@@ -181,7 +181,7 @@ export function PlacesManager({ initialPlaces }: PlacesManagerProps) {
             type="button"
             data-testid="empty-state-add-place-btn"
             onClick={() => setShowAddForm(true)}
-            className="rounded-button bg-brand-premium px-4 py-2 text-xs font-semibold text-white hover:bg-brand-premium/80"
+            className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80"
           >
             + Add Your First Place
           </button>


### PR DESCRIPTION
## Summary

Migrates the 13 files for child-profile and saved-places management surfaces from legacy `brand-*` aliases (and a pair of raw hex literals) to the canonical 4-color token scheme established by #246.

Part of epic #243. Closes #250.

## Files changed (14)

Children (7):
- `components/children/add-child-form.tsx`
- `components/children/edit-child-form.tsx`
- `components/children/child-form-fields.tsx`
- `components/children/child-profile-card.tsx` (also removed raw hex `#055A8C` / `#044A72` / `#E0F0F8`)
- `components/children/children-manager.tsx`
- `components/children/profile-switcher.tsx`
- `app/(app)/children/page.tsx`

Places (6):
- `components/places/add-place-form.tsx`
- `components/places/edit-place-form.tsx`
- `components/places/place-form-fields.tsx`
- `components/places/place-card.tsx`
- `components/places/places-manager.tsx`
- `app/(app)/places/page.tsx`

Test (1):
- `__tests__/components/children/child-form-fields.test.tsx` (assertion updated from `bg-brand-premium-light`/`text-brand-premium` to `bg-white`/`text-alert-red` to match canonical error-banner tokens)

## Token rename summary

| From | To | Notes |
|------|-----|------|
| `border-brand-border`, `border-brand-border-light`, `border-brand-primary-light` | `border-champ-blue` | |
| `bg-brand-primary-light`, `bg-brand-surface-muted` | `bg-white` (or `bg-champ-blue` on avatar chips) | |
| `text-brand-primary-dark`, `text-brand-text`, `text-brand-text-secondary`, `text-brand-text-muted`, `text-brand-text-faint` | `text-dusty-denim` | |
| `bg-brand-premium`, `text-brand-premium` (primary CTAs) | `bg-dusty-denim`, `text-dusty-denim` | |
| `bg-brand-premium-light` / `text-brand-premium` (form error banners) | `bg-white` / `text-alert-red` | per ticket guardrail C |
| `bg-brand-primary-light text-brand-primary` (profile-switcher active state) | `bg-champ-blue text-white` | guardrail: must remain visibly distinct without opacity |
| `bg-[#055A8C]`, `bg-[#044A72]`, `bg-[#E0F0F8]`, `text-[#055A8C]` | `bg-champ-blue` / `bg-white` / `text-champ-blue` | raw-hex removal |

Total: ~66 className changes across 13 surface files + 1 test assertion update.

## Defensive final grep

- `rg "brand-" components/children components/places app/(app)/children/page.tsx app/(app)/places/page.tsx` → zero matches
- `rg "#[0-9A-Fa-f]{6}" components/children components/places` → zero matches

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 1167/1167 pass (52 in-scope children/places tests green)
- [x] `npm run build` — successful production build
- [ ] Reviewer walks through: add/edit/remove child, profile switcher selection, add/edit/remove saved place