### PR TITLE
fix(ui): P0 regressions batch — bracket alignment, button padding, layout

### DIFF
--- a/__tests__/components/layout/nav-bar.test.tsx
+++ b/__tests__/components/layout/nav-bar.test.tsx
@@ -181,6 +181,28 @@ describe("NavBar", () => {
     });
   });
 
+  describe("desktop padding + spacing (#276)", () => {
+    it("authenticated nav items use comfortable per-item padding so text isn't cramped", () => {
+      render(<NavBar authState="authenticated" />);
+      const dashLink = screen
+        .getAllByRole("link")
+        .find((a) => a.getAttribute("href") === "/dashboard" && a.textContent === "Dashboard");
+      expect(dashLink).toBeDefined();
+      // Base padding contract — px-5 py-2.5 keeps "Dashboard" / "Check-in" etc.
+      // from touching the pill edges, and the active pill inherits the same.
+      expect(dashLink?.className).toContain("px-5");
+      expect(dashLink?.className).toContain("py-2.5");
+    });
+
+    it("desktop action row uses a ≥ gap-3 gap between nav items", () => {
+      const { container } = render(<NavBar authState="authenticated" />);
+      // The desktop action row is the first `hidden sm:flex` container.
+      const row = container.querySelector("div.hidden.sm\\:flex");
+      expect(row).not.toBeNull();
+      expect(row?.className).toContain("gap-3");
+    });
+  });
+
   describe("mobile hamburger (both states)", () => {
     it("toggles mobile menu in authenticated state", () => {
       render(<NavBar authState="authenticated" />);

--- a/__tests__/components/leaderboard/leaderboard.test.tsx
+++ b/__tests__/components/leaderboard/leaderboard.test.tsx
@@ -106,6 +106,24 @@ const defaultProps = {
 };
 
 describe("Leaderboard", () => {
+  describe("'Your Allergen Leaderboard' title placement (#276)", () => {
+    it("renders the title inline when Full Rankings are shown inline (default)", () => {
+      render(<Leaderboard {...defaultProps} />);
+      expect(
+        screen.getByRole("heading", { level: 1, name: /your allergen leaderboard/i }),
+      ).toBeDefined();
+    });
+
+    it("does NOT render the title inline when showFullRankings=false (dashboard case — title moves to FullRankings reveal block)", () => {
+      render(<Leaderboard {...defaultProps} showFullRankings={false} />);
+      expect(
+        screen.queryByRole("heading", { level: 1, name: /your allergen leaderboard/i }),
+      ).toBeNull();
+      // Champion still rendered — it's no longer orphaned below an unused title.
+      expect(screen.getByTestId("trigger-champion-card")).toBeDefined();
+    });
+  });
+
   describe("normal mode (acknowledged, has data)", () => {
     it("renders the leaderboard container", () => {
       render(<Leaderboard {...defaultProps} />);

--- a/__tests__/components/shared/reveal-gate.test.tsx
+++ b/__tests__/components/shared/reveal-gate.test.tsx
@@ -63,6 +63,17 @@ describe("RevealGate", () => {
     expect(document.getElementById(controlsId ?? "")).not.toBeNull();
   });
 
+  it("uses padded default button classes (#276 — px-6 py-3 minimum so View All / Hide Bracket text doesn't overflow)", () => {
+    render(
+      <RevealGate label="View All">
+        <p>hidden</p>
+      </RevealGate>,
+    );
+    const btn = screen.getByRole("button", { name: "View All" });
+    expect(btn.className).toContain("px-6");
+    expect(btn.className).toContain("py-3");
+  });
+
   it("removes the button entirely after reveal when no hideLabel is provided", () => {
     render(
       <RevealGate label="Show Secret">

--- a/components/bracket/bracket-node.tsx
+++ b/components/bracket/bracket-node.tsx
@@ -83,33 +83,33 @@ function Side({ side, isWinner, isChampion, label }: SideProps) {
       />
 
       <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center">
           <span
             data-testid={`bracket-side-${label}-name`}
             className={[
-              "truncate text-sm font-semibold text-dusty-denim",
+              "min-w-0 truncate text-sm font-semibold text-dusty-denim",
               isWinner ? "" : "line-through",
             ].join(" ")}
           >
             {side.name}
           </span>
-          {isWinner && isChampion && (
-            <span
-              data-testid="bracket-champion-badge"
-              className="inline-flex items-center rounded-pill bg-nature-pop px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-dusty-denim"
-            >
-              Most likely trigger
-            </span>
-          )}
-          {isWinner && !isChampion && (
-            <span
-              data-testid="bracket-winner-badge"
-              className="inline-flex items-center rounded-pill border border-champ-blue bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-dusty-denim"
-            >
-              Advances
-            </span>
-          )}
         </div>
+        {isWinner && isChampion && (
+          <span
+            data-testid="bracket-champion-badge"
+            className="mt-1 inline-flex items-center self-start rounded-pill bg-nature-pop px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-dusty-denim"
+          >
+            Most likely trigger
+          </span>
+        )}
+        {isWinner && !isChampion && (
+          <span
+            data-testid="bracket-winner-badge"
+            className="mt-1 inline-flex items-center self-start rounded-pill border border-champ-blue bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-dusty-denim"
+          >
+            Advances
+          </span>
+        )}
 
         {/* Confidence bar — width encodes discriminative, color encodes tier.
             Intentionally NO raw percentage label as the primary signal. */}

--- a/components/bracket/bracket.tsx
+++ b/components/bracket/bracket.tsx
@@ -85,13 +85,13 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
     <section
       data-testid="bracket"
       aria-label="Tournament bracket"
-      className="rounded-card border border-champ-blue bg-white p-4 shadow-sm"
+      className="rounded-card border border-champ-blue bg-white p-6 shadow-sm"
     >
-      <header className="mb-4">
-        <h2 className="text-lg font-bold text-dusty-denim">
+      <header className="mb-4 px-1">
+        <h2 className="break-words text-lg font-bold text-dusty-denim">
           Tournament Bracket
         </h2>
-        <p className="mt-1 text-xs text-dusty-denim">
+        <p className="mt-1 break-words text-xs text-dusty-denim">
           Head-to-head matchups that produced your most likely trigger.
         </p>
       </header>
@@ -155,7 +155,7 @@ export function Bracket({ nodes, ranked, showLines = true }: BracketProps) {
                       <div
                         key={`${vm.round}-${vm.matchId}`}
                         data-testid={`bracket-node-wrap-${vm.round}-${vm.matchId}`}
-                        className="bracket-node-enter flex-1"
+                        className="bracket-node-enter flex flex-1 flex-col justify-center"
                         style={{
                           animationDelay: `${roundDelayMs + nodeIdx * 40}ms`,
                         }}

--- a/components/layout/nav-bar.tsx
+++ b/components/layout/nav-bar.tsx
@@ -80,7 +80,7 @@ export function NavBar({ authState }: NavBarProps) {
         </Link>
 
         {/* Desktop actions */}
-        <div className="hidden items-center gap-1 sm:flex">
+        <div className="hidden items-center gap-3 sm:flex">
           {isAuthenticated ? (
             <>
               {AUTHENTICATED_LINKS.map((link) => (
@@ -88,7 +88,7 @@ export function NavBar({ authState }: NavBarProps) {
                   key={link.href}
                   href={link.href}
                   aria-current={isActive(link.href) ? "page" : undefined}
-                  className={`rounded-button px-3 py-2 text-sm font-medium transition-colors ${
+                  className={`rounded-button px-5 py-2.5 text-sm font-medium transition-colors ${
                     isActive(link.href)
                       ? "bg-white/20 text-white"
                       : "text-white/80 hover:bg-white/10 hover:text-white"
@@ -101,7 +101,7 @@ export function NavBar({ authState }: NavBarProps) {
                 type="button"
                 onClick={handleSignOut}
                 data-testid="sign-out-button"
-                className="ml-2 rounded-button px-3 py-2 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+                className="ml-3 rounded-button px-5 py-2.5 text-sm font-medium text-white/80 transition-colors hover:bg-white/10 hover:text-white"
               >
                 Sign Out
               </button>

--- a/components/leaderboard/full-rankings.tsx
+++ b/components/leaderboard/full-rankings.tsx
@@ -50,6 +50,16 @@ export function FullRankings({
 
   return (
     <div>
+      {/* "Your Allergen Leaderboard" title (#276) — co-located with the
+          list it labels when the dashboard gates Full Rankings behind
+          the "View All" reveal. Prior placement above the champion
+          orphaned the title. */}
+      <h1
+        data-testid="full-rankings-title"
+        className="mb-2 text-2xl font-bold text-dusty-denim"
+      >
+        Your Allergen Leaderboard
+      </h1>
       <h2 className="mb-3 text-lg font-semibold text-dusty-denim">
         Full Rankings
       </h2>

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -210,9 +210,18 @@ export function Leaderboard({
       data-testid="leaderboard"
       className="mx-auto max-w-2xl space-y-6 px-4 py-6"
     >
-      <h1 className="text-2xl font-bold text-dusty-denim">
-        Your Allergen Leaderboard
-      </h1>
+      {/* "Your Allergen Leaderboard" title (#276): only rendered here
+          when the Full Rankings list is shown inline. When the parent
+          surface (e.g., dashboard #242) gates Full Rankings behind a
+          reveal button and suppresses them inline (`showFullRankings
+          === false`), the title moves into the FullRankings component
+          so it is co-located with the list it labels, not orphaned
+          above the champion. */}
+      {showFullRankings && (
+        <h1 className="text-2xl font-bold text-dusty-denim">
+          Your Allergen Leaderboard
+        </h1>
+      )}
 
       {/* FDA Disclaimer — always visible unless the parent surface
           has opted to render it elsewhere (see #242, where the

--- a/components/leaderboard/trigger-champion-card.tsx
+++ b/components/leaderboard/trigger-champion-card.tsx
@@ -16,10 +16,10 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
   return (
     <div
       data-testid="trigger-champion-card"
-      className="rounded-xl border-2 border-champ-blue bg-white p-6 shadow-lg"
+      className="flex flex-col items-center rounded-xl border-2 border-champ-blue bg-white p-6 text-center shadow-lg"
     >
       {/* Champion header — white icon on blue circle per brand guide */}
-      <div className="mb-3 flex items-center gap-2">
+      <div className="mb-3 flex items-center justify-center gap-2">
         <span
           className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-champ-blue"
           aria-hidden="true"
@@ -34,7 +34,7 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
       </div>
 
       {/* Allergen name + thumbnail + category */}
-      <div className="mb-3 flex items-center gap-3">
+      <div className="mb-3 flex items-center justify-center gap-3">
         {/* Thumbnail — plain <img> for SVG compat, matches bracket-node pattern (#179) */}
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
@@ -54,7 +54,7 @@ export function TriggerChampionCard({ allergen }: TriggerChampionCardProps) {
       </div>
 
       {/* Elo score + confidence */}
-      <div className="flex items-center gap-3">
+      <div className="flex items-center justify-center gap-3">
         <span
           data-testid="champion-elo"
           className="text-lg font-semibold text-dusty-denim"

--- a/components/shared/fda-disclaimer.tsx
+++ b/components/shared/fda-disclaimer.tsx
@@ -66,12 +66,12 @@ export function FdaDisclaimer({
       role="status"
       aria-label="FDA disclaimer"
       data-testid="fda-disclaimer"
-      className={`rounded-card border border-champ-blue bg-white px-4 py-3 ${className}`.trim()}
+      className={`rounded-card border border-champ-blue bg-white px-6 py-4 ${className}`.trim()}
     >
-      <p className="text-sm font-semibold text-dusty-denim">
+      <p className="break-words text-sm font-semibold text-dusty-denim">
         {FDA_DISCLAIMER_LABEL}
       </p>
-      <p className="mt-1 text-xs text-dusty-denim">
+      <p className="mt-1 break-words text-xs text-dusty-denim">
         {FDA_DISCLAIMER_FULL_TEXT}
       </p>
     </div>

--- a/components/shared/reveal-gate.tsx
+++ b/components/shared/reveal-gate.tsx
@@ -48,7 +48,7 @@ export function RevealGate({
   const panelId = useId();
 
   const defaultButtonClasses =
-    "inline-flex items-center justify-center rounded-card border border-champ-blue bg-white px-4 py-2 text-sm font-semibold text-dusty-denim hover:bg-white";
+    "inline-flex items-center justify-center rounded-card border border-champ-blue bg-white px-6 py-3 text-sm font-semibold text-dusty-denim hover:bg-white";
 
   return (
     <div data-testid={dataTestId}>


### PR DESCRIPTION
## Summary

Closes #276.

P0 batch fix for 10 user-reported UI regressions on the dashboard, post-
migration from #242 (layout restructure), #246-#252 (brand consolidation),
and #270 (button radius).

## DoD checklist — all 10 items addressed

- [x] **1. Bracket alignment** — node wrappers now `flex flex-col justify-center` inside their `flex-1` slot, so each match card centers vertically. Round-N matches sit at the midpoint of their two feeders, producing the classic pyramid. Existing connector strategy from #238 (self-stretch + flex-1 pair halves) is retained — alignment was the wrapper bug, not the connector.
- [x] **2. ADVANCES badge overflow** — badge (and champion "Most likely trigger" badge) moved from inline-with-name to its own row below the name via `self-start mt-1`. Long allergen names no longer push the badge past the node border.
- [x] **3. Hide Bracket button too small** — `RevealGate` default button padding bumped from `px-4 py-2` to `px-6 py-3`.
- [x] **4. View All button too small** — same `RevealGate` fix covers it.
- [x] **5. Nav items too cramped** — per-item padding `px-3 py-2` → `px-5 py-2.5`; inter-item `gap-1` → `gap-3`; sign-out `ml-2` → `ml-3`.
- [x] **6. Active nav pill too small** — active state shares the base classes, so the new padding applies automatically.
- [x] **7. FDA disclaimer overflow** — container padding `px-4 py-3` → `px-6 py-4`, with `break-words` on both lines.
- [x] **8. "Tournament Bracket" title overflow** — bracket section padding `p-4` → `p-6`; header text given `break-words`.
- [x] **9. Trigger Champion left-justified** — card now `flex flex-col items-center text-center` with `justify-center` on each inner row.
- [x] **10. "Your Allergen Leaderboard" orphaned title** — title gated to `showFullRankings=true`; when the dashboard hides Full Rankings inline and renders them in the "View All" reveal, the title moves into `FullRankings` so it ships alongside the list it labels.

## Guardrails respected

- 4-color palette unchanged — all fixes via padding / layout utilities, no new colors or tints
- No opacity tweaks
- `prefers-reduced-motion` still honored — CSS rule untouched
- #155 slide-in animation untouched
- #242 reveal-gate contract preserved (DOM order: champion → Final Four → bracket reveal → rankings reveal → FDA disclaimer)
- Engine code untouched

## Tests

- 1174 pre-existing tests pass
- +5 new assertions:
  - `RevealGate` default button padding (`px-6 py-3`)
  - Nav-bar per-item padding (`px-5 py-2.5`) + desktop row gap (`gap-3`)
  - Leaderboard title placement contract (inline vs. dashboard-gated)

## Test plan

- [ ] CI: lint + typecheck + test + build all green
- [ ] Manual spot-check on dashboard: all 10 items visibly resolved
- [ ] Verify 8, 16, and 32-entry brackets produce a visible pyramid shape
- [ ] Verify bracket nodes with long allergen names (e.g. "Kentucky Bluegrass") render ADVANCES badge on its own row without overflow
- [ ] Verify nav bar has breathing room on desktop + active pill fits its label
- [ ] Verify FDA disclaimer + "Tournament Bracket" header sit inside their borders
- [ ] Verify Trigger Champion content is horizontally centered
- [ ] Verify "Your Allergen Leaderboard" title appears inside the View All reveal, not above the champion

🤖 Generated with [Claude Code](https://claude.com/claude-code)