### PR TITLE
fix(auth): guard dashboard against users with incomplete onboarding

### DIFF
--- a/__tests__/app/dashboard-page.test.ts
+++ b/__tests__/app/dashboard-page.test.ts
@@ -161,6 +161,16 @@ describe("dashboard page source scan (revert detection)", () => {
     // Verify the prop is wired through to the leaderboard surface.
     expect(dashboardSource).toMatch(/hasFullRankings=\{hasFullRankings\}/);
   });
+
+  it("redirects to /onboarding when user has no home_region (#282 defense-in-depth)", () => {
+    // The dashboard must guard against authenticated-but-not-onboarded
+    // users. This source-scan catches a revert that would reintroduce
+    // the P0 bug (empty dashboard + symptom_checkins FK violation).
+    expect(dashboardSource).toMatch(/home_region/);
+    expect(dashboardSource).toMatch(
+      /if\s*\(\s*!profile\?\.home_region\s*\)\s*\{?\s*redirect\(\s*["']\/onboarding["']\s*\)/,
+    );
+  });
 });
 
 /* ------------------------------------------------------------------ */

--- a/__tests__/auth/callback.test.ts
+++ b/__tests__/auth/callback.test.ts
@@ -1,12 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock the server Supabase client
+// Mock the server Supabase client. The callback now also calls
+// `supabase.auth.getUser()` and queries `user_profiles.home_region`
+// to decide the post-confirmation landing page (#282 — defense-in-depth
+// with the middleware onboarding guard).
 const mockExchangeCodeForSession = vi.fn();
+const mockGetUser = vi.fn();
+const mockMaybeSingle = vi.fn();
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn().mockResolvedValue({
     auth: {
       exchangeCodeForSession: mockExchangeCodeForSession,
+      getUser: mockGetUser,
     },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: mockMaybeSingle,
+        })),
+      })),
+    })),
   }),
 }));
 
@@ -15,9 +29,17 @@ const { GET } = await import("@/app/api/auth/callback/route");
 describe("GET /api/auth/callback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: authenticated user with completed onboarding.
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+    });
+    mockMaybeSingle.mockResolvedValue({
+      data: { home_region: "pacific_northwest" },
+      error: null,
+    });
   });
 
