### PR TITLE
refactor(misc-surfaces): migrate landing/subscription/referral/scout/pfas to 4-color tokens

### DIFF
--- a/__tests__/landing-page.test.tsx
+++ b/__tests__/landing-page.test.tsx
@@ -147,9 +147,9 @@ describe("HomePage", () => {
     });
 
     // WCAG AA contrast (#185): the "How It Works" band must use
-    // bg-brand-premium (#055A8C) so white text achieves >=4.5:1.
+    // bg-dusty-denim (#055A8C) so white text achieves >=4.5:1.
     // Champ Blue (#00B6E2) fails AA with any available text color.
-    it("uses brand-premium (not Champ Blue) for the How It Works band", async () => {
+    it("uses dusty-denim (not Champ Blue) for the How It Works band", async () => {
       const Page = await HomePage();
       const { container } = render(Page);
 
@@ -159,8 +159,8 @@ describe("HomePage", () => {
       const section = heading.closest("section");
       expect(section).not.toBeNull();
       const classes = section!.className.split(/\s+/);
-      expect(classes).toContain("bg-brand-premium");
-      expect(classes).not.toContain("bg-brand-primary");
+      expect(classes).toContain("bg-dusty-denim");
+      expect(classes).not.toContain("bg-champ-blue");
       // Silence unused-var lint for container
       void container;
     });

--- a/app/(app)/referral/page.tsx
+++ b/app/(app)/referral/page.tsx
@@ -29,10 +29,10 @@ export default async function ReferralPage() {
   return (
     <PageContainer width="sm" className="space-y-6">
       <div>
-        <h1 className="m-0 text-2xl font-bold text-brand-primary-dark">
+        <h1 className="m-0 text-2xl font-bold text-dusty-denim">
           Invite Friends
         </h1>
-        <p className="mt-1 mb-0 text-sm text-brand-text-muted">
+        <p className="mt-1 mb-0 text-sm text-dusty-denim">
           Share Allergy Madness with friends and unlock all features for free.
         </p>
       </div>

--- a/app/(app)/scout/page.tsx
+++ b/app/(app)/scout/page.tsx
@@ -31,10 +31,10 @@ export default async function ScoutPage() {
     <PageContainer width="sm">
       {/* Header */}
       <div className="mb-6">
-        <h1 className="m-0 mb-1 text-2xl font-bold text-brand-primary-dark">
+        <h1 className="m-0 mb-1 text-2xl font-bold text-dusty-denim">
           Trigger Scout
         </h1>
-        <p className="m-0 text-sm text-brand-text-secondary">
+        <p className="m-0 text-sm text-dusty-denim">
           Photograph a plant you suspect causes reactions. AI will identify it
           and check it against your allergen profile.
         </p>
@@ -52,7 +52,7 @@ export default async function ScoutPage() {
       <div className="mt-6 text-center">
         <a
           href="/dashboard"
-          className="text-sm text-brand-primary no-underline hover:text-brand-primary-dark hover:underline"
+          className="text-sm text-champ-blue no-underline hover:text-dusty-denim hover:underline"
         >
           Back to Dashboard
         </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,12 +37,12 @@ export default async function HomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-brand-surface">
+    <div className="min-h-screen bg-white">
       {/* Unified navigation (unauthenticated variant) */}
       <NavBar authState="unauthenticated" />
 
       {/* Hero Section */}
-      <section className="bg-brand-premium px-4 py-16 sm:px-6 sm:py-24">
+      <section className="bg-dusty-denim px-4 py-16 sm:px-6 sm:py-24">
         <div className="mx-auto max-w-3xl text-center">
           <h1
             className="text-3xl font-bold tracking-tight text-white sm:text-5xl"
@@ -50,7 +50,7 @@ export default async function HomePage() {
           >
             Allergy Madness
           </h1>
-          <p className="mx-auto mt-2 text-base text-brand-primary-light">
+          <p className="mx-auto mt-2 text-base text-white">
             by Champ Allergy
           </p>
           <p className="mx-auto mt-4 max-w-xl text-lg text-white/90 sm:mt-6 sm:text-xl">
@@ -63,7 +63,7 @@ export default async function HomePage() {
           <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4">
             <Link
               href="/signup"
-              className="w-full rounded-button bg-brand-accent px-8 py-3 text-center text-base font-semibold text-brand-primary-dark shadow-sm transition-colors hover:bg-brand-accent-dark sm:w-auto"
+              className="w-full rounded-button bg-nature-pop px-8 py-3 text-center text-base font-semibold text-dusty-denim shadow-sm transition-colors hover:bg-nature-pop sm:w-auto"
             >
               Get Started Free
             </Link>
@@ -81,7 +81,7 @@ export default async function HomePage() {
       </section>
 
       {/* How It Works */}
-      <section className="bg-brand-premium px-4 py-16 sm:px-6">
+      <section className="bg-dusty-denim px-4 py-16 sm:px-6">
         <div className="mx-auto max-w-5xl">
           <h2
             className="text-center text-2xl font-bold text-white sm:text-3xl"
@@ -113,10 +113,10 @@ export default async function HomePage() {
       </section>
 
       {/* Features */}
-      <section className="bg-brand-primary-light px-4 py-16 sm:px-6">
+      <section className="bg-white px-4 py-16 sm:px-6">
         <div className="mx-auto max-w-5xl">
           <h2
-            className="text-center text-2xl font-bold text-brand-primary-dark sm:text-3xl"
+            className="text-center text-2xl font-bold text-dusty-denim sm:text-3xl"
             style={{ fontFamily: "var(--font-title)" }}
           >
             Features
@@ -151,7 +151,7 @@ export default async function HomePage() {
       </section>
 
       {/* CTA Section */}
-      <section className="bg-brand-premium px-4 py-16 sm:px-6">
+      <section className="bg-dusty-denim px-4 py-16 sm:px-6">
         <div className="mx-auto max-w-2xl text-center">
           <h2
             className="text-2xl font-bold text-white sm:text-3xl"
@@ -165,7 +165,7 @@ export default async function HomePage() {
           </p>
           <Link
             href="/signup"
-            className="mt-8 inline-block rounded-button bg-brand-accent px-8 py-3 text-base font-semibold text-brand-primary-dark shadow-sm transition-colors hover:bg-brand-accent-dark"
+            className="mt-8 inline-block rounded-button bg-nature-pop px-8 py-3 text-base font-semibold text-dusty-denim shadow-sm transition-colors hover:bg-nature-pop"
           >
             Get Started Free
           </Link>
@@ -173,22 +173,22 @@ export default async function HomePage() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-brand-border bg-white px-4 py-8 sm:px-6">
+      <footer className="border-t border-champ-blue bg-white px-4 py-8 sm:px-6">
         <div className="mx-auto max-w-5xl">
           {/* FDA Disclaimer */}
-          <div className="rounded-card border border-brand-border bg-brand-primary-light px-4 py-3">
-            <p className="text-sm font-semibold text-brand-primary-dark">
+          <div className="rounded-card border border-champ-blue bg-white px-4 py-3">
+            <p className="text-sm font-semibold text-dusty-denim">
               {FDA_DISCLAIMER_LABEL}
             </p>
-            <p className="mt-1 text-xs text-brand-text-secondary">
+            <p className="mt-1 text-xs text-dusty-denim">
               {FDA_DISCLAIMER_FULL_TEXT}
             </p>
           </div>
           <div className="mt-6 flex flex-col items-center gap-2 text-center">
-            <p className="text-sm font-medium text-brand-text-secondary">
+            <p className="text-sm font-medium text-dusty-denim">
               Allergy Madness — The Digital Allergy Test by Champ Allergy
             </p>
-            <p className="text-xs text-brand-text-muted">
+            <p className="text-xs text-dusty-denim">
               &copy; {new Date().getFullYear()} Champ Allergy. All rights
               reserved.
             </p>
@@ -214,7 +214,7 @@ function StepCard({
 }) {
   return (
     <div className="flex flex-col items-center text-center">
-      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-sm font-bold text-brand-primary">
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-sm font-bold text-champ-blue">
         {step}
       </div>
       <h3 className="mt-4 text-lg font-semibold text-white">{title}</h3>
@@ -231,9 +231,9 @@ function FeatureCard({
   description: string;
 }) {
   return (
-    <div className="rounded-card border border-brand-border bg-white p-6">
-      <h3 className="text-base font-semibold text-brand-primary-dark">{title}</h3>
-      <p className="mt-2 text-sm text-brand-text-secondary">{description}</p>
+    <div className="rounded-card border border-champ-blue bg-white p-6">
+      <h3 className="text-base font-semibold text-dusty-denim">{title}</h3>
+      <p className="mt-2 text-sm text-dusty-denim">{description}</p>
     </div>
   );
 }

--- a/components/pfas/pfas-panel.tsx
+++ b/components/pfas/pfas-panel.tsx
@@ -79,7 +79,7 @@ function FoodTag({ food }: { food: string }) {
   return (
     <span
       data-testid="pfas-food-tag"
-      className="inline-block rounded-full border border-brand-border bg-brand-primary-light px-2 py-1 text-xs font-medium text-brand-primary-dark"
+      className="inline-block rounded-full border border-champ-blue bg-white px-2 py-1 text-xs font-medium text-dusty-denim"
     >
       {food}
     </span>
@@ -104,13 +104,13 @@ function AllergenCrossReactivityCard({
   return (
     <div
       data-testid="pfas-allergen-card"
-      className="rounded-card border border-brand-border bg-white p-4"
+      className="rounded-card border border-champ-blue bg-white p-4"
     >
       {/* Allergen header — always visible */}
       <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <CategoryIcon category={entry.category} />
-          <span className="text-sm font-semibold text-brand-primary-dark">
+          <span className="text-sm font-semibold text-dusty-denim">
             {entry.common_name}
           </span>
         </div>
@@ -119,7 +119,7 @@ function AllergenCrossReactivityCard({
 
       {/* Food list — blurred for free tier */}
       <div>
-        <p className="mb-2 text-xs font-medium text-brand-text-muted">
+        <p className="mb-2 text-xs font-medium text-dusty-denim">
           Cross-reactive foods
         </p>
         {isPremium ? (
@@ -147,10 +147,10 @@ export function PfasPanel({ entries, isPremium }: PfasPanelProps) {
     >
       {/* Section header */}
       <div>
-        <h2 className="text-lg font-semibold text-brand-text-accent">
+        <h2 className="text-lg font-semibold text-dusty-denim">
           Food Cross-Reactivity (PFAS)
         </h2>
-        <p className="mt-1 text-xs text-brand-text-muted">
+        <p className="mt-1 text-xs text-dusty-denim">
           Foods that may trigger oral symptoms due to pollen-food allergy
           syndrome
         </p>

--- a/components/referral/referral-progress.tsx
+++ b/components/referral/referral-progress.tsx
@@ -28,12 +28,12 @@ export function ReferralProgress({
     return (
       <div
         data-testid="referral-progress"
-        className={`rounded-card border border-brand-border bg-brand-primary-light p-4 ${className}`.trim()}
+        className={`rounded-card border border-champ-blue bg-white p-4 ${className}`.trim()}
       >
-        <p className="text-sm font-semibold text-brand-primary-dark">
+        <p className="text-sm font-semibold text-dusty-denim">
           All features unlocked!
         </p>
-        <p className="mt-1 text-xs text-brand-text-secondary">
+        <p className="mt-1 text-xs text-dusty-denim">
           Thank you for sharing Allergy Madness with {referralCount} friend
           {referralCount !== 1 ? "s" : ""}. Your premium features are permanently active.
         </p>
@@ -44,19 +44,19 @@ export function ReferralProgress({
   return (
     <div
       data-testid="referral-progress"
-      className={`rounded-card border border-brand-border bg-white p-4 ${className}`.trim()}
+      className={`rounded-card border border-champ-blue bg-white p-4 ${className}`.trim()}
     >
-      <p className="text-sm font-semibold text-brand-text">
+      <p className="text-sm font-semibold text-dusty-denim">
         {progress} of {REFERRAL_UNLOCK_THRESHOLD} friends invited
       </p>
-      <p className="mt-1 text-xs text-brand-text-muted">
+      <p className="mt-1 text-xs text-dusty-denim">
         Invite {REFERRAL_UNLOCK_THRESHOLD - progress} more friend
         {REFERRAL_UNLOCK_THRESHOLD - progress !== 1 ? "s" : ""} to unlock all features
       </p>
 
       {/* Progress bar */}
       <div
-        className="mt-3 h-2 w-full overflow-hidden rounded-full bg-brand-surface-muted"
+        className="mt-3 h-2 w-full overflow-hidden rounded-full bg-white"
         role="progressbar"
         aria-valuenow={progress}
         aria-valuemin={0}
@@ -64,7 +64,7 @@ export function ReferralProgress({
         aria-label={`${progress} of ${REFERRAL_UNLOCK_THRESHOLD} referrals`}
       >
         <div
-          className="h-full rounded-full bg-brand-primary-dark transition-all duration-300"
+          className="h-full rounded-full bg-dusty-denim transition-all duration-300"
           style={{ width: `${progressPercent}%` }}
         />
       </div>
@@ -76,8 +76,8 @@ export function ReferralProgress({
             key={i}
             className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium ${
               i < progress
-                ? "bg-brand-premium text-white"
-                : "bg-brand-surface-muted text-brand-text-faint"
+                ? "bg-dusty-denim text-white"
+                : "bg-white text-dusty-denim"
             }`}
           >
             {i < progress ? "\u2713" : i + 1}

--- a/components/referral/referral-share.tsx
+++ b/components/referral/referral-share.tsx
@@ -71,17 +71,17 @@ export function ReferralShare({
   return (
     <div
       data-testid="referral-share"
-      className={`rounded-card border border-brand-border bg-white p-4 ${className}`.trim()}
+      className={`rounded-card border border-champ-blue bg-white p-4 ${className}`.trim()}
     >
-      <p className="text-sm font-semibold text-brand-text">
+      <p className="text-sm font-semibold text-dusty-denim">
         Your Referral Link
       </p>
 
       {/* Link display */}
-      <div className="mt-2 flex items-center gap-2 rounded-card border border-brand-border-light bg-brand-surface-muted px-3 py-2">
+      <div className="mt-2 flex items-center gap-2 rounded-card border border-champ-blue bg-white px-3 py-2">
         <code
           data-testid="referral-link-display"
-          className="flex-1 truncate text-xs text-brand-text-secondary"
+          className="flex-1 truncate text-xs text-dusty-denim"
         >
           {referralLink}
         </code>
@@ -95,8 +95,8 @@ export function ReferralShare({
           data-testid="referral-copy-btn"
           className={`flex-1 cursor-pointer rounded-button border-none px-4 py-2 text-sm font-medium text-white transition-colors ${
             copied
-              ? "bg-brand-premium"
-              : "bg-brand-premium hover:bg-brand-premium/80"
+              ? "bg-dusty-denim"
+              : "bg-dusty-denim hover:bg-dusty-denim/80"
           }`}
         >
           {copied ? "Copied!" : "Copy Link"}
@@ -107,14 +107,14 @@ export function ReferralShare({
             type="button"
             onClick={handleShare}
             data-testid="referral-share-btn"
-            className="flex-1 cursor-pointer rounded-button border border-brand-primary bg-white px-4 py-2 text-sm font-medium text-brand-primary transition-colors hover:bg-brand-primary-light"
+            className="flex-1 cursor-pointer rounded-button border border-champ-blue bg-white px-4 py-2 text-sm font-medium text-champ-blue transition-colors hover:bg-white"
           >
             Share
           </button>
         )}
       </div>
 
-      <p className="mt-2 text-xs text-brand-text-faint">
+      <p className="mt-2 text-xs text-dusty-denim">
         Share this link with friends. When 3 sign up, all features unlock permanently.
       </p>
     </div>

--- a/components/scout/scan-form.tsx
+++ b/components/scout/scan-form.tsx
@@ -112,7 +112,7 @@ export function ScanForm() {
 
       {/* Image preview */}
       {previewUrl && (
-        <div className="mb-4 overflow-hidden rounded-card border border-brand-border">
+        <div className="mb-4 overflow-hidden rounded-card border border-champ-blue">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={previewUrl}
@@ -129,7 +129,7 @@ export function ScanForm() {
           type="button"
           onClick={handleCapture}
           disabled={isScanning}
-          className="w-full cursor-pointer rounded-button border-none bg-brand-accent px-4 py-3 text-sm font-semibold text-brand-primary-dark hover:bg-brand-accent-dark disabled:opacity-50"
+          className="w-full cursor-pointer rounded-button border-none bg-nature-pop px-4 py-3 text-sm font-semibold text-dusty-denim hover:bg-nature-pop disabled:opacity-50"
           data-testid="scout-capture-btn"
         >
           {isScanning ? "Scanning..." : "Take Photo or Upload"}
@@ -139,7 +139,7 @@ export function ScanForm() {
       {/* Scanning spinner */}
       {isScanning && (
         <p
-          className="mt-3 text-center text-sm text-brand-text-muted"
+          className="mt-3 text-center text-sm text-dusty-denim"
           data-testid="scout-scanning"
         >
           Analyzing plant image with AI...
@@ -165,8 +165,8 @@ export function ScanForm() {
           data-testid="scout-results"
         >
           {results.matches.length === 0 ? (
-            <div className="rounded-card border border-brand-border bg-brand-surface-muted px-4 py-3">
-              <p className="text-sm text-brand-text-secondary">
+            <div className="rounded-card border border-champ-blue bg-white px-4 py-3">
+              <p className="text-sm text-dusty-denim">
                 No allergen-producing plants identified in this photo.
                 Try taking a closer photo of the plant.
               </p>
@@ -175,12 +175,12 @@ export function ScanForm() {
             <>
               {/* Summary */}
               <div className="mb-3">
-                <p className="text-sm font-medium text-brand-text">
+                <p className="text-sm font-medium text-dusty-denim">
                   {results.matches.length} plant
                   {results.matches.length === 1 ? "" : "s"} identified
                 </p>
                 {results.active_count > 0 && (
-                  <p className="text-xs text-brand-primary">
+                  <p className="text-xs text-champ-blue">
                     {results.active_count} active — {results.proximity_multiplier}x
                     proximity multiplier applied
                   </p>
@@ -200,7 +200,7 @@ export function ScanForm() {
           <button
             type="button"
             onClick={handleReset}
-            className="mt-4 w-full cursor-pointer rounded-button border border-brand-border bg-white px-4 py-2 text-sm font-medium text-brand-text hover:bg-brand-surface-muted"
+            className="mt-4 w-full cursor-pointer rounded-button border border-champ-blue bg-white px-4 py-2 text-sm font-medium text-dusty-denim hover:bg-white"
             data-testid="scout-reset-btn"
           >
             Scan Another Plant
@@ -222,17 +222,17 @@ function MatchCard({ match }: { match: ScanMatchResult }) {
     <div
       className={`rounded-card border px-4 py-3 ${
         isActive
-          ? "border-brand-border bg-brand-primary-light"
-          : "border-brand-border-light bg-brand-surface-muted"
+          ? "border-champ-blue bg-white"
+          : "border-champ-blue bg-white"
       }`}
       data-testid={`scout-match-${match.allergen_id}`}
     >
       <div className="flex items-center justify-between">
         <div>
-          <p className="text-sm font-semibold text-brand-primary-dark">
+          <p className="text-sm font-semibold text-dusty-denim">
             {match.common_name}
           </p>
-          <p className="mt-0.5 text-xs text-brand-text-muted">
+          <p className="mt-0.5 text-xs text-dusty-denim">
             {match.category} &middot; {Math.round(match.confidence * 100)}%
             confidence
           </p>
@@ -241,7 +241,7 @@ function MatchCard({ match }: { match: ScanMatchResult }) {
           className={`rounded-full px-2 py-1 text-xs font-medium ${
             isActive
               ? "bg-[#D6F0F8] text-[#0682BB]"
-              : "bg-brand-surface-muted text-brand-text-muted"
+              : "bg-white text-dusty-denim"
           }`}
           data-testid={`scout-badge-${match.allergen_id}`}
         >

--- a/components/subscription/premium-badge.tsx
+++ b/components/subscription/premium-badge.tsx
@@ -25,10 +25,10 @@ export function PremiumBadge({
     return (
       <span
         data-testid="premium-badge"
-        className="inline-flex items-center gap-1 rounded-full bg-brand-primary-light px-2 py-0.5 text-xs font-medium text-brand-primary-dark"
+        className="inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-xs font-medium text-dusty-denim"
       >
         {!compact && (
-          <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-brand-primary">
+          <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-champ-blue">
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
               <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" />
             </svg>
@@ -42,10 +42,10 @@ export function PremiumBadge({
   return (
     <span
       data-testid="premium-badge-locked"
-      className="inline-flex items-center gap-1 rounded-full bg-brand-surface-muted px-2 py-0.5 text-xs font-medium text-brand-text-muted"
+      className="inline-flex items-center gap-1 rounded-full bg-white px-2 py-0.5 text-xs font-medium text-dusty-denim"
     >
       {!compact && (
-        <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-brand-surface-muted">
+        <span aria-hidden="true" className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-white">
           <LockIcon size={10} strokeWidth={2.5} />
         </span>
       )}

--- a/components/subscription/upgrade-cta.tsx
+++ b/components/subscription/upgrade-cta.tsx
@@ -70,12 +70,12 @@ export function UpgradeCta({
   return (
     <div
       data-testid="upgrade-cta"
-      className="mx-auto max-w-md rounded-xl border border-brand-border bg-gradient-to-br from-brand-premium-light to-white p-6 text-center shadow-md"
+      className="mx-auto max-w-md rounded-xl border border-champ-blue bg-white p-6 text-center shadow-md"
     >
-      <h3 className="mb-2 text-lg font-bold text-brand-premium-dark">
+      <h3 className="mb-2 text-lg font-bold text-dusty-denim">
         Unlock {feature}
       </h3>
-      <p className="mb-4 text-sm text-brand-text-secondary">
+      <p className="mb-4 text-sm text-dusty-denim">
         Get the full picture of your allergen triggers with {tierName}.
       </p>
 
@@ -83,7 +83,7 @@ export function UpgradeCta({
       <button
         type="button"
         data-testid="upgrade-cta-subscribe"
-        className="mb-3 w-full cursor-pointer rounded-button border-none bg-brand-premium px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-brand-premium-dark"
+        className="mb-3 w-full cursor-pointer rounded-button border-none bg-nature-pop px-4 py-2.5 text-sm font-semibold text-dusty-denim shadow-sm hover:bg-nature-pop"
         onClick={handleSubscribeClick}
       >
         Upgrade to {tierName}
@@ -95,7 +95,7 @@ export function UpgradeCta({
           role="status"
           aria-live="polite"
           data-testid="upgrade-cta-coming-soon"
-          className="mb-3 text-sm font-medium text-brand-premium-dark"
+          className="mb-3 text-sm font-medium text-dusty-denim"
         >
           Subscriptions coming soon! We&apos;ll let you know when
           {" "}
@@ -107,7 +107,7 @@ export function UpgradeCta({
       {referralsNeeded > 0 && (
         <p
           data-testid="upgrade-cta-referral"
-          className="text-xs text-brand-text-muted"
+          className="text-xs text-dusty-denim"
         >
           Or invite {referralsNeeded} friend{referralsNeeded !== 1 ? "s" : ""}{" "}
           to unlock for free


### PR DESCRIPTION
## Summary

Final surface migration in epic #243 — brand-* aliases replaced with canonical 4-color tokens on the remaining misc surfaces. Next ticket #253 removes the aliases.

Closes #252

## Files changed (10)

- `app/page.tsx` — landing page (19 refs)
- `components/subscription/upgrade-cta.tsx` (6)
- `components/subscription/premium-badge.tsx` (4)
- `components/referral/referral-progress.tsx` (10)
- `components/referral/referral-share.tsx` (8)
- `app/(app)/referral/page.tsx` (2)
- `components/scout/scan-form.tsx` (13)
- `app/(app)/scout/page.tsx` (3)
- `components/pfas/pfas-panel.tsx` (6)
- `__tests__/landing-page.test.tsx` — updated WCAG-AA assertion from `bg-brand-premium` to `bg-dusty-denim`

## Token rename count

~71 className swaps across 10 files. Token-rename only — no copy, pricing, or behavior changes.

## Mapping applied

- `brand-primary` → `champ-blue`
- `brand-primary-dark` / `brand-premium*` / `brand-text*` → `dusty-denim`
- `brand-primary-light` / `brand-surface*` → `white`
- `brand-accent*` (primary CTAs on landing + upgrade + scout capture) → `nature-pop` with `text-dusty-denim`
- `brand-border*` → `champ-blue`

Upgrade CTA primary button moved from `bg-brand-premium`/`text-white` to `bg-nature-pop`/`text-dusty-denim` per ticket spec.

## Defensive grep

After migration, ran `brand-` grep across all in-scope paths (`app/page.tsx`, `components/subscription`, `components/referral`, `components/scout`, `components/pfas`, `app/(app)/referral`, `app/(app)/scout`, landing test) — **zero matches**.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 106 files / 1169 tests passing
- [x] `npm run build` — succeeds
- [ ] Reviewer visual-check: landing hero (50/30/18/2 ratio), upgrade CTA pop, referral share/progress, scout capture + results, PFAS panel

## Context

Epic #243 child 7 of 7. #246 merged (aliases added); #247–#251 migrations in review (PRs #261–#265). This PR is the **final surface migration** — after merge, #253 can remove the alias layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)