### PR TITLE
fix(bracket): align connectors to node positions across round columns

### DIFF
--- a/__tests__/bracket/bracket-lines.test.tsx
+++ b/__tests__/bracket/bracket-lines.test.tsx
@@ -143,3 +143,64 @@ describe("Bracket with lines (integration)", () => {
     }
   });
 });
+
+describe("BracketConnector alignment (ticket #238)", () => {
+  it("pair wrappers use flex-1 so heights scale with node sizes", () => {
+    render(<BracketConnector sourceMatchCount={4} />);
+    const pair0 = screen.getByTestId("bracket-connector-pair-0");
+    const pair1 = screen.getByTestId("bracket-connector-pair-1");
+    // Dynamic elbow heights (Fix 1) — pair wrappers must flex to span
+    // their feeder pair's vertical extent instead of using fixed `h-8`.
+    expect(pair0.className).toContain("flex-1");
+    expect(pair1.className).toContain("flex-1");
+  });
+
+  it("elbow halves use flex-1 (no fixed h-8 pixel height)", () => {
+    render(<BracketConnector sourceMatchCount={2} />);
+    const pair = screen.getByTestId("bracket-connector-pair-0");
+    const halves = pair.querySelectorAll("div");
+    for (const half of halves) {
+      expect(half.className).toContain("flex-1");
+      // Guard against regression to the fixed h-8 that caused #238.
+      expect(half.className).not.toContain("h-8");
+    }
+  });
+
+  it("connector column matches source gap-3 and uses self-stretch for parent-height alignment", () => {
+    render(<BracketConnector sourceMatchCount={4} />);
+    const connector = screen.getByTestId("bracket-connector");
+    // `gap-3` aligns pair boundaries with the source node stack's gap.
+    expect(connector.className).toContain("gap-3");
+    // `self-stretch` lets flex-row parent size the connector to the
+    // node stack's height (Fix 2 — explicit positioning strategy).
+    expect(connector.className).toContain("self-stretch");
+    // `justify-around` was the old alignment bug — must not return.
+    expect(connector.className).not.toContain("justify-around");
+  });
+
+  it("connector receives a fade-in animation class for reveal sync (Fix 3)", () => {
+    render(<BracketConnector sourceMatchCount={2} animationDelayMs={540} />);
+    const connector = screen.getByTestId("bracket-connector");
+    expect(connector.className).toContain("bracket-connector-enter");
+    expect(connector.getAttribute("style")).toContain("540ms");
+  });
+
+  it("bracket places connector as sibling of node stack, not of the label", () => {
+    // Alignment anchor: connector must live inside the flex-row with the
+    // node stack so `items-stretch` makes connector height == stack
+    // height. If the connector regressed to being a sibling of the
+    // round label (h3), the stack's `data-testid` wrapper would not be
+    // the connector's direct parent.
+    const trace = buildBracketTrace(makeEntries(8));
+    render(<Bracket nodes={trace} ranked={makeRanked(8)} />);
+    const connectors = screen.getAllByTestId("bracket-connector");
+    for (const connector of connectors) {
+      const row = connector.parentElement;
+      expect(row).not.toBeNull();
+      // The flex-row wrapper should contain both the node stack and
+      // the connector as siblings.
+      const stack = row?.querySelector("[data-testid^='bracket-node-stack-']");
+      expect(stack).not.toBeNull();
+    }
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -235,3 +235,28 @@ body {
     animation: none !important;
   }
 }
+
+/* Bracket connector fade-in (ticket #238) — connectors fade in after
+   the node slide-in animation resolves so lines never render out of
+   sync with the nodes they connect. Delay is passed from `bracket.tsx`
+   via inline `animation-delay`. `prefers-reduced-motion` users get
+   a static, correctly-aligned bracket with connectors visible from
+   the first paint. */
+@keyframes bracket-connector-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bracket-connector-enter {
+  animation: bracket-connector-fade-in 200ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bracket-connector-enter {
+    animation: none !important;
+  }
+}

--- a/components/bracket/bracket-lines.tsx
+++ b/components/bracket/bracket-lines.tsx
@@ -1,24 +1,40 @@
 /**
  * BracketConnector — CSS-based connecting lines between bracket rounds
- * (ticket #180)
+ * (tickets #180, #238)
  *
  * Renders between two adjacent round columns in the bracket flex layout.
  * For each pair of feeder matches (2K, 2K+1) in round N, draws an
  * elbow connector that merges into the corresponding match K in round N+1.
  *
- * Layout: three sub-columns per connector gap:
- *   1. Right stubs — short horizontal lines exiting each match in round N
- *   2. Vertical merge — a vertical bar spanning each feeder pair, with a
- *      midpoint horizontal stub entering the next round
- *   3. Left stubs — short horizontal lines entering each match in round N+1
+ * Alignment strategy (ticket #238):
+ *   - Connector column is a sibling of the source node stack inside a
+ *     flex-row wrapper. `items-stretch` makes the connector's height
+ *     equal to the node stack's height, so we can drive elbow heights
+ *     by flex-basis rather than fixed pixel values.
+ *   - Each pair wrapper is `flex-1` and its two elbow halves are each
+ *     `flex-1`. The connector mirrors the source column's `gap-3`
+ *     spacing, so pair boundaries line up with the gap between source
+ *     match pairs and each half's midpoint sits at the vertical center
+ *     of its feeder match.
  *
- * All strokes use champ-blue (Champ Blue) via border color tokens.
- * No raw hex, no black, no gray.
+ * All strokes use champ-blue via border color tokens. No raw hex.
+ *
+ * Animation sync (ticket #238):
+ *   The connector fades in after the node slide-in animation resolves.
+ *   See `.bracket-connector-enter` in `app/globals.css`. `animationDelay`
+ *   is passed from `bracket.tsx` so each connector column lines up with
+ *   its paired round's staggered reveal.
  */
 
 export interface BracketConnectorProps {
   /** Number of matches in the source (left) round. */
   sourceMatchCount: number;
+  /**
+   * Delay (ms) before the connector fades in. Should equal the source
+   * round's final node delay + node animation duration so connectors
+   * appear after the slide-in settles.
+   */
+  animationDelayMs?: number;
 }
 
 /**
@@ -28,7 +44,10 @@ export interface BracketConnectorProps {
  * `sourceMatchCount / 2` matches. Each pair of source matches merges
  * into one target match.
  */
-export function BracketConnector({ sourceMatchCount }: BracketConnectorProps) {
+export function BracketConnector({
+  sourceMatchCount,
+  animationDelayMs = 0,
+}: BracketConnectorProps) {
   const pairCount = Math.floor(sourceMatchCount / 2);
 
   if (pairCount === 0) return null;
@@ -36,19 +55,26 @@ export function BracketConnector({ sourceMatchCount }: BracketConnectorProps) {
   return (
     <div
       data-testid="bracket-connector"
-      className="flex flex-col justify-around"
+      // `gap-3` mirrors the source node stack's `gap-3` so pair
+      // boundaries line up with the gap between source pairs.
+      // `self-stretch` + `flex-1` pair wrappers let each elbow scale
+      // with variable node heights instead of a fixed `h-8`.
+      className="bracket-connector-enter flex flex-col gap-3 self-stretch"
+      style={{ animationDelay: `${animationDelayMs}ms` }}
       aria-hidden="true"
     >
       {Array.from({ length: pairCount }, (_, pairIdx) => (
         <div
           key={pairIdx}
           data-testid={`bracket-connector-pair-${pairIdx}`}
-          className="flex flex-col"
+          className="flex flex-1 flex-col"
         >
-          {/* Top half — upper feeder match elbow */}
-          <div className="h-8 w-6 border-r-2 border-t-2 border-champ-blue rounded-tr-lg" />
-          {/* Bottom half — lower feeder match elbow */}
-          <div className="h-8 w-6 border-r-2 border-b-2 border-champ-blue rounded-br-lg" />
+          {/* Top half — upper feeder match elbow. `flex-1` spans the
+              top feeder's full height so the corner sits at its vertical
+              center regardless of node content. */}
+          <div className="w-6 flex-1 border-r-2 border-t-2 border-champ-blue rounded-tr-lg" />
+          {/* Bottom half — lower feeder match elbow. */}
+          <div className="w-6 flex-1 border-r-2 border-b-2 border-champ-blue rounded-br-lg" />
         </div>
       ))}
     </div>

--- a/components/bracket/bracket.tsx
+++ b/components/bracket/bracket.tsx
@@ -122,6 +122,13 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
           // within the same column share a delay — keeps the sequence
           // readable without multiplying animation complexity.
           const roundDelayMs = roundIdx * 120;
+          // Connector fade-in delay (ticket #238): wait for the last node
+          // in this column to finish sliding in, then fade the connector
+          // so nodes and lines never render out of sync. 300ms matches
+          // `bracket-node-slide-in` duration in `app/globals.css`.
+          const lastNodeDelayMs =
+            roundDelayMs + Math.max(0, column.length - 1) * 40;
+          const connectorDelayMs = lastNodeDelayMs + 300;
           return (
             <div key={`round-group-${roundIdx}`} className="flex snap-start">
               <div
@@ -135,24 +142,36 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
                 >
                   {roundLabel(roundIdx, totalRounds)}
                 </h3>
-                <div className="flex flex-col justify-around gap-3">
-                  {column.map((vm, nodeIdx) => (
-                    <div
-                      key={`${vm.round}-${vm.matchId}`}
-                      data-testid={`bracket-node-wrap-${vm.round}-${vm.matchId}`}
-                      className="bracket-node-enter"
-                      style={{
-                        animationDelay: `${roundDelayMs + nodeIdx * 40}ms`,
-                      }}
-                    >
-                      <BracketNode node={vm} isFinal={isFinal} />
-                    </div>
-                  ))}
+                {/* Ticket #238: wrap the node stack + connector in a
+                    flex-row so the connector aligns to the node stack's
+                    vertical extent (excluding the round label) and can
+                    stretch to match variable node heights via flex-1. */}
+                <div className="flex flex-1 items-stretch">
+                  <div
+                    data-testid={`bracket-node-stack-${roundIdx}`}
+                    className="flex flex-1 flex-col gap-3"
+                  >
+                    {column.map((vm, nodeIdx) => (
+                      <div
+                        key={`${vm.round}-${vm.matchId}`}
+                        data-testid={`bracket-node-wrap-${vm.round}-${vm.matchId}`}
+                        className="bracket-node-enter flex-1"
+                        style={{
+                          animationDelay: `${roundDelayMs + nodeIdx * 40}ms`,
+                        }}
+                      >
+                        <BracketNode node={vm} isFinal={isFinal} />
+                      </div>
+                    ))}
+                  </div>
+                  {showLines && !isFinal && (
+                    <BracketConnector
+                      sourceMatchCount={column.length}
+                      animationDelayMs={connectorDelayMs}
+                    />
+                  )}
                 </div>
               </div>
-              {showLines && !isFinal && (
-                <BracketConnector sourceMatchCount={column.length} />
-              )}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary

Fixes three concrete alignment flaws in `BracketConnector` so round columns visually connect to bracket nodes.

**Before → After**

| Flaw | Before | After |
|------|--------|-------|
| Elbow heights | Fixed `h-8` — didn't scale to variable node heights | `flex-1` halves — span feeder match height; corners align to vertical center |
| Alignment | `justify-around` floated elbows in available space | `self-stretch` + `flex-1` pairs + `gap-3` mirroring source stack; connector is sibling of node stack inside a flex-row with `items-stretch` |
| Animation sync | Static connectors while nodes slid in → visible desync | `.bracket-connector-enter` fade-in delayed to `lastNodeDelay + 300ms` so lines appear after nodes settle |

## Implementation Notes

- Restructured `bracket.tsx` round group: h3 label + (flex-row containing node stack + connector). The connector now aligns to the node-stack height only, excluding the round label. This is the smallest JSX change that gives the connector a known anchor.
- `BracketConnector` now accepts `animationDelayMs` — `bracket.tsx` computes it per round from the last-node stagger.
- Added `.bracket-connector-enter` keyframe in `app/globals.css` with a `prefers-reduced-motion` opt-out that keeps connectors static and visible from the first paint.
- Kept CSS-border approach (no SVG overlay per PR #212 guardrail).
- Uses canonical `border-champ-blue` token (post-migration).

## Test Plan

- [x] `npm run lint` — green
- [x] `npm run typecheck` — green
- [x] `npm test` — 1174 tests passing (5 new alignment tests in `bracket-lines.test.tsx`)
- [x] `npm run build` — production build succeeds
- [x] Existing bracket tests (48) still pass
- [ ] Visual check on 8 / 16 / 32-entry brackets (human — Render PR preview)
- [ ] Mobile scroll-snap still works (human — PR preview on narrow viewport)
- [ ] `prefers-reduced-motion` shows correctly-aligned static bracket (human — DevTools emulation)

### Autonomous Caveats

- jsdom doesn't run CSS animations, so the animation-sync test asserts on the class + inline `animation-delay` rather than observed motion. A static-state DOM assertion (connector is sibling of node stack, flex-1 + self-stretch classes present) proves alignment math without requiring the animation to play.
- The three fixes are coupled: dynamic heights require the flex-row parent from the alignment fix; animation sync requires the delay computation to happen at the round-iteration level. All touch points stayed within the three files the ticket called out (plus one keyframe in `globals.css` and one test file).

Closes #238