-  it("exchanges code for session and redirects to /dashboard", async () => {
+  it("exchanges code for session and redirects to /dashboard for onboarded user", async () => {
     mockExchangeCodeForSession.mockResolvedValue({ error: null });
 
     const request = new Request(
@@ -32,14 +54,63 @@ describe("GET /api/auth/callback", () => {
     );
   });
 
-  it("redirects to custom next path after code exchange", async () => {
+  it("redirects new user without user_profiles row to /onboarding (#282)", async () => {
     mockExchangeCodeForSession.mockResolvedValue({ error: null });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
 
     const request = new Request(
-      "http://localhost:3000/api/auth/callback?code=test-code&next=/onboarding",
+      "http://localhost:3000/api/auth/callback?code=test-auth-code",
     );
     const response = await GET(request);
 
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/onboarding",
+    );
+  });
+
+  it("redirects user with null home_region to /onboarding (#282)", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+    mockMaybeSingle.mockResolvedValue({
+      data: { home_region: null },
+      error: null,
+    });
+
+    const request = new Request(
+      "http://localhost:3000/api/auth/callback?code=test-auth-code",
+    );
+    const response = await GET(request);
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/onboarding",
+    );
+  });
+
+  it("redirects to custom next path when user is onboarded", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+
+    const request = new Request(
+      "http://localhost:3000/api/auth/callback?code=test-code&next=/settings",
+    );
+    const response = await GET(request);
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/settings",
+    );
+  });
+
+  it("forces /onboarding even when next= is provided, if user is not onboarded", async () => {
+    mockExchangeCodeForSession.mockResolvedValue({ error: null });
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+
+    const request = new Request(
+      "http://localhost:3000/api/auth/callback?code=test-code&next=/dashboard",
+    );
+    const response = await GET(request);
+
+    // Onboarding-incomplete overrides the `next` hint — otherwise a
+    // fresh signup whose email link included `next=/dashboard` would
+    // end up on the empty dashboard, reintroducing the P0 bug.
     expect(response.headers.get("location")).toBe(
       "http://localhost:3000/onboarding",
     );

--- a/__tests__/auth/middleware.test.ts
+++ b/__tests__/auth/middleware.test.ts
@@ -115,11 +115,86 @@ describe("middleware", () => {
     mockUpdateSession.mockResolvedValue({
       user: { id: "user-123", email: "test@example.com" },
       supabaseResponse: mockResponse,
+      hasOnboardingProfile: true,
     });
 
     const request = createMockRequest("/dashboard");
     const response = await middleware(request as never);
 
+    expect(response).toBe(mockResponse);
+  });
+
+  it("redirects authenticated user without onboarding profile from /dashboard to /onboarding (#282)", async () => {
+    const mockResponse = { type: "next" };
+    mockUpdateSession.mockResolvedValue({
+      user: { id: "user-new", email: "new@example.com" },
+      supabaseResponse: mockResponse,
+      hasOnboardingProfile: false,
+    });
+
+    const request = createMockRequest("/dashboard");
+    const response = await middleware(request as never);
+
+    expect(response.type).toBe("redirect");
+    const redirectUrl = response.url as unknown as URL;
+    expect(redirectUrl.pathname).toBe("/onboarding");
+  });
+
+  it("allows authenticated user without onboarding profile to access /onboarding (no redirect loop) (#282)", async () => {
+    const mockResponse = { type: "next" };
+    mockUpdateSession.mockResolvedValue({
+      user: { id: "user-new", email: "new@example.com" },
+      supabaseResponse: mockResponse,
+      hasOnboardingProfile: false,
+    });
+
+    const request = createMockRequest("/onboarding");
+    const response = await middleware(request as never);
+
+    expect(response).toBe(mockResponse);
+  });
+
+  it("redirects authenticated user without onboarding profile from all onboarding-gated paths (#282)", async () => {
+    const gatedPaths = [
+      "/dashboard",
+      "/checkin",
+      "/travel",
+      "/children",
+      "/scout",
+      "/settings",
+    ];
+
+    for (const path of gatedPaths) {
+      vi.clearAllMocks();
+      const mockResponse = { type: "next" };
+      mockUpdateSession.mockResolvedValue({
+        user: { id: "user-new", email: "new@example.com" },
+        supabaseResponse: mockResponse,
+        hasOnboardingProfile: false,
+      });
+
+      const request = createMockRequest(path);
+      const response = await middleware(request as never);
+
+      expect(response.type).toBe("redirect");
+      const redirectUrl = response.url as unknown as URL;
+      expect(redirectUrl.pathname).toBe("/onboarding");
+    }
+  });
+
+  it("does not redirect when hasOnboardingProfile is null (lookup failed — fail-open) (#282)", async () => {
+    const mockResponse = { type: "next" };
+    mockUpdateSession.mockResolvedValue({
+      user: { id: "user-123", email: "test@example.com" },
+      supabaseResponse: mockResponse,
+      hasOnboardingProfile: null,
+    });
+
+    const request = createMockRequest("/dashboard");
+    const response = await middleware(request as never);
+
+    // Fails open to supabaseResponse — the dashboard page-level guard
+    // will catch it as defense-in-depth.
     expect(response).toBe(mockResponse);
   });
 

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -42,14 +42,28 @@ export default async function DashboardPage() {
     redirect("/login");
   }
 
-  // Fetch profile for FDA acknowledgment status
+  // Fetch profile for FDA acknowledgment status + onboarding gate.
+  // Defense-in-depth with the middleware onboarding guard (#282):
+  // if the user has no `user_profiles` row (fresh signup that bypassed
+  // onboarding somehow) or the row is missing `home_region`, redirect
+  // to `/onboarding` before rendering anything. This also prevents
+  // downstream `symptom_checkins_user_id_fkey` FK violations because
+  // every user reaching the dashboard is guaranteed to have a profile.
   const { data: profileData } = await supabase
     .from("user_profiles")
-    .select("fda_acknowledged")
+    .select("fda_acknowledged, home_region")
     .eq("id", user.id)
-    .single();
+    .maybeSingle();
 
-  const profile = profileData as { fda_acknowledged: boolean } | null;
+  const profile = profileData as {
+    fda_acknowledged: boolean;
+    home_region: string | null;
+  } | null;
+
+  if (!profile?.home_region) {
+    redirect("/onboarding");
+  }
+
   const fdaAcknowledged = profile?.fda_acknowledged ?? false;
 
   // Resolve subscription + referral access via the canonical helper.

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -5,19 +5,51 @@ import { createClient } from "@/lib/supabase/server";
  * Auth callback handler for email confirmation flows.
  *
  * Supabase sends the user here after they click a confirmation link.
- * We exchange the auth code for a session and redirect to the app.
+ * We exchange the auth code for a session and redirect the user to
+ * the correct landing surface:
+ *
+ *   - Completed onboarding (user_profiles.home_region is set) → /dashboard
+ *   - No profile / incomplete onboarding → /onboarding
+ *
+ * This is defense-in-depth with the middleware onboarding guard
+ * (issue #282). Without this check, a fresh signup landed on an empty
+ * /dashboard because no `user_profiles` row existed yet, which also
+ * cascaded into `symptom_checkins_user_id_fkey` FK violations.
+ *
+ * An explicit `?next=` override is honored only when the user is
+ * already onboarded — otherwise we always route to `/onboarding`
+ * first.
  */
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/dashboard";
+  const nextParam = searchParams.get("next");
 
   if (code) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      let destination = nextParam ?? "/dashboard";
+
+      if (user) {
+        const { data: profileData } = await supabase
+          .from("user_profiles")
+          .select("home_region")
+          .eq("id", user.id)
+          .maybeSingle();
+
+        const profile = profileData as { home_region: string | null } | null;
+        if (!profile?.home_region) {
+          destination = "/onboarding";
+        }
+      }
+
+      return NextResponse.redirect(`${origin}${destination}`);
     }
   }
 

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -6,7 +6,14 @@ import type { Database } from "./types";
  * Supabase middleware helper.
  *
  * Refreshes the auth session on every request so cookies stay fresh.
- * Returns the updated response with refreshed cookies.
+ * Returns the updated response with refreshed cookies, plus a lightweight
+ * onboarding-completion flag for the authenticated user (issue #282).
+ *
+ * `hasOnboardingProfile` is `true` when the user has a `user_profiles`
+ * row with a non-null `home_region`. It is `null` when the user is
+ * unauthenticated or when the lookup fails (fail-open: middleware will
+ * not force a redirect on transient DB errors — downstream server
+ * components re-check as defense-in-depth).
  */
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
@@ -39,5 +46,24 @@ export async function updateSession(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  return { user, supabaseResponse };
+  let hasOnboardingProfile: boolean | null = null;
+  if (user) {
+    // Single-column lookup — minimal overhead per request. We do NOT
+    // log the value (home_region is user-provided; HIPAA: no profile
+    // content in logs). Errors are swallowed: middleware falls back to
+    // null (treat as "unknown") and lets the page-level guards enforce.
+    try {
+      const { data } = await supabase
+        .from("user_profiles")
+        .select("home_region")
+        .eq("id", user.id)
+        .maybeSingle();
+      const profile = data as { home_region: string | null } | null;
+      hasOnboardingProfile = Boolean(profile?.home_region);
+    } catch {
+      hasOnboardingProfile = null;
+    }
+  }
+
+  return { user, supabaseResponse, hasOnboardingProfile };
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -21,6 +21,21 @@ const PROTECTED_PATHS = [
  */
 const AUTH_PATHS = ["/login", "/signup"];
 
+/**
+ * Paths that require an authenticated user AND a completed onboarding
+ * profile. Authenticated-but-onboarding-incomplete users hitting these
+ * paths are redirected to /onboarding (issue #282). `/onboarding`
+ * itself is intentionally excluded so the wizard can render.
+ */
+const ONBOARDING_REQUIRED_PATHS = [
+  "/dashboard",
+  "/checkin",
+  "/travel",
+  "/children",
+  "/scout",
+  "/settings",
+];
+
 function isProtectedPath(pathname: string): boolean {
   return PROTECTED_PATHS.some(
     (path) => pathname === path || pathname.startsWith(`${path}/`),
@@ -33,8 +48,15 @@ function isAuthPath(pathname: string): boolean {
   );
 }
 
+function requiresOnboarding(pathname: string): boolean {
+  return ONBOARDING_REQUIRED_PATHS.some(
+    (path) => pathname === path || pathname.startsWith(`${path}/`),
+  );
+}
+
 export async function middleware(request: NextRequest) {
-  const { user, supabaseResponse } = await updateSession(request);
+  const { user, supabaseResponse, hasOnboardingProfile } =
+    await updateSession(request);
   const { pathname } = request.nextUrl;
 
   // Unauthenticated user trying to access protected route → redirect to login
@@ -48,6 +70,21 @@ export async function middleware(request: NextRequest) {
   if (user && isAuthPath(pathname)) {
     const url = request.nextUrl.clone();
     url.pathname = "/dashboard";
+    return NextResponse.redirect(url);
+  }
+
+  // Authenticated user without a completed onboarding profile trying to
+  // access an onboarding-gated route → redirect to /onboarding (#282).
+  // `hasOnboardingProfile === false` means the lookup succeeded and the
+  // user has no `user_profiles.home_region`. A `null` value (lookup
+  // error) falls through; downstream server-component guards enforce.
+  if (
+    user &&
+    hasOnboardingProfile === false &&
+    requiresOnboarding(pathname)
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/onboarding";
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
## Summary

Closes #282.

Fixes **two cascading P0 bugs** with a single root cause:

1. New user signs up, confirms email, lands on an empty `/dashboard` instead of `/onboarding`.
2. When that user attempts a check-in, the INSERT fails with `symptom_checkins_user_id_fkey` because no `user_profiles` row exists yet.

Root cause: `middleware.ts` never enforced onboarding completion. `app/page.tsx` had the guard; `/dashboard` did not. New signups slipped through.

## Fix (defense-in-depth across three layers)

- **Middleware guard** (`middleware.ts` + `lib/supabase/middleware.ts`) — authenticated users without `user_profiles.home_region` are redirected to `/onboarding` on gated paths: `/dashboard`, `/checkin`, `/travel`, `/children`, `/scout`, `/settings`. `/onboarding` itself is intentionally excluded so the wizard can render (no redirect loop). Lookup is a single-column `maybeSingle` on `user_profiles`; transient errors fail open to the page-level guards.
- **Auth callback** (`app/api/auth/callback/route.ts`) — after code exchange, checks `user_profiles.home_region`. New users always route to `/onboarding` even when `?next=` was provided; onboarded users honor `?next=` or default to `/dashboard`.
- **Dashboard server component** (`app/(app)/dashboard/page.tsx`) — belt-and-suspenders guard mirroring the existing `app/page.tsx` pattern. The existing `fda_acknowledged` query was extended to also read `home_region`, so no extra DB round-trip is introduced.

## Why this also fixes the FK violation

`symptom_checkins.user_id REFERENCES user_profiles(id)`. By forcing onboarding to complete before a user can reach `/checkin`, the `user_profiles` row is guaranteed to exist by the time any check-in INSERT runs.

## Tests

- `__tests__/auth/middleware.test.ts` — new-user redirect to `/onboarding`, no-loop on `/onboarding`, all six gated paths covered, fail-open on null lookup.
- `__tests__/auth/callback.test.ts` — new user → `/onboarding`, onboarded user → `/dashboard` (or `?next=`), `?next=` is overridden for non-onboarded users.
- `__tests__/app/dashboard-page.test.ts` — source-scan assertion that the `!profile?.home_region → redirect("/onboarding")` guard is present (catches regressions).

## Non-goals (per ticket)

- Auto-creating `user_profiles` stubs on signup — explicit non-goal; onboarding captures zip code and home allergens that a stub cannot provide.
- Restructuring the email confirmation flow.

## Guardrails honored

- Authentication is unchanged; onboarding check runs AFTER auth.
- No `user_profiles` stubs are created.
- HIPAA: no profile content (zip, home_region) is logged in any added error path.
- Brand tokens unchanged (4-color palette).
- Middleware stays fast — single-column `select("home_region")`.

## Test plan

- [x] `npm run lint` — green
- [x] `npm run typecheck` — green
- [x] `npm test` — 1188/1188 passing
- [x] `npm run build` — green
- [ ] Manual: fresh signup → email confirm → lands on `/onboarding`
- [ ] Manual: complete wizard → lands on `/dashboard`
- [ ] Manual: check-in works for the new user (no FK violation)