### PR TITLE
fix(ci): disable preview-deploy workflow (quick fix)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,8 +1,16 @@
 name: Preview Deploy
 
+# TEMPORARILY DISABLED (2026-04-21): Render free-tier pipeline minutes
+# exhausted — every PR's preview run was instantly rejected with
+# build_failed, but still burned workflow-runtime cost on GitHub.
+# Switched to workflow_dispatch so it only runs when manually triggered.
+# Re-enable by replacing this block with:
+#   on:
+#     pull_request:
+#       types: [opened, synchronize, reopened]
+# once Render quota resets OR the workspace is upgraded to a paid plan.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   ci:


### PR DESCRIPTION
Closes #275

## Context

Render free-tier pipeline minutes are exhausted. Every PR's `preview-deploy` run is instantly rejected by Render with `build_failed`, but the GitHub workflow still fires on every PR event and burns workflow-runtime cost before Render rejects it.

This PR switches the workflow trigger from `pull_request` events to `workflow_dispatch` so it only runs when manually invoked.

**Quick fix — no linked ticket** per Quick Fix Protocol (diff under 20 lines, no behavior change to application code).

## Impact

- PR preview environments will no longer be created automatically. Reviewers lose the live preview URL on new PRs until this is reverted.
- Production deploys (via `deploy.yml` on merge to `main`) are unaffected and will resume working once Render quota resets or the workspace is upgraded.
- The workflow itself is preserved and can still be triggered manually via the Actions tab if needed.

## Re-enable instructions

Either revert this commit, or swap the `on:` block in `.github/workflows/preview-deploy.yml` back to:

```yaml
on:
  pull_request:
    types: [opened, synchronize, reopened]
```

once Render quota resets OR the workspace is upgraded to a paid plan.

## Note on this PR's own checks

GitHub uses the workflow definition from the **base branch** for `pull_request` events, so this PR itself will still trigger the old preview-deploy config one last time — and fail the same way every other PR currently fails. That's expected.