### PR TITLE
fix(ui): reduce --radius-button from 24px to 8px (P0)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -105,7 +105,7 @@
   /* ------------------------------------------------------------------ */
 
   --radius-card: 1.5rem;
-  --radius-button: 1.5rem;
+  --radius-button: 0.5rem;
   --radius-pill: 9999px;
   --radius-xl: 0.75rem;
 }


### PR DESCRIPTION
## Summary

Single-line token fix: change `--radius-button` from `1.5rem` (24px) to `0.5rem` (8px) in `app/globals.css`.

Buttons currently render with the same rounding as cards (24px), which breaks the intended visual hierarchy. Reducing to 8px restores button identity without touching card/pill/xl radii.

## Scope

- `--radius-card`, `--radius-pill`, `--radius-xl` unchanged
- No component-level `rounded-button` usages touched
- One line changed

## Test Plan

- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 1169/1169 pass
- [x] `npm run build` — pass

Closes #270

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>