### PR TITLE
fix(ui): P0 regressions batch 2 — check-in, children, landing page

### DIFF
--- a/__tests__/components/checkin/severity-slider.test.tsx
+++ b/__tests__/components/checkin/severity-slider.test.tsx
@@ -38,4 +38,12 @@ describe("SeveritySlider", () => {
     expect(screen.getByText("No symptoms today")).toBeDefined();
     expect(screen.getByText("Minor, barely noticeable")).toBeDefined();
   });
+
+  it("centers content inside each severity button (regression #279)", () => {
+    render(<SeveritySlider value={0} onChange={vi.fn()} />);
+    const btn = screen.getByTestId("severity-1");
+    expect(btn.className).toContain("justify-center");
+    expect(btn.className).toContain("items-center");
+    expect(btn.className).toContain("text-center");
+  });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,33 +43,33 @@ export default async function HomePage() {
 
       {/* Hero Section */}
       <section className="bg-dusty-denim px-4 py-16 sm:px-6 sm:py-24">
-        <div className="mx-auto max-w-3xl text-center">
+        <div className="mx-auto flex max-w-6xl flex-col items-center text-center">
           <h1
-            className="text-3xl font-bold tracking-tight text-white sm:text-5xl"
+            className="break-words text-3xl font-bold tracking-tight text-white sm:text-5xl"
             style={{ fontFamily: "var(--font-title)" }}
           >
             Allergy Madness
           </h1>
-          <p className="mx-auto mt-2 text-base text-white">
+          <p className="mt-2 text-base text-white">
             by Champ Allergy
           </p>
-          <p className="mx-auto mt-4 max-w-xl text-lg text-white/90 sm:mt-6 sm:text-xl">
+          <p className="mt-4 max-w-xl break-words text-lg text-white/90 sm:mt-6 sm:text-xl">
             Predict Your Allergy Triggers
           </p>
-          <p className="mx-auto mt-2 max-w-xl text-base text-white/80">
+          <p className="mt-2 max-w-xl break-words text-base text-white/80">
             Track symptoms, discover patterns, and get personalized insights
             about what may be causing your allergies — all from your phone.
           </p>
-          <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4">
+          <div className="mt-8 flex w-full flex-col items-center gap-3 sm:flex-row sm:justify-center sm:gap-4">
             <Link
               href="/signup"
-              className="w-full rounded-button bg-nature-pop px-8 py-3 text-center text-base font-semibold text-dusty-denim shadow-sm transition-colors hover:bg-nature-pop sm:w-auto"
+              className="inline-flex w-full items-center justify-center rounded-button bg-nature-pop px-8 py-4 text-center text-base font-semibold text-dusty-denim shadow-sm transition-colors hover:bg-nature-pop sm:w-auto"
             >
               Get Started Free
             </Link>
             <Link
               href="/login"
-              className="w-full rounded-button border border-white/40 px-8 py-3 text-center text-base font-medium text-white transition-colors hover:border-white hover:bg-white/10 sm:w-auto"
+              className="inline-flex w-full items-center justify-center rounded-button border border-white/40 px-8 py-4 text-center text-base font-medium text-white transition-colors hover:border-white hover:bg-white/10 sm:w-auto"
             >
               Sign In
             </Link>
@@ -82,7 +82,7 @@ export default async function HomePage() {
 
       {/* How It Works */}
       <section className="bg-dusty-denim px-4 py-16 sm:px-6">
-        <div className="mx-auto max-w-5xl">
+        <div className="mx-auto max-w-6xl">
           <h2
             className="text-center text-2xl font-bold text-white sm:text-3xl"
             style={{ fontFamily: "var(--font-title)" }}
@@ -92,7 +92,7 @@ export default async function HomePage() {
           <p className="mx-auto mt-2 max-w-lg text-center text-white/80">
             Three simple steps to understanding your allergy triggers.
           </p>
-          <div className="mt-12 grid gap-8 sm:grid-cols-3">
+          <div className="mt-12 grid items-start gap-6 sm:grid-cols-3">
             <StepCard
               step="1"
               title="Quick Onboarding"
@@ -114,14 +114,14 @@ export default async function HomePage() {
 
       {/* Features */}
       <section className="bg-white px-4 py-16 sm:px-6">
-        <div className="mx-auto max-w-5xl">
+        <div className="mx-auto max-w-6xl">
           <h2
             className="text-center text-2xl font-bold text-dusty-denim sm:text-3xl"
             style={{ fontFamily: "var(--font-title)" }}
           >
             Features
           </h2>
-          <div className="mt-12 grid gap-6 sm:grid-cols-2">
+          <div className="mt-12 grid auto-rows-fr gap-6 sm:grid-cols-2">
             <FeatureCard
               title="Symptom Check-in"
               description="Log severity, body zones, and timing each day. Takes less than 30 seconds."
@@ -151,21 +151,21 @@ export default async function HomePage() {
       </section>
 
       {/* CTA Section */}
-      <section className="bg-dusty-denim px-4 py-16 sm:px-6">
-        <div className="mx-auto max-w-2xl text-center">
+      <section className="bg-dusty-denim px-4 py-16 text-center sm:px-6">
+        <div className="mx-auto flex max-w-6xl flex-col items-center text-center">
           <h2
-            className="text-2xl font-bold text-white sm:text-3xl"
+            className="break-words text-2xl font-bold text-white sm:text-3xl"
             style={{ fontFamily: "var(--font-title)" }}
           >
             Ready to Understand Your Allergies?
           </h2>
-          <p className="mt-3 text-white/80">
+          <p className="mt-3 max-w-xl break-words text-white/80">
             Join thousands of families using Allergy Madness to track and
             predict allergy triggers.
           </p>
           <Link
             href="/signup"
-            className="mt-8 inline-block rounded-button bg-nature-pop px-8 py-3 text-base font-semibold text-dusty-denim shadow-sm transition-colors hover:bg-nature-pop"
+            className="mt-8 inline-flex items-center justify-center rounded-button bg-nature-pop px-8 py-4 text-center text-base font-semibold text-dusty-denim shadow-sm transition-colors hover:bg-nature-pop"
           >
             Get Started Free
           </Link>
@@ -174,13 +174,13 @@ export default async function HomePage() {
 
       {/* Footer */}
       <footer className="border-t border-champ-blue bg-white px-4 py-8 sm:px-6">
-        <div className="mx-auto max-w-5xl">
+        <div className="mx-auto max-w-6xl">
           {/* FDA Disclaimer */}
           <div className="rounded-card border border-champ-blue bg-white px-4 py-3">
-            <p className="text-sm font-semibold text-dusty-denim">
+            <p className="break-words text-sm font-semibold text-dusty-denim">
               {FDA_DISCLAIMER_LABEL}
             </p>
-            <p className="mt-1 text-xs text-dusty-denim">
+            <p className="mt-1 break-words text-xs text-dusty-denim">
               {FDA_DISCLAIMER_FULL_TEXT}
             </p>
           </div>
@@ -217,8 +217,8 @@ function StepCard({
       <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-sm font-bold text-champ-blue">
         {step}
       </div>
-      <h3 className="mt-4 text-lg font-semibold text-white">{title}</h3>
-      <p className="mt-2 text-sm text-white/80">{description}</p>
+      <h3 className="mt-4 break-words text-lg font-semibold text-white">{title}</h3>
+      <p className="mt-2 break-words text-sm text-white/80">{description}</p>
     </div>
   );
 }
@@ -231,9 +231,9 @@ function FeatureCard({
   description: string;
 }) {
   return (
-    <div className="rounded-card border border-champ-blue bg-white p-6">
-      <h3 className="text-base font-semibold text-dusty-denim">{title}</h3>
-      <p className="mt-2 text-sm text-dusty-denim">{description}</p>
+    <div className="flex h-full flex-col rounded-card border border-champ-blue bg-white p-6">
+      <h3 className="break-words text-base font-semibold text-dusty-denim">{title}</h3>
+      <p className="mt-2 break-words text-sm text-dusty-denim">{description}</p>
     </div>
   );
 }

--- a/components/checkin/checkin-form.tsx
+++ b/components/checkin/checkin-form.tsx
@@ -159,7 +159,7 @@ export function CheckinForm({ onSuccess, alreadyCheckedIn = false }: CheckinForm
         type="submit"
         disabled={isSubmitting}
         data-testid="checkin-submit"
-        className="w-full rounded-button bg-dusty-denim px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-dusty-denim/80 disabled:cursor-not-allowed disabled:opacity-50"
+        className="flex w-full items-center justify-center rounded-button bg-dusty-denim px-6 py-3 text-center text-base font-semibold text-white transition-colors hover:bg-dusty-denim/80 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {isSubmitting ? "Submitting..." : formData.severity === 0 ? "Log Symptom-Free Day" : "Submit Check-in"}
       </button>

--- a/components/checkin/severity-slider.tsx
+++ b/components/checkin/severity-slider.tsx
@@ -33,13 +33,13 @@ export function SeveritySlider({ value, onChange }: SeveritySliderProps) {
               aria-label={`${level.label}: ${level.description}`}
               data-testid={`severity-${level.value}`}
               onClick={() => onChange(level.value)}
-              className={`cursor-pointer rounded-card border-2 p-3 text-left transition-colors ${
+              className={`flex cursor-pointer flex-col items-center justify-center rounded-card border-2 px-4 py-3 text-center transition-colors ${
                 isSelected
                   ? "border-champ-blue bg-champ-blue text-white"
                   : "border-champ-blue bg-white text-dusty-denim hover:border-champ-blue"
               }`}
             >
-              <div className="mb-1 flex items-center gap-2">
+              <div className="mb-1 flex items-center justify-center gap-2">
                 <span
                   className="inline-block h-3 w-3 rounded-full"
                   style={{ backgroundColor: level.color }}
@@ -49,7 +49,7 @@ export function SeveritySlider({ value, onChange }: SeveritySliderProps) {
                   {level.label}
                 </span>
               </div>
-              <p className={`text-xs ${isSelected ? "text-white" : "text-dusty-denim"}`}>
+              <p className={`break-words text-xs ${isSelected ? "text-white" : "text-dusty-denim"}`}>
                 {level.description}
               </p>
             </button>

--- a/components/checkin/timing-selector.tsx
+++ b/components/checkin/timing-selector.tsx
@@ -42,7 +42,7 @@ export function TimingSelector({
                 aria-checked={isSelected}
                 data-testid={`timing-${option.value}`}
                 onClick={() => onPeakTimeChange(option.value)}
-                className={`cursor-pointer rounded-button border-2 px-4 py-2 text-sm font-medium transition-colors ${
+                className={`flex cursor-pointer items-center justify-center rounded-button border-2 px-4 py-2 text-center text-sm font-medium transition-colors ${
                   isSelected
                     ? "border-champ-blue bg-champ-blue text-white"
                     : "border-champ-blue bg-white text-dusty-denim hover:border-champ-blue"
@@ -75,7 +75,7 @@ export function TimingSelector({
                 aria-checked={isSelected}
                 data-testid={`indoors-${option.value}`}
                 onClick={() => onIndoorsChange(option.value)}
-                className={`cursor-pointer rounded-button border-2 px-4 py-2 text-sm font-medium transition-colors ${
+                className={`flex cursor-pointer items-center justify-center rounded-button border-2 px-4 py-2 text-center text-sm font-medium transition-colors ${
                   isSelected
                     ? "border-champ-blue bg-champ-blue text-white"
                     : "border-champ-blue bg-white text-dusty-denim hover:border-champ-blue"

--- a/components/children/add-child-form.tsx
+++ b/components/children/add-child-form.tsx
@@ -52,7 +52,7 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
           type="button"
           onClick={onCancel}
           disabled={isLoading}
-          className="rounded-button border border-champ-blue bg-white px-4 py-2 text-xs font-medium text-dusty-denim hover:bg-white disabled:opacity-50"
+          className="flex items-center justify-center rounded-button border border-champ-blue bg-white px-6 py-2.5 text-center text-sm font-medium text-dusty-denim hover:bg-white disabled:opacity-50"
         >
           Cancel
         </button>
@@ -60,7 +60,7 @@ export function AddChildForm({ onSubmit, onCancel, isLoading, error }: AddChildF
           type="submit"
           data-testid="save-child-btn"
           disabled={isLoading || !name.trim()}
-          className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80 disabled:opacity-50"
+          className="flex items-center justify-center rounded-button bg-dusty-denim px-6 py-2.5 text-center text-sm font-semibold text-white hover:bg-dusty-denim/80 disabled:opacity-50"
         >
           {isLoading ? "Saving..." : "Save"}
         </button>

--- a/components/children/child-profile-card.tsx
+++ b/components/children/child-profile-card.tsx
@@ -45,7 +45,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
         <button
           type="button"
           data-testid="edit-child-btn"
-          className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-dusty-denim hover:bg-white"
+          className="inline-flex items-center justify-center rounded-button border border-champ-blue bg-white px-4 py-1.5 text-center text-xs font-medium text-dusty-denim hover:bg-white"
           onClick={() => onEdit(child.id)}
         >
           Edit
@@ -56,7 +56,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
             <button
               type="button"
               data-testid="confirm-delete-btn"
-              className="rounded-button bg-champ-blue px-3 py-1.5 text-xs font-medium text-white hover:bg-champ-blue/80"
+              className="inline-flex items-center justify-center rounded-button bg-champ-blue px-4 py-1.5 text-center text-xs font-medium text-white hover:bg-champ-blue/80"
               onClick={() => {
                 onDelete(child.id);
                 setConfirmDelete(false);
@@ -66,7 +66,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
             </button>
             <button
               type="button"
-              className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-dusty-denim hover:bg-white"
+              className="inline-flex items-center justify-center rounded-button border border-champ-blue bg-white px-4 py-1.5 text-center text-xs font-medium text-dusty-denim hover:bg-white"
               onClick={() => setConfirmDelete(false)}
             >
               Cancel
@@ -76,7 +76,7 @@ export function ChildProfileCard({ child, onDelete, onEdit }: ChildProfileCardPr
           <button
             type="button"
             data-testid="delete-child-btn"
-            className="rounded-button border border-champ-blue bg-white px-3 py-1.5 text-xs font-medium text-champ-blue hover:bg-white"
+            className="inline-flex items-center justify-center rounded-button border border-champ-blue bg-white px-4 py-1.5 text-center text-xs font-medium text-champ-blue hover:bg-white"
             onClick={() => setConfirmDelete(true)}
           >
             Remove

--- a/components/children/children-manager.tsx
+++ b/components/children/children-manager.tsx
@@ -160,7 +160,7 @@ export function ChildrenManager({
               setShowAddForm(true);
               setError(null);
             }}
-            className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80"
+            className="flex items-center justify-center rounded-button bg-dusty-denim px-6 py-2.5 text-center text-sm font-semibold text-white hover:bg-dusty-denim/80"
           >
             + Add Child
           </button>
@@ -196,7 +196,7 @@ export function ChildrenManager({
             type="button"
             data-testid="empty-state-add-btn"
             onClick={() => setShowAddForm(true)}
-            className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80"
+            className="inline-flex items-center justify-center rounded-button bg-dusty-denim px-6 py-3 text-center text-sm font-semibold text-white hover:bg-dusty-denim/80"
           >
             + Add Your First Child
           </button>

--- a/components/children/edit-child-form.tsx
+++ b/components/children/edit-child-form.tsx
@@ -56,7 +56,7 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
           onClick={onCancel}
           disabled={isLoading}
           data-testid="edit-child-cancel-btn"
-          className="rounded-button border border-champ-blue bg-white px-4 py-2 text-xs font-medium text-dusty-denim hover:bg-white disabled:opacity-50"
+          className="flex items-center justify-center rounded-button border border-champ-blue bg-white px-6 py-2.5 text-center text-sm font-medium text-dusty-denim hover:bg-white disabled:opacity-50"
         >
           Cancel
         </button>
@@ -64,7 +64,7 @@ export function EditChildForm({ child, onSubmit, onCancel, isLoading, error }: E
           type="submit"
           data-testid="edit-child-save-btn"
           disabled={isLoading || !name.trim()}
-          className="rounded-button bg-dusty-denim px-4 py-2 text-xs font-semibold text-white hover:bg-dusty-denim/80 disabled:opacity-50"
+          className="flex items-center justify-center rounded-button bg-dusty-denim px-6 py-2.5 text-center text-sm font-semibold text-white hover:bg-dusty-denim/80 disabled:opacity-50"
         >
           {isLoading ? "Saving..." : "Save"}
         </button>


### PR DESCRIPTION
## Summary

Extends #276 / PR #277 to the remaining surfaces that still had inline button implementations missing centered content, adequate padding, and section alignment: check-in, children, and the unauthenticated landing page.

Approach: after grepping scope surfaces (~28 inline button implementations), decision was made to apply consistent inline utilities rather than extract a shared `<Button>` primitive in the same PR (non-goal in ticket body; too much blast radius for a P0). A follow-up ticket should still capture primitive extraction as the durable fix.

Guardrails respected:
- Brand tokens only (`champ-blue`, `dusty-denim`, `white`, `nature-pop`, `alert-red`)
- `rounded-button` (8px) from #270 retained
- No copy/content changes
- No opacity, no tints, no new colors

## Checklist (all 13 DoD items)

- [x] 1. Check-in severity buttons (None/Mild/Moderate/Severe) content centered inside the pill (dot + label + description)
- [x] 2. Check-in "Log Symptom-Free Day" / Submit button centered with `px-6 py-3`
- [x] 3. Other check-in buttons (timing peak-time + indoors/outdoors) center-justified
- [x] 4. Children "Add Child" top-right trigger uses `px-6 py-2.5 text-sm`, flex-centered
- [x] 5. Children "Add Your First Child" empty-state CTA uses `px-6 py-3`, flex-centered
- [x] 6. Child form Save/Cancel (add + edit) and card Edit/Remove/Confirm/Cancel buttons apply consistent padding and flex-center
- [x] 7. Landing "Get Started Free" hero + bottom CTA uses `px-8 py-4` (landing-hero size)
- [x] 8. Landing "Sign In" matches hero CTA padding
- [x] 9. "Ready to Understand Your Allergies?" section centered horizontally (`mx-auto flex items-center text-center`)
- [x] 10. Landing sections use consistent `max-w-6xl mx-auto` (hero, How It Works, Features, CTA, footer)
- [x] 11. Features grid cards: `auto-rows-fr` + `h-full` equal heights; `break-words` on headings + body
- [x] 12. How It Works three columns: `grid-cols-3 gap-6 items-start` horizontally aligned
- [x] 13. FDA "Predicted Triggers" footer: `break-words` so long label text wraps rather than overflowing

## Files changed

- `app/page.tsx` — hero, section wrappers, CTA, FeatureCard, StepCard
- `components/checkin/severity-slider.tsx` — center-justify content
- `components/checkin/checkin-form.tsx` — submit button flex-centered
- `components/checkin/timing-selector.tsx` — all timing buttons centered
- `components/children/children-manager.tsx` — Add Child + Add Your First Child
- `components/children/add-child-form.tsx` — Save/Cancel
- `components/children/edit-child-form.tsx` — Save/Cancel
- `components/children/child-profile-card.tsx` — Edit/Remove/Confirm/Cancel
- `__tests__/components/checkin/severity-slider.test.tsx` — new DOM-structure regression test

## Test plan

- [x] `npm run lint` green
- [x] `npm run typecheck` green
- [x] `npm test` — 1180 tests passing (added 1 new regression test for severity-slider center-justify)
- [x] `npm run build` green
- [ ] Manual spot-check on `/checkin`, `/children`, `/` after preview deploy

Closes #279